### PR TITLE
chore: tune synth-switch 

### DIFF
--- a/bin/stacks/cron-dashboard-stack.ts
+++ b/bin/stacks/cron-dashboard-stack.ts
@@ -164,7 +164,7 @@ const SynthSwitchFlippedWidget = (region: string): LambdaWidget => ({
     ],
     view: 'timeSeries',
     region,
-    stat: 'Sum',
+    stat: 'Average',
     period: PERIOD,
     stacked: true,
     title: 'Orders Outcome',

--- a/lib/cron/synth-switch.ts
+++ b/lib/cron/synth-switch.ts
@@ -262,6 +262,12 @@ async function main(metricsLogger: MetricsLogger) {
             metrics.putMetric(metricContext(Metric.DYNAMO_REQUEST_ERROR, 'enable_synth'), 1, MetricLoggerUnit.Count);
           }
         }
+        if (!shouldDisable) {
+          log.info(
+            { key, totalOrders, negPIRate: neg / totalOrders },
+            `[Skipping] ${key} - neg PI rate: ${neg / totalOrders}; totalOrders: ${totalOrders}`
+          );
+        }
       });
     }
     metrics.putMetric(

--- a/lib/cron/synth-switch.ts
+++ b/lib/cron/synth-switch.ts
@@ -55,7 +55,7 @@ type TradeOutcome = {
   neg: number;
 };
 
-const MINIMUM_ORDERS = 10;
+const MINIMUM_ORDERS = 5;
 const DISABLE_THRESHOLD = 0.25;
 
 export const handler: ScheduledHandler = metricScope(
@@ -480,6 +480,6 @@ const CREATE_COMBINED_URA_RESPONSES_VIEW_SQL = `
           from synth
           join "uniswap_x"."public"."unifiedroutingresponses" ur
           on ur.requestid = synth.requestid and ur.quoteid != synth.quoteid
-          WHERE synth.createdat >= extract(epoch from (GETDATE() - INTERVAL '4 HOURS')) -- 4 hours rolling window
+          WHERE synth.createdat >= extract(epoch from (GETDATE() - INTERVAL '8 HOURS')) -- 8 hours rolling window
   );
 `;


### PR DESCRIPTION
We aren't disabling synth orders with negative outcomes because we don't have enough data points to meet the threshold. 