### PR TITLE
feat: filter quote requests by chainid

### DIFF
--- a/lib/providers/webhook/index.ts
+++ b/lib/providers/webhook/index.ts
@@ -9,6 +9,9 @@ export interface WebhookConfiguration {
   endpoint: string;
   headers?: { [key: string]: string };
   overrides?: WebhookOverrides;
+  // the chainids the endpoint should receive webhooks for
+  // if null, send for all chains
+  chainIds?: number[];
 }
 
 export interface WebhookConfigurationProvider {

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -32,6 +32,14 @@ export class WebhookQuoter implements Quoter {
 
   private async fetchQuote(config: WebhookConfiguration, request: QuoteRequest): Promise<QuoteResponse | null> {
     const { endpoint, headers } = config;
+    if (config.chainIds !== undefined && !config.chainIds.includes(request.tokenInChainId)) {
+      this.log.debug(
+        { configuredChainIds: config.chainIds, chainId: request.tokenInChainId },
+        `chainId not configured for ${endpoint}`
+      );
+      return null;
+    }
+
     metric.putMetric(metricContext(Metric.RFQ_REQUESTED, endpoint), 1, MetricLoggerUnit.Count);
     try {
       this.log.info({ request, headers }, `Webhook request to: ${endpoint}`);


### PR DESCRIPTION
allow configs to have supported chainId lists. default to all chains
