### PR TITLE
Remove offerer address from calls to webhooks

### DIFF
--- a/lib/entities/QuoteRequest.ts
+++ b/lib/entities/QuoteRequest.ts
@@ -20,6 +20,8 @@ export interface QuoteRequestDataJSON extends Omit<QuoteRequestData, 'amount' | 
   type: string;
 }
 
+export interface CleanQuoteRequestDataJSON extends Omit<QuoteRequestDataJSON, 'offerer'> {}
+
 // data class for QuoteRequest helpers and conversions
 export class QuoteRequest {
   public static fromRequestBody(body: PostQuoteRequestBody): QuoteRequest {
@@ -43,6 +45,18 @@ export class QuoteRequest {
       tokenOutChainId: this.tokenOutChainId,
       requestId: this.requestId,
       offerer: getAddress(this.offerer),
+      tokenIn: getAddress(this.tokenIn),
+      tokenOut: getAddress(this.tokenOut),
+      amount: this.amount.toString(),
+      type: TradeType[this.type],
+    };
+  }
+
+  public toCleanJSON(): CleanQuoteRequestDataJSON {
+    return {
+      tokenInChainId: this.tokenInChainId,
+      tokenOutChainId: this.tokenOutChainId,
+      requestId: this.requestId,
       tokenIn: getAddress(this.tokenIn),
       tokenOut: getAddress(this.tokenOut),
       amount: this.amount.toString(),

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -46,7 +46,7 @@ export class WebhookQuoter implements Quoter {
 
       const before = Date.now();
       const timeoutOverride = config.overrides?.timeout;
-      const hookResponse = await axios.post(endpoint, request.toJSON(), {
+      const hookResponse = await axios.post(endpoint, request.toCleanJSON(), {
         timeout: timeoutOverride ? Number(timeoutOverride) : WEBHOOK_TIMEOUT_MS,
         ...(!!headers && { headers }),
       });


### PR DESCRIPTION
Omit the `offerer` key in outgoing webhook requests to RFQ participants. We introduce a new type for this and keep the offerer key in everything else, including in logging + redshift data.

Potentially breaking for integrators