### PR TITLE
fix: rename dynamo tables

### DIFF
--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -91,8 +91,8 @@ export class CronStack extends cdk.NestedStack {
     });
 
     /* RFQ fade rate table */
-    const fadeRateTable = new aws_dynamo.Table(this, `${SERVICE_NAME}FadeRateTable`, {
-      tableName: DYNAMO_TABLE_NAME.FADE_RATE,
+    const fadesTable = new aws_dynamo.Table(this, `${SERVICE_NAME}FadesTable`, {
+      tableName: DYNAMO_TABLE_NAME.FADES,
       partitionKey: {
         name: DYNAMO_TABLE_KEY.FILLER,
         type: aws_dynamo.AttributeType.STRING,
@@ -102,10 +102,10 @@ export class CronStack extends cdk.NestedStack {
       contributorInsightsEnabled: true,
       ...PROD_TABLE_CAPACITY.fadeRate,
     });
-    this.alarmsPerTable(fadeRateTable, DYNAMO_TABLE_NAME.FADE_RATE, chatbotSNSArn);
+    this.alarmsPerTable(fadesTable, DYNAMO_TABLE_NAME.FADES, chatbotSNSArn);
 
     const synthSwitchTable = new aws_dynamo.Table(this, `${SERVICE_NAME}SynthSwitchTable`, {
-      tableName: DYNAMO_TABLE_NAME.SYNTH_SWITCH,
+      tableName: DYNAMO_TABLE_NAME.SYNTHETIC_SWITCH,
       partitionKey: {
         name: PARTITION_KEY,
         type: aws_dynamo.AttributeType.STRING,
@@ -115,7 +115,7 @@ export class CronStack extends cdk.NestedStack {
       contributorInsightsEnabled: true,
       ...PROD_TABLE_CAPACITY.synthSwitch,
     });
-    this.alarmsPerTable(synthSwitchTable, DYNAMO_TABLE_NAME.SYNTH_SWITCH, chatbotSNSArn);
+    this.alarmsPerTable(synthSwitchTable, DYNAMO_TABLE_NAME.SYNTHETIC_SWITCH, chatbotSNSArn);
   }
 
   private alarmsPerTable(table: aws_dynamo.Table, name: string, chatbotSNSArn?: string): void {

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   tables: [
     {
-      TableName: `SynthSwitch`,
+      TableName: `SyntheticSwitch`,
       KeySchema: [
         { AttributeName: 'inputToken#inputTokenChainId#outputToken#outputTokenChainId#type', KeyType: 'HASH' },
       ],

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,8 +4,8 @@ export const INTEGRATION_S3_KEY = 'integration.json';
 export const PRODUCTION_S3_KEY = 'production.json';
 
 export const DYNAMO_TABLE_NAME = {
-  FADE_RATE: 'FadeRate',
-  SYNTH_SWITCH: 'SynthSwitch',
+  FADES: 'Fades',
+  SYNTHETIC_SWITCH: 'SyntheticSwitch',
 };
 
 export const DYNAMO_TABLE_KEY = {

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -143,13 +143,13 @@ function createDynamoEntity() {
   });
 
   const table = new Table({
-    name: DYNAMO_TABLE_NAME.FADE_RATE,
+    name: DYNAMO_TABLE_NAME.FADES,
     partitionKey: DYNAMO_TABLE_KEY.FILLER,
     DocumentClient,
   });
 
   return new Entity({
-    name: `${DYNAMO_TABLE_NAME.FADE_RATE}Entity`,
+    name: `${DYNAMO_TABLE_NAME.FADES}Entity`,
     attributes: {
       filler: { partitionKey: true, type: 'string' },
       faderate: { type: 'number' },

--- a/lib/repositories/switch-repository.ts
+++ b/lib/repositories/switch-repository.ts
@@ -18,7 +18,7 @@ export class SwitchRepository implements BaseSwitchRepository {
     });
 
     const switchTable = new Table({
-      name: DYNAMO_TABLE_NAME.SYNTH_SWITCH,
+      name: DYNAMO_TABLE_NAME.SYNTHETIC_SWITCH,
       partitionKey: PARTITION_KEY,
       DocumentClient: documentClient,
     });


### PR DESCRIPTION
having to rename the dynamo tables because we want to remove a sort key which isn't possible