### PR TITLE
[chore] AnalyticsEvent eventTime to ISO string

### DIFF
--- a/lib/entities/analytics-events.ts
+++ b/lib/entities/analytics-events.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { timestampInMstoISOString } from '../util/time';
 
 export enum AnalyticsEventType {
   WEBHOOK_RESPONSE = 'WebhookQuoterResponse',
@@ -17,13 +18,13 @@ export enum WebhookResponseType {
 export class AnalyticsEvent {
   eventId: string; // gets set in constructor
   eventType: AnalyticsEventType;
-  eventTime: number; // gets set in constructor
+  eventTime: string; // gets set in constructor
   eventProperties: { [key: string]: any };
 
   constructor(eventType: AnalyticsEventType, eventProperties: { [key: string]: any }) {
     this.eventId = uuidv4();
     this.eventType = eventType;
-    this.eventTime = Date.now();
+    this.eventTime = timestampInMstoISOString(Date.now());
     this.eventProperties = eventProperties;
   }
 };

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -10,6 +10,7 @@ import { WebhookConfiguration, WebhookConfigurationProvider } from '../providers
 import { CircuitBreakerConfigurationProvider } from '../providers/circuit-breaker';
 import { FillerComplianceConfigurationProvider } from '../providers/compliance';
 import { Quoter, QuoterType } from '.';
+import { timestampInMstoISOString } from '../util/time';
 
 // TODO: shorten, maybe take from env config
 const WEBHOOK_TIMEOUT_MS = 500;
@@ -114,7 +115,7 @@ export class WebhookQuoter implements Quoter {
       quoteId: cleanRequest.quoteId,
       name: name,
       endpoint: endpoint,
-      requestTime: before,
+      requestTime: timestampInMstoISOString(before),
       timeoutSettingMs: axiosConfig.timeout,
     };
 
@@ -139,7 +140,7 @@ export class WebhookQuoter implements Quoter {
       const rawResponse = {
         status: hookResponse.status,
         data: hookResponse.data,
-        responseTime: Date.now(),
+        responseTime: timestampInMstoISOString(Date.now()),
         latencyMs: Date.now() - before,
       };
 
@@ -254,7 +255,7 @@ export class WebhookQuoter implements Quoter {
       metric.putMetric(Metric.RFQ_FAIL_ERROR, 1, MetricLoggerUnit.Count);
       metric.putMetric(metricContext(Metric.RFQ_FAIL_ERROR, name), 1, MetricLoggerUnit.Count);
       const errorLatency = {
-        responseTime: Date.now(),
+        responseTime: timestampInMstoISOString(Date.now()),
         latencyMs: Date.now() - before,
       };
       if (e instanceof AxiosError) {

--- a/lib/util/time.ts
+++ b/lib/util/time.ts
@@ -1,5 +1,6 @@
 export const currentTimestampInSeconds = () => Math.floor(Date.now() / 1000).toString();
 export const currentTimestampInMs = () => Date.now().toString();
+export const timestampInMstoISOString = (timestamp: number) => new Date(timestamp).toISOString();
 export const timestampInMstoSeconds = (timestamp: number) => Math.floor(timestamp / 1000).toString();
 
 export function sleep(ms: number) {

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -78,9 +78,9 @@ describe('WebhookQuoter tests', () => {
     quoteId: expect.any(String),
     name: 'uniswap',
     endpoint: WEBHOOK_URL,
-    requestTime: expect.any(Number),
+    requestTime: expect.any(String),
     timeoutSettingMs: 500,
-    responseTime: expect.any(Number),
+    responseTime: expect.any(String),
     latencyMs: expect.any(Number),
   };
 


### PR DESCRIPTION
- Updates AnalyticsEvent `eventTime` class variable to be an ISO string to ingest in BigQuery natively as a Timestamp type
- Updates `requestTime` and `responseTime` event properies logged with the QuoterWebhookResponse events.