### PR TITLE
fix: bump prov concurrency for endpoints from 5 to 100

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -126,7 +126,7 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '830217277613', region: 'us-east-2' },
-      provisionedConcurrency: 5,
+      provisionedConcurrency: 100,
       internalApiKey: internalApiKey.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       envVars: {

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -256,7 +256,7 @@ export class APIStack extends cdk.Stack {
     const mockQuoteAlias = new aws_lambda.Alias(this, `MockQuoteLiveAlias`, {
       aliasName: 'live',
       version: mockQuoteLambda.currentVersion,
-      provisionedConcurrentExecutions: provisionedConcurrency > 0 ? provisionedConcurrency : undefined,
+      provisionedConcurrentExecutions: 0,
     });
 
     const integrationRfqLambda = new aws_lambda_nodejs.NodejsFunction(this, 'Rfq', {
@@ -294,6 +294,11 @@ export class APIStack extends cdk.Stack {
       });
 
       quoteTarget.node.addDependency(quoteLambdaAlias);
+
+      quoteTarget.scaleToTrackMetric('QuoteProvConcTracking', {
+        targetValue: 0.8,
+        predefinedMetric: aws_asg.PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION,
+      })
     }
 
     /*


### PR DESCRIPTION
btw disabling provisioned concurrency for mockQuote endpoint

Bumping provisioned concurrency since we saw that provisionedConcurrencyRolloverRate (cold start rate) is ~90% for this service

Seems like max concurrent executions is ~200, so if we do 100 we can scale to max 5 * 100 = 500 which should more than cover it. Right now we're giving equal provisionedConcurrency to the /enabled and /quote endpoints which I think makes sense, they are both hit once per request.  

<img width="1222" alt="Screenshot 2023-09-05 at 3 13 06 PM" src="https://github.com/Uniswap/uniswapx-parameterization-api/assets/25067635/81c9de89-ab23-4006-a18d-b693b9a383c3">
