### PR TITLE
chore: lower redshift reaper threshold to two weeks

### DIFF
--- a/lib/cron/redshift-reaper.ts
+++ b/lib/cron/redshift-reaper.ts
@@ -22,6 +22,6 @@ export const handler: ScheduledHandler = async (_event: EventBridgeEvent<string,
 
   // needs to be sequential be cause of the vacuum command
   for (const table of TABLES_TO_CLEAN) {
-    await analyticsRepository.cleanUpTable(table, CREATEDAT, TimestampThreshold.ONE_MONTH);
+    await analyticsRepository.cleanUpTable(table, CREATEDAT, TimestampThreshold.TWO_WEEKS);
   }
 };

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -23,6 +23,7 @@ export type ExecutionConfigs = {
 };
 
 export enum TimestampThreshold {
+  TWO_WEEKS = "'2 WEEKS'",
   ONE_MONTH = "'1 MONTH'",
   TWO_MONTHS = "'2 MONTHS'",
 }


### PR DESCRIPTION
daily volume steadily increasing as we ramp up to 100% 