### PR TITLE
chore: set quoteId equal to requestId

### DIFF
--- a/lib/entities/QuoteResponse.ts
+++ b/lib/entities/QuoteResponse.ts
@@ -1,11 +1,10 @@
 import { TradeType } from '@uniswap/sdk-core';
 import { BigNumber } from 'ethers';
 import { ValidationResult } from 'joi';
-import { v4 as uuidv4 } from 'uuid';
 
-import { QuoteRequestData } from '.';
 import { PostQuoteResponse, RfqResponse, RfqResponseJoi } from '../handlers/quote/schema';
 import { currentTimestampInSeconds } from '../util/time';
+import { QuoteRequestData } from '.';
 
 export interface QuoteResponseData
   extends Omit<QuoteRequestData, 'tokenInChainId' | 'tokenOutChainId' | 'amount' | 'type'> {
@@ -28,7 +27,7 @@ export class QuoteResponse implements QuoteResponseData {
       {
         chainId: request.tokenInChainId, // TODO: update schema
         requestId: request.requestId,
-        quoteId: uuidv4(),
+        quoteId: request.requestId,
         swapper: request.swapper,
         tokenIn: request.tokenIn,
         tokenOut: request.tokenOut,
@@ -50,7 +49,7 @@ export class QuoteResponse implements QuoteResponseData {
         {
           ...data,
           swapper: request.swapper,
-          quoteId: uuidv4(),
+          quoteId: request.requestId,
           amountIn: BigNumber.from(data.amountIn ?? 0),
           amountOut: BigNumber.from(data.amountOut ?? 0),
         },


### PR DESCRIPTION
## Summary
Currently market makers have difficulty associating their quote response with the actual signed order. This is because we generate a random id for the `quoteId` returned from the param service. We send them the `requestId` of the param api request. This PR sets the `quoteId == requestId` so that you can directly link a RFQ quote request to the signed order.

Data concerns brought up in [this thread](https://uniswapteam.slack.com/archives/C052XQ3EUTT/p1694468331011049).