### PR TITLE
feat: change how we count faded quotes

### DIFF
--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -60,7 +60,7 @@ export class CronStack extends cdk.NestedStack {
       },
     });
     new aws_events.Rule(this, `${SERVICE_NAME}ScheduleCronLambda`, {
-      schedule: aws_events.Schedule.rate(Duration.hours(1)),
+      schedule: aws_events.Schedule.rate(Duration.minutes(10)),
       targets: [new aws_events_targets.LambdaFunction(this.fadeRateCronLambda)],
     });
 

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -196,7 +196,7 @@ WITH ORDERS_CTE AS (
     SELECT 
         rfqFiller,
         COUNT(*) AS totalQuotes,
-        SUM(CASE WHEN rfqFiller != actualFiller OR (tradeType = 'EXACT_INPUT' AND quotedAmount > filledAmount) OR (tradeType = 'EXACT_OUTPUT' AND quotedAmount < filledAmount) THEN 1 ELSE 0 END) AS fadedQuotes
+        SUM(CASE WHEN (tradeType = 'EXACT_INPUT' AND quotedAmount > filledAmount) OR (tradeType = 'EXACT_OUTPUT' AND quotedAmount < filledAmount) THEN 1 ELSE 0 END) AS fadedQuotes
     FROM rfqOrders 
     GROUP BY rfqFiller
 )

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -178,7 +178,7 @@ AND latestOrders.quoteId IS NOT NULL
 AND rfqFiller != '0x0000000000000000000000000000000000000000'
 AND chainId NOT IN (5,8001,420,421613) -- exclude mainnet goerli, polygon goerli, optimism goerli and arbitrum goerli testnets 
 AND
-    postTimestamp >= extract(epoch from (GETDATE() - INTERVAL '72 HOURS'))
+    postTimestamp >= extract(epoch from (GETDATE() - INTERVAL '168 HOURS'))
 );
 `;
 


### PR DESCRIPTION
Change the Redshift query to do the following instead:
- get the last 20 quotes from the last 7 days for each filler address
- count total and unfilled orders (`actualFiller` != original filler address in quote)
- filter out those who provided less than 10 quotes

Also, move fade rate calculation to quote handler (future PR) since a filler entity can have multiple addresses