### PR TITLE
chore: output intermediary S3 data as JSONL

### DIFF
--- a/lib/handlers/blueprints/cw-log-firehose-processor.js
+++ b/lib/handlers/blueprints/cw-log-firehose-processor.js
@@ -37,7 +37,7 @@ function processRecords(records, transformFn) {
         recordId: recId,
       };
     } else if (data.messageType === 'DATA_MESSAGE') {
-      const joinedData = data.logEvents.map((e) => transformFn(e)).join('');
+      const joinedData = data.logEvents.map((e) => transformFn(e)).join('\n');
       const encodedData = Buffer.from(joinedData, 'utf-8').toString('base64');
       return {
         data: encodedData,


### PR DESCRIPTION
Currently the UniswapX analytics events are processed and stored in an intermediate S3 bucket as blobs of JSON objects without being newline-delimited or comma-separated. This works fine for ingestion to Redshift, but additional downstream transformations are required to transform them to newline-delimited JSON (JSONL) for ingestion to BigQuery. This PR changes the output of the S3 data to JSONL as part of the firehose processor's output, which has no impact on how the data is ingested into Redshift, but allows for simplification on the BigQuery ingestion.

**Testing**
I tested this change end-to-end in AWS by logging 4x RFQ requests in rapid succession, which produced a JSONL blob in S3 containing 4 JSON objects each on a new line. I checked for the same 4 `requestId`s in Redshift and they had been ingested.