### PR TITLE
fix-attempt: x-account logging

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -24,7 +24,7 @@ export class APIStage extends Stage {
       provisionedConcurrency: number;
       chatbotSNSArn?: string;
       stage: string;
-      envVars?: Record<string, string>;
+      envVars: Record<string, string>;
     }
   ) {
     super(scope, id, props);
@@ -109,6 +109,7 @@ export class APIPipeline extends Stack {
       stage: STAGE.BETA,
       envVars: {
         ...jsonRpcUrls,
+        FILL_LOG_SENDER_ACCOUNT: '321377678687',
       },
     });
 
@@ -123,6 +124,7 @@ export class APIPipeline extends Stack {
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       envVars: {
         ...jsonRpcUrls,
+        FILL_LOG_SENDER_ACCOUNT: '316116520258',
       },
       stage: STAGE.PROD,
     });
@@ -190,6 +192,7 @@ Object.values(SUPPORTED_CHAINS).forEach((chainId) => {
   envVars[`RPC_${chainId}`] = process.env[`RPC_${chainId}`] || '';
 });
 envVars[`RPC_TENDERLY`] = process.env[`RPC_TENDERLY`] || '';
+envVars['FILL_LOG_SENDER_ACCOUNT'] = process.env['FILL_LOG_SENDER_ACCOUNT'] || '';
 
 new APIStack(app, `${SERVICE_NAME}Stack`, {
   env: {

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -32,7 +32,7 @@ export class APIStack extends cdk.Stack {
       throttlingOverride?: string;
       chatbotSNSArn?: string;
       stage: string;
-      envVars?: { [key: string]: string };
+      envVars: Record<string, string>;
     }
   ) {
     super(parent, name, props);
@@ -233,6 +233,7 @@ export class APIStack extends cdk.Stack {
      */
     new AnalyticsStack(this, 'AnalyticsStack', {
       quoteLambda,
+      envVars: props.envVars,
     });
 
     this.url = new CfnOutput(this, 'Url', {


### PR DESCRIPTION
This PR is an attempt to fix the cross-account log sharing that is necessary to stream fill events to our redshift cluster. The idea here is that, once `subscriptionRole` is created (in param-api, our recipient account), we note down its resource ARN and import it in `gouda-service` (our sender account) to use with the subscription filter.

It's a bit awkward to test this way, but I don't have two dev accounts to test locally 😞 