### PR TITLE
fix: separate rfq joi

### DIFF
--- a/lib/entities/QuoteResponse.ts
+++ b/lib/entities/QuoteResponse.ts
@@ -3,7 +3,7 @@ import { BigNumber } from 'ethers';
 import { ValidationResult } from 'joi';
 import { v4 as uuidv4 } from 'uuid';
 
-import { PostQuoteResponse, PostQuoteResponseJoi } from '../handlers/quote/schema';
+import { PostQuoteResponse, RfqResponse, RfqResponseJoi } from '../handlers/quote/schema';
 import { currentTimestampInSeconds } from '../util/time';
 import { QuoteRequestData } from '.';
 
@@ -40,8 +40,8 @@ export class QuoteResponse implements QuoteResponseData {
     );
   }
 
-  public static fromResponseJSON(data: PostQuoteResponse, type: TradeType): ValidatedResponse {
-    const responseValidation = PostQuoteResponseJoi.validate(data, {
+  public static fromRFQ(request: QuoteRequestData, data: RfqResponse, type: TradeType): ValidatedResponse {
+    const responseValidation = RfqResponseJoi.validate(data, {
       allowUnknown: true,
       stripUnknown: true,
     });
@@ -49,6 +49,7 @@ export class QuoteResponse implements QuoteResponseData {
       response: new QuoteResponse(
         {
           ...data,
+          offerer: request.offerer,
           quoteId: uuidv4(),
           amountIn: BigNumber.from(data.amountIn ?? 0),
           amountOut: BigNumber.from(data.amountOut ?? 0),

--- a/lib/handlers/quote/schema.ts
+++ b/lib/handlers/quote/schema.ts
@@ -35,6 +35,17 @@ export const PostQuoteResponseJoi = Joi.object({
   filler: FieldValidator.address,
 });
 
+export type PostQuoteResponse = {
+  chainId: number;
+  requestId: string;
+  tokenIn: string;
+  amountIn: string;
+  tokenOut: string;
+  amountOut: string;
+  offerer: string;
+  filler?: string;
+};
+
 export const URAResponseJoi = Joi.object({
   chainId: FieldValidator.chainId.required(),
   requestId: FieldValidator.uuid.required(),
@@ -47,13 +58,22 @@ export const URAResponseJoi = Joi.object({
   quoteId: FieldValidator.uuid,
 });
 
-export type PostQuoteResponse = {
+export const RfqResponseJoi = Joi.object({
+  chainId: FieldValidator.chainId.required(),
+  requestId: FieldValidator.uuid.required(),
+  tokenIn: Joi.string().required(),
+  amountIn: FieldValidator.amount.required(),
+  tokenOut: Joi.string().required(),
+  amountOut: FieldValidator.amount.required(),
+  filler: FieldValidator.address,
+});
+
+export type RfqResponse = {
   chainId: number;
   requestId: string;
   tokenIn: string;
   amountIn: string;
   tokenOut: string;
   amountOut: string;
-  offerer: string;
   filler?: string;
 };

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -56,7 +56,7 @@ export class WebhookQuoter implements Quoter {
         MetricLoggerUnit.Milliseconds
       );
 
-      const { response, validation } = QuoteResponse.fromResponseJSON(hookResponse.data, request.type);
+      const { response, validation } = QuoteResponse.fromRFQ(request, hookResponse.data, request.type);
 
       // TODO: remove, using for debugging purposes
       this.log.info(

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -81,7 +81,31 @@ describe('WebhookQuoter tests', () => {
     const response = await webhookQuoter.quote(request);
 
     expect(response.length).toEqual(1);
-    expect(response[0].toResponseJSON()).toEqual({ ...quote, quoteId: expect.any(String) });
+    expect(response[0].toResponseJSON()).toEqual({ ...quote, offerer: request.offerer, quoteId: expect.any(String) });
+  });
+
+  it('Simple request and response null offerer', async () => {
+    const quote = {
+      amountOut: ethers.utils.parseEther('2').toString(),
+      tokenIn: request.tokenIn,
+      tokenOut: request.tokenOut,
+      amountIn: request.amount.toString(),
+      chainId: request.tokenInChainId,
+      requestId: request.requestId,
+      quoteId: QUOTE_ID,
+      offerer: null,
+      filler: FILLER,
+    };
+
+    mockedAxios.post.mockImplementationOnce((_endpoint, _req, _options) => {
+      return Promise.resolve({
+        data: quote,
+      });
+    });
+    const response = await webhookQuoter.quote(request);
+
+    expect(response.length).toEqual(1);
+    expect(response[0].toResponseJSON()).toEqual({ ...quote, offerer: request.offerer, quoteId: expect.any(String) });
   });
 
   it('Simple request and response with explicit chainId', async () => {


### PR DESCRIPTION
RFQ responses shouldnt be constrained to the same response schema as gpa
itself, this commit separates its validation and doesnt consider offerer
at all
