### PR TITLE
[fix] add analyticsStreamArn to processor lambdas env vars

### DIFF
--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -38,6 +38,7 @@ enum RS_DATA_TYPES {
 export interface AnalyticsStackProps extends cdk.NestedStackProps {
   quoteLambda: aws_lambda_nodejs.NodejsFunction;
   envVars: Record<string, string>;
+  analyticsStreamArn: string;
 }
 
 /**
@@ -56,7 +57,7 @@ export class AnalyticsStack extends cdk.NestedStack {
 
   constructor(scope: Construct, id: string, props: AnalyticsStackProps) {
     super(scope, id, props);
-    const { quoteLambda } = props;
+    const { quoteLambda, analyticsStreamArn } = props;
 
     /* S3 Initialization */
     const rfqRequestBucket = new aws_s3.Bucket(this, 'RfqRequestBucket');
@@ -391,6 +392,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
+        ANALYTICS_STREAM_ARN: analyticsStreamArn,
       },
     });
 
@@ -407,6 +409,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
+        ANALYTICS_STREAM_ARN: analyticsStreamArn,
       },
     });
 
@@ -423,6 +426,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
+        ANALYTICS_STREAM_ARN: analyticsStreamArn,
       },
     });
 
@@ -439,6 +443,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
+        ANALYTICS_STREAM_ARN: analyticsStreamArn,
       },
     });
 

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -404,6 +404,7 @@ export class APIStack extends cdk.Stack {
     const analyticsStack = new AnalyticsStack(this, 'AnalyticsStack', {
       quoteLambda,
       envVars: props.envVars,
+      analyticsStreamArn: firehoseStack.analyticsStreamArn,
     });
 
     const cronStack = new CronStack(this, 'CronStack', {


### PR DESCRIPTION
## background

1. https://github.com/Uniswap/uniswapx-parameterization-api/pull/236 added a FirehoseLogger to the container injector, which is constructed using a `ANALYTICS_STREAM_ARN` environment variable as an argument
2. https://github.com/Uniswap/uniswapx-parameterization-api/pull/236 added `ANALYTICS_STREAM_ARN` environment variable to the lambda handlers initialized in `bin/stacks/api-stack.ts`, but did not add the environment variable to the Firehose lambda processors in `bin/stacks/analytics-stack.ts`
3. The logging to CloudWatch remained the same, but the Firehose lambda processors started to fail because the `ANALYTICS_STREAM_ARN` environment variable was missing and FirehoseLogger was constructed with an undefined `streamArn` param, so the logged events were not processed by firehose successfully and delivered to S3 / Redshift.

## changes

1. add `ANALYTICS_STREAM_ARN` environment variable to the Firehose lambda processors in `bin/stacks/analytics-stack.ts`

## testing

1. deployed changes in dev and verified that the Firehose lambda processors in `bin/stacks/analytics-stack.ts` have the `ANALYTICS_STREAM_ARN` environment variable set and that they processed QuoteRequest events properly during integration tests.
