### PR TITLE
fix: new quote id get generated after quote response

### DIFF
--- a/lib/entities/QuoteResponse.ts
+++ b/lib/entities/QuoteResponse.ts
@@ -3,9 +3,9 @@ import { BigNumber } from 'ethers';
 import { ValidationResult } from 'joi';
 import { v4 as uuidv4 } from 'uuid';
 
-import { QuoteRequestData } from '.';
 import { PostQuoteResponse, RfqResponse, RfqResponseJoi } from '../handlers/quote/schema';
 import { currentTimestampInMs, timestampInMstoSeconds } from '../util/time';
+import { QuoteRequestData } from '.';
 
 export interface QuoteResponseData
   extends Omit<QuoteRequestData, 'tokenInChainId' | 'tokenOutChainId' | 'amount' | 'type' | 'numOutputs'> {
@@ -52,7 +52,6 @@ export class QuoteResponse implements QuoteResponseData {
         {
           ...data,
           swapper: request.swapper,
-          quoteId: request.quoteId ?? uuidv4(),
           amountIn: BigNumber.from(data.amountIn ?? 0),
           amountOut: BigNumber.from(data.amountOut ?? 0),
         },

--- a/lib/handlers/quote/schema.ts
+++ b/lib/handlers/quote/schema.ts
@@ -80,5 +80,6 @@ export type RfqResponse = {
   amountIn: string;
   tokenOut: string;
   amountOut: string;
+  quoteId: string;
   filler?: string;
 };


### PR DESCRIPTION
We require fillers to echo back quoteId and we should use that as the source of truth

right now, a bug exists such that a new quoteId is generated after we get back the response