### PR TITLE
fix: fix sql query and execute dynamo command

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -2,13 +2,12 @@ import * as cdk from 'aws-cdk-lib';
 import { CfnOutput, SecretValue, Stack, StackProps, Stage, StageProps } from 'aws-cdk-lib';
 import * as chatbot from 'aws-cdk-lib/aws-chatbot';
 import { BuildEnvironmentVariableType, BuildSpec } from 'aws-cdk-lib/aws-codebuild';
+import { PipelineNotificationEvents } from 'aws-cdk-lib/aws-codepipeline';
 import * as sm from 'aws-cdk-lib/aws-secretsmanager';
-
 import { CodeBuildStep, CodePipeline, CodePipelineSource } from 'aws-cdk-lib/pipelines';
 import { Construct } from 'constructs';
 import dotenv from 'dotenv';
 
-import { PipelineNotificationEvents } from 'aws-cdk-lib/aws-codepipeline';
 import { STAGE } from '../lib/util/stage';
 import { SERVICE_NAME } from './constants';
 import { APIStack } from './stacks/api-stack';

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -106,10 +106,16 @@ const handler: ScheduledHandler = async (_event: EventBridgeEvent<string, void>)
       log.info({ result }, 'fade rate result');
       result.forEach(async (row) => {
         try {
-          await fadeRateEntity.put({
-            filler: row[0].stringValue ?? '',
-            faderate: parseFloat(row[1].stringValue ?? ''),
-          });
+          const res = await fadeRateEntity.put(
+            {
+              filler: row[0].stringValue ?? '',
+              faderate: parseFloat(row[1].stringValue ?? ''),
+            },
+            {
+              execute: true,
+            }
+          );
+          log.info({ res }, 'fade rate put result');
         } catch (e) {
           log.error({ error: e }, 'Failed to put fade rate');
           throw e;
@@ -157,14 +163,14 @@ const CREATE_VIEW_SQL = `
 CREATE OR REPLACE VIEW rfqOrders 
 AS
 SELECT
-    postedorders.filler as rfqFiller, postedorders.quoteid as quoteId, archivedorders.filler as actualFiller, archivedorders.filltimestamp as fillTimestamp, archivedorders.txhash as txHash
+    postedorders.filler as rfqFiller, postedorders.quoteid as quoteId, archivedorders.filler as actualFiller, postedorders.createdat as postTimestamp, archivedorders.txhash as txHash
 FROM
     postedorders LEFT OUTER JOIN archivedorders ON postedorders.quoteid = archivedorders.quoteid
 where
 rfqFiller IS NOT NULL
 AND rfqFiller != '0x0000000000000000000000000000000000000000'
 AND
-    fillTimestamp >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS'));
+    postTimestamp >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS'));
 `;
 
 const FADE_RATE_SQL = `

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -163,13 +163,14 @@ const CREATE_VIEW_SQL = `
 CREATE OR REPLACE VIEW rfqOrders 
 AS
 SELECT
-    postedorders.filler as rfqFiller, postedorders.quoteid as quoteId, archivedorders.filler as actualFiller, postedorders.createdat as postTimestamp, archivedorders.txhash as txHash
+    postedorders.chainid as chainId, postedorders.filler as rfqFiller, postedorders.quoteid, archivedorders.filler as actualFiller, postedorders.createdat as postTimestamp, archivedorders.txhash as txHash
 FROM
     postedorders LEFT OUTER JOIN archivedorders ON postedorders.quoteid = archivedorders.quoteid
 where
 rfqFiller IS NOT NULL
-AND quoteId IS NOT NULL
+AND postedorders.quoteId IS NOT NULL
 AND rfqFiller != '0x0000000000000000000000000000000000000000'
+AND chainId NOT IN (5,8001,420,421613) -- exclude mainnet goerli, polygon goerli, optimism goerli and arbitrum goerli testnets 
 AND
     postTimestamp >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS'));
 `;

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -168,6 +168,7 @@ FROM
     postedorders LEFT OUTER JOIN archivedorders ON postedorders.quoteid = archivedorders.quoteid
 where
 rfqFiller IS NOT NULL
+AND quoteId IS NOT NULL
 AND rfqFiller != '0x0000000000000000000000000000000000000000'
 AND
     postTimestamp >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS'));


### PR DESCRIPTION
fix the fade rate calculation query:
- exclude testnet orders
- expecting `fillTimestamp >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS'));` means that we only considered **filled orders** because expired ones don't have `fillTimestamp`

also, force-execute the dynamo command