### PR TITLE
Add auth to RFQ request

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -101,6 +101,10 @@ export class APIPipeline extends Stack {
     });
     jsonRpcUrls['RPC_TENDERLY'] = goudaRpc.secretValueFromJson('RPC_TENDERLY').toString();
 
+    const authSigningKey = sm.Secret.fromSecretAttributes(this, 'authSigningKey', {
+      secretCompleteArn: 'arn:' // TODO: add to secrets manager
+    });
+
     // Beta us-east-2
 
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
@@ -113,6 +117,7 @@ export class APIPipeline extends Stack {
         ORDER_LOG_SENDER_ACCOUNT: '321377678687',
         URA_ACCOUNT: '665191769009',
         BOT_ACCOUNT: '800035746608',
+        AUTH_SIGNING_KEY: authSigningKey.secretValue.toString(),
       },
     });
 
@@ -131,6 +136,7 @@ export class APIPipeline extends Stack {
         ORDER_LOG_SENDER_ACCOUNT: '316116520258',
         URA_ACCOUNT: '652077092967',
         BOT_ACCOUNT: '456809954954',
+        AUTH_SIGNING_KEY: authSigningKey.secretValue.toString(),
       },
       stage: STAGE.PROD,
     });
@@ -201,6 +207,7 @@ envVars[`RPC_TENDERLY`] = process.env[`RPC_TENDERLY`] || '';
 envVars['FILL_LOG_SENDER_ACCOUNT'] = process.env['FILL_LOG_SENDER_ACCOUNT'] || '';
 envVars['URA_ACCOUNT'] = process.env['URA_ACCOUNT'] || '';
 envVars['BOT_ACCOUNT'] = process.env['BOT_ACCOUNT'] || '';
+envVars['AUTH_SIGNING_KEY'] = process.env['AUTH_SIGNING_KEY'] || '';
 
 new APIStack(app, `${SERVICE_NAME}Stack`, {
   env: {

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -1,6 +1,7 @@
 import { setGlobalLogger } from '@uniswap/smart-order-router';
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { default as bunyan, default as Logger } from 'bunyan';
+import { ethers } from 'ethers';
 
 import { JsonWebhookConfigurationProvider } from '../../providers';
 import { Quoter, WebhookQuoter } from '../../quoters';
@@ -27,7 +28,9 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, PostQ
 
     const webhookProvider = new JsonWebhookConfigurationProvider();
 
-    const quoters: Quoter[] = [new WebhookQuoter(log, webhookProvider)];
+    const authSigningKey = new ethers.utils.SigningKey(process.env['AUTH_SIGNING_KEY']!);
+
+    const quoters: Quoter[] = [new WebhookQuoter(log, webhookProvider, authSigningKey)];
     if (process.env['stage'] == STAGE.LOCAL) {
       quoters.push(new MockQuoter(log));
     }


### PR DESCRIPTION
Initiate the WebhookQuoter with a ethers SigningKey created with fetched secret from SecretManager and sign the endpoint with it. Integrations should verify that the recovered public key matches our published public key.

Open to not using ethers but another more lightweight library if implementations don't use ethers though any library that supports secp256k1 would work
