### PR TITLE
fix: add stage field to lambda env

### DIFF
--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -94,6 +94,7 @@ export class CronStack extends cdk.NestedStack {
         REDSHIFT_DATABASE: RsDatabase,
         REDSHIFT_CLUSTER_IDENTIFIER: RsClusterIdentifier,
         REDSHIFT_SECRET_ARN: RedshiftCredSecretArn,
+        stage: stage,
         ...envVars,
       },
     });
@@ -118,6 +119,7 @@ export class CronStack extends cdk.NestedStack {
         REDSHIFT_DATABASE: RsDatabase,
         REDSHIFT_CLUSTER_IDENTIFIER: RsClusterIdentifier,
         REDSHIFT_SECRET_ARN: RedshiftCredSecretArn,
+        stage: stage,
         ...envVars,
       },
     });


### PR DESCRIPTION
synth-switch cron lambda is trying to read from `synth-config-undefined-1` because `stage` is not in process env