### PR TITLE
chore: add support for beta s3 config

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,6 +3,7 @@ export const SYNTH_SWITCH_BUCKET = 'synth-config';
 export const FADE_RATE_BUCKET = 'fade-rate-config';
 export const INTEGRATION_S3_KEY = 'integration.json';
 export const PRODUCTION_S3_KEY = 'production.json';
+export const BETA_S3_KEY = 'beta.json';
 export const FADE_RATE_S3_KEY = 'fade-rate.json';
 
 export const DYNAMO_TABLE_NAME = {

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -29,8 +29,9 @@ async function main(metrics: MetricsLogger) {
     name: 'FadeRate',
     serializers: Logger.stdSerializers,
   });
-  const s3Key = process.env['stage'] === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
-  const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-prod-1`, s3Key);
+  const stage = process.env['stage'];
+  const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
+  const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
 
   const sharedConfig: SharedConfigs = {
     Database: checkDefined(process.env.REDSHIFT_DATABASE),

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -3,12 +3,19 @@ import { ScheduledHandler } from 'aws-lambda/trigger/cloudwatch-events';
 import { EventBridgeEvent } from 'aws-lambda/trigger/eventbridge';
 import Logger from 'bunyan';
 
-import { FADE_RATE_BUCKET, FADE_RATE_S3_KEY, PRODUCTION_S3_KEY, WEBHOOK_CONFIG_BUCKET } from '../constants';
+import {
+  BETA_S3_KEY,
+  FADE_RATE_BUCKET,
+  FADE_RATE_S3_KEY,
+  PRODUCTION_S3_KEY,
+  WEBHOOK_CONFIG_BUCKET,
+} from '../constants';
 import { CircuitBreakerMetricDimension } from '../entities';
 import { checkDefined } from '../preconditions/preconditions';
 import { S3WebhookConfigurationProvider } from '../providers';
 import { S3CircuitBreakerConfigurationProvider } from '../providers/circuit-breaker/s3';
 import { FadesRepository, FadesRowType, SharedConfigs } from '../repositories';
+import { STAGE } from '../util/stage';
 
 export const handler: ScheduledHandler = metricScope((metrics) => async (_event: EventBridgeEvent<string, void>) => {
   await main(metrics);
@@ -22,7 +29,8 @@ async function main(metrics: MetricsLogger) {
     name: 'FadeRate',
     serializers: Logger.stdSerializers,
   });
-  const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-prod-1`, PRODUCTION_S3_KEY);
+  const s3Key = process.env['stage'] === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
+  const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-prod-1`, s3Key);
 
   const sharedConfig: SharedConfigs = {
     Database: checkDefined(process.env.REDSHIFT_DATABASE),

--- a/lib/cron/synth-switch.ts
+++ b/lib/cron/synth-switch.ts
@@ -16,12 +16,11 @@ import { EventBridgeEvent } from 'aws-lambda/trigger/eventbridge';
 import { default as bunyan, default as Logger } from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 
-import { BETA_S3_KEY, PRODUCTION_S3_KEY, SYNTH_SWITCH_BUCKET } from '../constants';
+import { PRODUCTION_S3_KEY, SYNTH_SWITCH_BUCKET } from '../constants';
 import { AWSMetricsLogger, Metric, metricContext } from '../entities';
 import { SynthSwitchQueryParams } from '../handlers/synth-switch';
 import { checkDefined } from '../preconditions/preconditions';
 import { SwitchRepository } from '../repositories/switch-repository';
-import { STAGE } from '../util/stage';
 
 export type TokenConfig = {
   tokenIn: string;
@@ -415,11 +414,10 @@ function sleep(ms: number) {
 async function readTokenConfig(log: Logger): Promise<TokenConfig[]> {
   const s3Client = new S3Client({});
   const stage = process.env['stage'];
-  const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
   const s3Res = await s3Client.send(
     new GetObjectCommand({
       Bucket: `${SYNTH_SWITCH_BUCKET}-${stage}-1`,
-      Key: s3Key,
+      Key: PRODUCTION_S3_KEY,
     })
   );
   const s3Body = checkDefined(s3Res.Body, 's3Res.Body is undefined');

--- a/lib/cron/synth-switch.ts
+++ b/lib/cron/synth-switch.ts
@@ -16,11 +16,12 @@ import { EventBridgeEvent } from 'aws-lambda/trigger/eventbridge';
 import { default as bunyan, default as Logger } from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 
-import { PRODUCTION_S3_KEY, SYNTH_SWITCH_BUCKET } from '../constants';
+import { BETA_S3_KEY, PRODUCTION_S3_KEY, SYNTH_SWITCH_BUCKET } from '../constants';
 import { AWSMetricsLogger, Metric, metricContext } from '../entities';
 import { SynthSwitchQueryParams } from '../handlers/synth-switch';
 import { checkDefined } from '../preconditions/preconditions';
 import { SwitchRepository } from '../repositories/switch-repository';
+import { STAGE } from '../util/stage';
 
 export type TokenConfig = {
   tokenIn: string;
@@ -414,10 +415,11 @@ function sleep(ms: number) {
 async function readTokenConfig(log: Logger): Promise<TokenConfig[]> {
   const s3Client = new S3Client({});
   const stage = process.env['stage'];
+  const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
   const s3Res = await s3Client.send(
     new GetObjectCommand({
       Bucket: `${SYNTH_SWITCH_BUCKET}-${stage}-1`,
-      Key: PRODUCTION_S3_KEY,
+      Key: s3Key,
     })
   );
   const s3Body = checkDefined(s3Res.Body, 's3Res.Body is undefined');

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -4,6 +4,7 @@ import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { default as bunyan, default as Logger } from 'bunyan';
 
 import {
+  BETA_S3_KEY,
   FADE_RATE_BUCKET,
   FADE_RATE_S3_KEY,
   INTEGRATION_S3_KEY,
@@ -18,6 +19,7 @@ import {
 import { S3WebhookConfigurationProvider } from '../../providers';
 import { S3CircuitBreakerConfigurationProvider } from '../../providers/circuit-breaker/s3';
 import { Quoter, WebhookQuoter } from '../../quoters';
+import { STAGE } from '../../util/stage';
 import { ApiInjector, ApiRInj } from '../base/api-handler';
 import { PostQuoteRequestBody } from './schema';
 
@@ -38,11 +40,8 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     });
 
     const stage = process.env['stage'];
-    const webhookProvider = new S3WebhookConfigurationProvider(
-      log,
-      `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`,
-      PRODUCTION_S3_KEY
-    );
+    const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
+    const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
 
     const circuitBreakerProvider = new S3CircuitBreakerConfigurationProvider(
       log,


### PR DESCRIPTION
## Summary
In order to support our beta test env we need to change the s3 bucket we read from based on the stage we are deployed in.