### PR TITLE
[chore] add eventId to AnalyticsEvent class

### DIFF
--- a/lib/entities/analytics-events.ts
+++ b/lib/entities/analytics-events.ts
@@ -15,9 +15,9 @@ export enum WebhookResponseType {
 };
 
 export class AnalyticsEvent {
-  eventId?: string; // gets set in constructor
+  eventId: string; // gets set in constructor
   eventType: AnalyticsEventType;
-  eventTime?: number; // gets set in constructor
+  eventTime: number; // gets set in constructor
   eventProperties: { [key: string]: any };
 
   constructor(eventType: AnalyticsEventType, eventProperties: { [key: string]: any }) {

--- a/lib/entities/analytics-events.ts
+++ b/lib/entities/analytics-events.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export enum AnalyticsEventType {
   WEBHOOK_RESPONSE = 'WebhookQuoterResponse',
 };
@@ -13,11 +15,13 @@ export enum WebhookResponseType {
 };
 
 export class AnalyticsEvent {
+  eventId?: string; // gets set in constructor
   eventType: AnalyticsEventType;
   eventTime?: number; // gets set in constructor
   eventProperties: { [key: string]: any };
 
   constructor(eventType: AnalyticsEventType, eventProperties: { [key: string]: any }) {
+    this.eventId = uuidv4();
     this.eventType = eventType;
     this.eventTime = Date.now();
     this.eventProperties = eventProperties;

--- a/test/providers/analytics/firehose.test.ts
+++ b/test/providers/analytics/firehose.test.ts
@@ -36,7 +36,7 @@ describe('FirehoseLogger', () => {
 
   it('should send analytics event to Firehose', async () => {
     const firehose = new FirehoseLogger(logger, validStreamArn);
-    const analyticsEvent: AnalyticsEvent = { eventType: AnalyticsEventType.WEBHOOK_RESPONSE, eventProperties: { status: 200 } };
+    const analyticsEvent =  new AnalyticsEvent(AnalyticsEventType.WEBHOOK_RESPONSE,{ status: 200 });
 
     const putRecordMock = jest.fn();
     mockedFirehose.prototype.putRecord = putRecordMock;

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -376,7 +376,7 @@ describe('WebhookQuoter tests', () => {
       `Webhook Response failed validation. Webhook: ${WEBHOOK_URL}.`
     );
     expect(mockFirehoseLogger.sendAnalyticsEvent).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         eventType: AnalyticsEventType.WEBHOOK_RESPONSE,
         eventProperties: {
           ...sharedWebhookResponseEventProperties,
@@ -392,7 +392,7 @@ describe('WebhookQuoter tests', () => {
             },
           ],
         }
-      },
+      }),
     );
     expect(response).toEqual([]);
   });
@@ -426,7 +426,7 @@ describe('WebhookQuoter tests', () => {
       'Webhook ResponseId does not match request'
     );    
     expect(mockFirehoseLogger.sendAnalyticsEvent).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         eventType: AnalyticsEventType.WEBHOOK_RESPONSE,
         eventProperties: {
           ...sharedWebhookResponseEventProperties,
@@ -435,7 +435,7 @@ describe('WebhookQuoter tests', () => {
           responseType: WebhookResponseType.REQUEST_ID_MISMATCH,
           mismatchedRequestId: quote.requestId,
         }
-      },
+      }),
     );
     expect(response).toEqual([]);
   });
@@ -456,7 +456,7 @@ describe('WebhookQuoter tests', () => {
       `Webhook elected not to quote: ${WEBHOOK_URL}`
     );
     expect(mockFirehoseLogger.sendAnalyticsEvent).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         eventType: AnalyticsEventType.WEBHOOK_RESPONSE,
         eventProperties: {
           ...sharedWebhookResponseEventProperties,
@@ -464,7 +464,7 @@ describe('WebhookQuoter tests', () => {
           data: '',
           responseType: WebhookResponseType.NON_QUOTE,
         }
-      },
+      }),
     );
     expect(response.length).toEqual(0);
   });
@@ -499,7 +499,7 @@ describe('WebhookQuoter tests', () => {
       `Webhook elected not to quote: ${WEBHOOK_URL}`
     );
     expect(mockFirehoseLogger.sendAnalyticsEvent).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         eventType: AnalyticsEventType.WEBHOOK_RESPONSE,
         eventProperties: {
           ...sharedWebhookResponseEventProperties,
@@ -507,7 +507,7 @@ describe('WebhookQuoter tests', () => {
           data: quote,
           responseType: WebhookResponseType.NON_QUOTE,
         }
-      },
+      }),
     );
   });
 
@@ -553,7 +553,7 @@ describe('WebhookQuoter tests', () => {
       `Webhook elected not to quote: ${WEBHOOK_URL}`
     );
     expect(mockFirehoseLogger.sendAnalyticsEvent).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         eventType: AnalyticsEventType.WEBHOOK_RESPONSE,
         eventProperties: {
           ...sharedWebhookResponseEventProperties,
@@ -561,7 +561,7 @@ describe('WebhookQuoter tests', () => {
           data: quote,
           responseType: WebhookResponseType.NON_QUOTE,
         }
-      },
+      }),
     );
   });
 });


### PR DESCRIPTION
- adds `eventId` to AnalyticsEvent class for downstream deduping purposes
- updates AnalyticsEvent class to require `eventTime` class variable
- updates code to construct `AnalyticsEvent` before passing to sendAnalyticsEvent()