### PR TITLE
fix: raise thresholds for GPA 4xx alarms even more

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -349,7 +349,7 @@ export class APIStack extends cdk.Stack {
         period: Duration.minutes(5),
         statistic: 'avg',
       }),
-      threshold: 0.98,
+      threshold: 0.99,
       evaluationPeriods: 3,
     });
 
@@ -359,7 +359,7 @@ export class APIStack extends cdk.Stack {
         period: Duration.minutes(5),
         statistic: 'avg',
       }),
-      threshold: 0.95,
+      threshold: 0.98,
       evaluationPeriods: 3,
     });
 


### PR DESCRIPTION
threshold is already 0.95 for SEV3, now we added eth out and it's likely to go above that for a while until quoters come on