### PR TITLE
feat: Automated CB based on timestamps, Cron and DB part

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -4,5 +4,6 @@ import { TableCapacityConfig } from './stacks/cron-stack';
 
 export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
   fadeRate: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 5 },
+  timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 5 },
   synthSwitch: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 5 },
 };

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -31,6 +31,7 @@ type TableCapacityOptions = {
 export type TableCapacityConfig = {
   fadeRate: TableCapacityOptions;
   synthSwitch: TableCapacityOptions;
+  timestamps: TableCapacityOptions;
 };
 
 export interface CronStackProps extends cdk.NestedStackProps {
@@ -177,6 +178,19 @@ export class CronStack extends cdk.NestedStack {
       ...PROD_TABLE_CAPACITY.synthSwitch,
     });
     this.alarmsPerTable(synthSwitchTable, DYNAMO_TABLE_NAME.SYNTHETIC_SWITCH_TABLE, chatbotTopic);
+
+    const fillerCBTimestampsTable = new aws_dynamo.Table(this, `${SERVICE_NAME}FillerCBTimestampsTable`, {
+      tableName: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS,
+      partitionKey: {
+        name: 'hash',
+        type: aws_dynamo.AttributeType.STRING,
+      },
+      deletionProtection: true,
+      pointInTimeRecovery: true,
+      contributorInsightsEnabled: true,
+      ...PROD_TABLE_CAPACITY.timestamps,
+    });
+    this.alarmsPerTable(fillerCBTimestampsTable, DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS, chatbotTopic);
   }
 
   private alarmsPerTable(table: aws_dynamo.Table, name: string, chatbotSNSTopic?: ITopic): void {

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -10,6 +10,16 @@ module.exports = {
       ],
       ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
     },
+    {
+      TableName: 'Timestamp',
+      KeySchema: [
+        { AttributeName: 'hash', KeyType: 'HASH' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'hash', AttributeType: 'S' },
+      ],
+      ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
+    }
   ],
   port: 8000,
 };

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -11,7 +11,7 @@ module.exports = {
       ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
     },
     {
-      TableName: 'Timestamp',
+      TableName: 'FillerCBTimestamps',
       KeySchema: [
         { AttributeName: 'hash', KeyType: 'HASH' },
       ],

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,7 +12,7 @@ export const BETA_COMPLIANCE_S3_KEY = 'beta.json';
 export const DYNAMO_TABLE_NAME = {
   FADES: 'Fades',
   SYNTHETIC_SWITCH_TABLE: 'SyntheticSwitchTable',
-  TIMESTAMP: 'Timestamp',
+  FILLER_CB_TIMESTAMPS: 'FillerCBTimestamps',
 };
 
 export const DYNAMO_TABLE_KEY = {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -24,5 +24,7 @@ export const DYNAMO_TABLE_KEY = {
   TRADE_TYPE: 'type',
   LOWER: 'lower',
   ENABLED: 'enabled',
-  TIMESTAMP: 'timestamp',
+  BLOCK_UNTIL_TIMESTAMP: 'blockUntilTimestamp',
+  LAST_POST_TIMESTAMP: 'lastPostTimestamp',
+  FADED: 'faded',
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,6 +12,7 @@ export const BETA_COMPLIANCE_S3_KEY = 'beta.json';
 export const DYNAMO_TABLE_NAME = {
   FADES: 'Fades',
   SYNTHETIC_SWITCH_TABLE: 'SyntheticSwitchTable',
+  TIMESTAMP: 'Timestamp',
 };
 
 export const DYNAMO_TABLE_KEY = {
@@ -23,4 +24,5 @@ export const DYNAMO_TABLE_KEY = {
   TRADE_TYPE: 'type',
   LOWER: 'lower',
   ENABLED: 'enabled',
+  TIMESTAMP: 'timestamp',
 };

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -71,6 +71,9 @@ async function main(metrics: MetricsLogger) {
     //  |---- bar ------|---- 1 ----|---- 12222222 ----|
     const fillersNewFades = getFillersNewFades(result, addressToFillerHash, fillerTimestamps, log);
 
+    //  | hash        |lastPostTimestamp|blockUntilTimestamp|
+    //  |---- foo ----|---- 1300000 ----|---- now + fades * block_per_fade ----|
+    //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
     const updatedTimestamps = calculateNewTimestamps(
       fillerTimestamps,
       fillersNewFades,

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -66,9 +66,9 @@ async function main(metrics: MetricsLogger) {
     const addressToFillerHash = await webhookProvider.addressToFillerHash();
 
     // aggregated # of fades by filler entity (not address)
-    //  | hash    |     faded  |   postTimestamp  |
-    //  |---- foo ------|---- 3 ----|---- 12345678 ----|
-    //  |---- bar ------|---- 1 ----|---- 12222222 ----|
+    //  | hash    |  faded  |
+    //  |-- foo --|--- 3 ---|`
+    //  |-- bar --|--- 1 ---|
     const fillersNewFades = getFillersNewFades(result, addressToFillerHash, fillerTimestamps, log);
 
     //  | hash        |lastPostTimestamp|blockUntilTimestamp|

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -108,6 +108,9 @@ export function calculateNewTimestamps(
   return updatedTimestamps;
 }
 
+/* find the number of new fades, for each filler entity, from 
+   the last time this cron is run
+*/
 export function getFillersNewFades(
   rows: FadesRowType[],
   addressToFillerHash: Map<string, string>,

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -91,7 +91,7 @@ export function calculateNewTimestamps(
     }
     const newFades = fillersNewFades[hash];
     if (newFades) {
-      const blockUntilTimestamp = Math.floor(Date.now() / 1000) + newFades * BLOCK_PER_FADE_SECS;
+      const blockUntilTimestamp = newPostTimestamp + newFades * BLOCK_PER_FADE_SECS;
       updatedTimestamps.push([hash, newPostTimestamp, blockUntilTimestamp]);
     }
   });

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -51,6 +51,13 @@ async function main(metrics: MetricsLogger) {
   };
   const fadesRepository = FadesRepository.create(sharedConfig);
   await fadesRepository.createFadesView();
+  /*
+   query redshift for recent orders
+        | fillerAddress |    faded  |   postTimestamp |
+        |---- 0x1 ------|---- 0 ----|---- 12222222 ---|
+        |---- 0x2 ------|---- 1 ----|---- 12345679 --|
+        |---- 0x1 ------|---- 0 ----|---- 12345678 ---|
+  */
   const result = await fadesRepository.getFades();
 
   if (result) {
@@ -58,8 +65,8 @@ async function main(metrics: MetricsLogger) {
     const fillerTimestamps = await timestampDB.getFillerTimestampsMap(fillerHashes);
     const addressToFillerHash = await webhookProvider.addressToFillerHash();
 
-    // get fillers new fades from last checked timestamp:
-    //  | rfqFiller    |     faded  |   postTimestamp  |
+    // aggregated # of fades by filler entity (not address)
+    //  | hash    |     faded  |   postTimestamp  |
     //  |---- foo ------|---- 3 ----|---- 12345678 ----|
     //  |---- bar ------|---- 1 ----|---- 12222222 ----|
     const fillersNewFades = getFillersNewFades(result, addressToFillerHash, fillerTimestamps, log);

--- a/lib/cron/fade-rate.ts
+++ b/lib/cron/fade-rate.ts
@@ -66,7 +66,7 @@ async function main(metrics: MetricsLogger) {
     const addressToFillerHash = await webhookProvider.addressToFillerHash();
 
     // aggregated # of fades by filler entity (not address)
-    //  | hash    |  faded  |
+    //  | hash    |  fades  |
     //  |-- foo --|--- 3 ---|`
     //  |-- bar --|--- 1 ---|
     const fillersNewFades = getFillersNewFades(result, addressToFillerHash, fillerTimestamps, log);

--- a/lib/providers/circuit-breaker/s3.ts
+++ b/lib/providers/circuit-breaker/s3.ts
@@ -3,19 +3,23 @@ import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { MetricsLogger, Unit } from 'aws-embedded-metrics';
 import Logger from 'bunyan';
 
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { CircuitBreakerConfiguration, CircuitBreakerConfigurationProvider } from '.';
 import { Metric } from '../../entities';
 import { checkDefined } from '../../preconditions/preconditions';
+import { BaseTimestampRepository } from '../../repositories';
+import { TimestampRepository } from '../../repositories/timestamp-repository';
 
 export class S3CircuitBreakerConfigurationProvider implements CircuitBreakerConfigurationProvider {
   private log: Logger;
   private fillers: CircuitBreakerConfiguration[];
   private lastUpdatedTimestamp: number;
   private client: S3Client;
+  private timestampDB: BaseTimestampRepository;
 
   // try to refetch endpoints every minute
   private static UPDATE_PERIOD_MS = 1 * 60000;
-  private static FILL_RATE_THRESHOLD = 0.75;
 
   constructor(_log: Logger, private bucket: string, private key: string) {
     this.log = _log.child({ quoter: 'S3CircuitBreakerConfigurationProvider' });
@@ -26,6 +30,15 @@ export class S3CircuitBreakerConfigurationProvider implements CircuitBreakerConf
         requestTimeout: 500,
       }),
     });
+    const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+      marshallOptions: {
+        convertEmptyValues: true,
+      },
+      unmarshallOptions: {
+        wrapNumbers: true,
+      },
+    });
+    this.timestampDB = TimestampRepository.create(documentClient);
   }
 
   async getConfigurations(): Promise<CircuitBreakerConfiguration[]> {

--- a/lib/providers/circuit-breaker/s3.ts
+++ b/lib/providers/circuit-breaker/s3.ts
@@ -3,9 +3,9 @@ import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { MetricsLogger, Unit } from 'aws-embedded-metrics';
 import Logger from 'bunyan';
 
+import { CircuitBreakerConfiguration, CircuitBreakerConfigurationProvider } from '.';
 import { Metric } from '../../entities';
 import { checkDefined } from '../../preconditions/preconditions';
-import { CircuitBreakerConfiguration, CircuitBreakerConfigurationProvider } from '.';
 
 export class S3CircuitBreakerConfigurationProvider implements CircuitBreakerConfigurationProvider {
   private log: Logger;
@@ -13,8 +13,8 @@ export class S3CircuitBreakerConfigurationProvider implements CircuitBreakerConf
   private lastUpdatedTimestamp: number;
   private client: S3Client;
 
-  // try to refetch endpoints every 5 mins
-  private static UPDATE_PERIOD_MS = 5 * 60000;
+  // try to refetch endpoints every minute
+  private static UPDATE_PERIOD_MS = 1 * 60000;
   private static FILL_RATE_THRESHOLD = 0.75;
 
   constructor(_log: Logger, private bucket: string, private key: string) {

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -27,6 +27,7 @@ const WEBHOOK_TIMEOUT_MS = 500;
 // endpoints must return well-formed QuoteResponse JSON
 export class WebhookQuoter implements Quoter {
   private log: Logger;
+  private readonly ALLOW_LIST: Set<string>;
 
   constructor(
     _log: Logger,
@@ -37,6 +38,7 @@ export class WebhookQuoter implements Quoter {
     _allow_list: Set<string> = new Set<string>(['1ed189c4b20479e36acf74e2bc87e03bfdce765ecba6696970caee8299fc005f'])
   ) {
     this.log = _log.child({ quoter: 'WebhookQuoter' });
+    this.ALLOW_LIST = _allow_list;
   }
 
   public async quote(request: QuoteRequest): Promise<QuoteResponse[]> {
@@ -70,6 +72,7 @@ export class WebhookQuoter implements Quoter {
         const enabledEndpoints: WebhookConfiguration[] = [];
         endpoints.forEach((e) => {
           if (
+            this.ALLOW_LIST.has(e.hash) ||
             (fillerToConfigMap.has(e.hash) && fillerToConfigMap.get(e.hash)?.enabled) ||
             !fillerToConfigMap.has(e.hash) // default to allowing fillers not in the config
           ) {

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -19,7 +19,6 @@ import { FirehoseLogger } from '../providers/analytics';
 import { CircuitBreakerConfigurationProvider } from '../providers/circuit-breaker';
 import { FillerComplianceConfigurationProvider } from '../providers/compliance';
 import { timestampInMstoISOString } from '../util/time';
-import { Quoter, QuoterType } from '.';
 
 // TODO: shorten, maybe take from env config
 const WEBHOOK_TIMEOUT_MS = 500;

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -78,7 +78,8 @@ export interface BaseSwitchRepository {
 }
 
 export interface BaseTimestampRepository {
-  updateTimestampsBatch(toUpdate: [string, number][], ts: number): Promise<void>;
+  updateTimestampsBatch(toUpdate: [string, number, number?][]): Promise<void>;
   getFillerTimestamps(hash: string): Promise<TimestampRepoRow>;
+  getFillerTimestampsMap(hashes: string[]): Promise<Map<string, Omit<TimestampRepoRow, 'hash'>>>;
   getTimestampsBatch(hashes: string[]): Promise<TimestampRepoRow[]>;
 }

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -28,6 +28,17 @@ export enum TimestampThreshold {
   TWO_MONTHS = "'2 MONTHS'",
 }
 
+export type TimestampRepoRow = {
+  hash: string;
+  lastPostTimestamp: number;
+  blockUntilTimestamp: number;
+};
+
+export type DynamoTimestampRepoRow = Exclude<TimestampRepoRow, 'lastPostTimestamp' | 'blockUntilTimestamp'> & {
+  lastPostTimestamp: string;
+  blockUntilTimestamp: string;
+};
+
 export abstract class BaseRedshiftRepository {
   constructor(readonly client: RedshiftDataClient, private readonly configs: SharedConfigs) {}
 
@@ -67,5 +78,7 @@ export interface BaseSwitchRepository {
 }
 
 export interface BaseTimestampRepository {
-  updateTimestamp(hash: string, ts: number): Promise<void>;
+  updateTimestampsBatch(toUpdate: [string, number][], ts: number): Promise<void>;
+  getFillerTimestamps(hash: string): Promise<TimestampRepoRow>;
+  getTimestampsBatch(hashes: string[]): Promise<TimestampRepoRow[]>;
 }

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -65,3 +65,7 @@ export interface BaseSwitchRepository {
   putSynthSwitch(trade: SynthSwitchTrade, lower: string, enabled: boolean): Promise<void>;
   syntheticQuoteForTradeEnabled(trade: SynthSwitchQueryParams): Promise<boolean>;
 }
+
+export interface BaseTimestampRepository {
+  updateTimestamp(hash: string, ts: number): Promise<void>;
+}

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -29,13 +29,15 @@ export class FadesRepository extends BaseRedshiftRepository {
     await this.executeStatement(CREATE_VIEW_SQL, FadesRepository.log, { waitTimeMs: 2_000 });
   }
 
+  //get latest 20 orders for each filler address, and whether they are faded or not
   async getFades(): Promise<FadesRowType[]> {
     const stmtId = await this.executeStatement(FADE_RATE_SQL, FadesRepository.log, { waitTimeMs: 2_000 });
     const response = await this.client.send(new GetStatementResultCommand({ Id: stmtId }));
     /* result should be in the following format
-        | rfqFiller    |     faded     |   postTimestamp  |
-        |---- foo ------|---- 1 ----|---- 12345678 ----|
+        | rfqFiller    |     faded  |   postTimestamp  |
         |---- bar ------|---- 0 ----|---- 12222222 ----|
+        |---- foo ------|---- 1 ----|---- 12345679 ----|
+        |---- foo ------|---- 0 ----|---- 12345678 ----|
       */
     const result = response.Records;
     if (!result) {
@@ -56,14 +58,15 @@ export class FadesRepository extends BaseRedshiftRepository {
 }
 
 const CREATE_VIEW_SQL = `
-CREATE OR REPLACE VIEW rfqOrdersTimestamp 
+CREATE OR REPLACE VIEW latestRfqs 
 AS (
 WITH latestOrders AS (
   SELECT * FROM (
     SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders
   )
-  WHERE row_num <= 10
+  WHERE row_num <= 20
   AND deadline < EXTRACT(EPOCH FROM GETDATE()) -- exclude orders that can still be filled
+  LIMIT 1000
 )
 SELECT
     latestOrders.chainid as chainId, latestOrders.filler as rfqFiller, latestOrders.startTime as decayStartTime, latestOrders.quoteid, archivedorders.filler as actualFiller, latestOrders.createdat as postTimestamp, archivedorders.txhash as txHash, archivedOrders.fillTimestamp as fillTimestamp,
@@ -80,20 +83,17 @@ AND rfqFiller != '0x0000000000000000000000000000000000000000'
 AND chainId NOT IN (5,8001,420,421613) -- exclude mainnet goerli, polygon goerli, optimism goerli and arbitrum goerli testnets 
 AND
     postTimestamp >= extract(epoch from (GETDATE() - INTERVAL '168 HOURS')) -- 7 days rolling window
-);
+)
+ORDER BY rfqFiller, postTimestamp DESC
+LIMIT 1000 
 `;
 
 const FADE_RATE_SQL = `
-WITH ORDERS_CTE AS (
-    SELECT 
-        rfqFiller,
-        postTimestamp,
-        CASE WHEN (decayStartTime < fillTimestamp) THEN 1 ELSE 0 END AS faded,
-    FROM rfqOrdersTimestamp
-)
 SELECT 
     rfqFiller,
     postTimestamp,
-    faded
-FROM ORDERS_CTE
+    CASE WHEN (decayStartTime < fillTimestamp) THEN 1 ELSE 0 END AS faded
+FROM latestRfqs
+ORDER BY rfqFiller, postTimestamp DESC
+LIMIT 1000
 `;

--- a/lib/repositories/switch-repository.ts
+++ b/lib/repositories/switch-repository.ts
@@ -61,7 +61,6 @@ export class SwitchRepository implements BaseSwitchRepository {
       { execute: true, consistent: true }
     );
 
-    SwitchRepository.log.info({ res: result.Item }, 'get result');
     if (result.Item && BigNumber.from(result.Item.lower).lte(amount)) {
       return result.Item.enabled;
     } else {
@@ -71,7 +70,6 @@ export class SwitchRepository implements BaseSwitchRepository {
   }
 
   public async putSynthSwitch(trade: SynthSwitchTrade, lower: string, enabled: boolean): Promise<void> {
-    SwitchRepository.log.info({ pk: `${SwitchRepository.getKey(trade)}` }, 'put pk');
     await this.switchEntity.put(
       {
         [PARTITION_KEY]: `${SwitchRepository.getKey(trade)}`,

--- a/lib/repositories/timestamp-repository.ts
+++ b/lib/repositories/timestamp-repository.ts
@@ -22,7 +22,7 @@ export class TimestampRepository implements BaseTimestampRepository {
     delete this.log.fields.hostname;
 
     const table = new Table({
-      name: DYNAMO_TABLE_NAME.TIMESTAMP,
+      name: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS,
       partitionKey: TimestampRepository.PARTITION_KEY,
       DocumentClient: documentClient,
     });
@@ -88,7 +88,7 @@ export class TimestampRepository implements BaseTimestampRepository {
         parse: true,
       }
     );
-    return items[DYNAMO_TABLE_NAME.TIMESTAMP].map((row: DynamoTimestampRepoRow) => {
+    return items[DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS].map((row: DynamoTimestampRepoRow) => {
       return {
         hash: row.hash,
         lastPostTimestamp: parseInt(row.lastPostTimestamp),

--- a/lib/repositories/timestamp-repository.ts
+++ b/lib/repositories/timestamp-repository.ts
@@ -1,0 +1,55 @@
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import Logger from 'bunyan';
+import { Entity, Table } from 'dynamodb-toolbox';
+
+import { DYNAMO_TABLE_KEY, DYNAMO_TABLE_NAME } from '../constants';
+import { BaseTimestampRepository } from './base';
+
+export class TimestampRepository implements BaseTimestampRepository {
+  static log: Logger;
+  static PARTITION_KEY = 'hash';
+
+  static create(documentClient: DynamoDBDocumentClient): BaseTimestampRepository {
+    this.log = Logger.createLogger({
+      name: 'DynamoTimestampRepository',
+      serializers: Logger.stdSerializers,
+    });
+
+    const table = new Table({
+      name: DYNAMO_TABLE_NAME.TIMESTAMP,
+      partitionKey: TimestampRepository.PARTITION_KEY,
+      DocumentClient: documentClient,
+    });
+
+    const entity = new Entity({
+      name: 'SynthSwitchEntity',
+      attributes: {
+        [TimestampRepository.PARTITION_KEY]: { partitionKey: true },
+        [`${DYNAMO_TABLE_KEY.TIMESTAMP}`]: { type: 'number' },
+      },
+      table: table,
+      autoExecute: true,
+    } as const);
+
+    return new TimestampRepository(table, entity);
+  }
+
+  private constructor(
+    // eslint-disable-next-line
+    // @ts-expect-error
+    private readonly _switchTable: Table<'Timestamp', 'hash', null>,
+    private readonly entity: Entity
+  ) {}
+
+  public async updateTimestamp(hash: string, ts: number): Promise<void> {
+    await this.entity.put(
+      {
+        [TimestampRepository.PARTITION_KEY]: hash,
+        [`${DYNAMO_TABLE_KEY.TIMESTAMP}`]: ts,
+      },
+      {
+        execute: true,
+      }
+    );
+  }
+}

--- a/lib/repositories/timestamp-repository.ts
+++ b/lib/repositories/timestamp-repository.ts
@@ -69,7 +69,6 @@ export class TimestampRepository implements BaseTimestampRepository {
         execute: true,
       }
     );
-    TimestampRepository.log.info({ Item }, 'get result');
     return {
       hash: Item?.hash,
       lastPostTimestamp: parseInt(Item?.lastPostTimestamp),

--- a/test/crons/fade-rate.test.ts
+++ b/test/crons/fade-rate.test.ts
@@ -22,6 +22,10 @@ const FADES_ROWS: FadesRowType[] = [
   { fillerAddress: '0x3', faded: 1, postTimestamp: now - 100 },
   // filler3
   { fillerAddress: '0x4', faded: 1, postTimestamp: now - 100 },
+  // filler4
+  { fillerAddress: '0x5', faded: 0, postTimestamp: now - 100 },
+  // filler5
+  { fillerAddress: '0x6', faded: 0, postTimestamp: now - 100 },
 ];
 
 const ADDRESS_TO_FILLER = new Map<string, string>([
@@ -29,12 +33,16 @@ const ADDRESS_TO_FILLER = new Map<string, string>([
   ['0x2', 'filler1'],
   ['0x3', 'filler2'],
   ['0x4', 'filler3'],
+  ['0x5', 'filler4'],
+  ['0x6', 'filler5'],
 ]);
 
 const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
   ['filler1', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN }],
   ['filler2', { lastPostTimestamp: now - 75, blockUntilTimestamp: now - 50 }],
   ['filler3', { lastPostTimestamp: now - 101, blockUntilTimestamp: now + 1000 }],
+  ['filler4', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN }],
+  ['filler5', { lastPostTimestamp: now - 150, blockUntilTimestamp: now + 100 }],
 ]);
 
 // silent logger in tests
@@ -53,6 +61,8 @@ describe('FadeRateCron test', () => {
         filler1: 3, // count all fades in FADES_ROWS
         filler2: 1, // only count postTimestamp == now - 70
         filler3: 1,
+        filler4: 0,
+        filler5: 0,
       });
     });
   });
@@ -69,6 +79,11 @@ describe('FadeRateCron test', () => {
         ['filler1', now, now + BLOCK_PER_FADE_SECS * 3],
         ['filler2', now, now + BLOCK_PER_FADE_SECS * 1],
       ]);
+    });
+
+    it('keep old blockUntilTimestamp if no new fades', () => {
+      expect(newTimestamps).not.toMatchObject([['filler5', expect.anything(), expect.anything()]]);
+      expect(newTimestamps).not.toMatchObject([['filler4', expect.anything(), expect.anything()]]);
     });
 
     it('ignores fillers with blockUntilTimestamp > current timestamp', () => {

--- a/test/crons/fade-rate.test.ts
+++ b/test/crons/fade-rate.test.ts
@@ -1,18 +1,40 @@
 import Logger from 'bunyan';
 
-import { calculateFillerFadeRates } from '../../lib/cron/fade-rate';
+import {
+  BLOCK_PER_FADE_SECS,
+  calculateNewTimestamps,
+  FillerFades,
+  FillerTimestamps,
+  getFillersNewFades,
+} from '../../lib/cron/fade-rate';
 import { FadesRowType } from '../../lib/repositories';
 
+const now = Math.floor(Date.now() / 1000);
+
 const FADES_ROWS: FadesRowType[] = [
-  { fillerAddress: '0x1', totalQuotes: 50, fadedQuotes: 10 },
-  { fillerAddress: '0x2', totalQuotes: 50, fadedQuotes: 20 },
-  { fillerAddress: '0x3', totalQuotes: 100, fadedQuotes: 5 },
+  // filler1
+  { fillerAddress: '0x1', faded: 1, postTimestamp: now - 100 },
+  { fillerAddress: '0x1', faded: 0, postTimestamp: now - 90 },
+  { fillerAddress: '0x1', faded: 1, postTimestamp: now - 80 },
+  { fillerAddress: '0x2', faded: 1, postTimestamp: now - 80 },
+  // filler2
+  { fillerAddress: '0x3', faded: 1, postTimestamp: now - 70 },
+  { fillerAddress: '0x3', faded: 1, postTimestamp: now - 100 },
+  // filler3
+  { fillerAddress: '0x4', faded: 1, postTimestamp: now - 100 },
 ];
 
 const ADDRESS_TO_FILLER = new Map<string, string>([
   ['0x1', 'filler1'],
   ['0x2', 'filler1'],
   ['0x3', 'filler2'],
+  ['0x4', 'filler3'],
+]);
+
+const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
+  ['filler1', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN }],
+  ['filler2', { lastPostTimestamp: now - 75, blockUntilTimestamp: now - 50 }],
+  ['filler3', { lastPostTimestamp: now - 101, blockUntilTimestamp: now + 1000 }],
 ]);
 
 // silent logger in tests
@@ -20,14 +42,38 @@ const logger = Logger.createLogger({ name: 'test' });
 logger.level(Logger.FATAL);
 
 describe('FadeRateCron test', () => {
-  describe('calculateFillerFadeRates', () => {
+  let newFades: FillerFades;
+  beforeAll(() => {
+    newFades = getFillersNewFades(FADES_ROWS, ADDRESS_TO_FILLER, FILLER_TIMESTAMPS, logger);
+  });
+
+  describe('getFillersNewFades', () => {
     it('takes into account multiple filler addresses of the same filler', () => {
-      expect(calculateFillerFadeRates(FADES_ROWS, ADDRESS_TO_FILLER, logger)).toEqual(
-        new Map<string, number>([
-          ['filler1', 0.3],
-          ['filler2', 0.05],
-        ])
-      );
+      expect(newFades).toEqual({
+        filler1: 3, // count all fades in FADES_ROWS
+        filler2: 1, // only count postTimestamp == now - 70
+        filler3: 1,
+      });
+    });
+  });
+
+  describe('calculateNewTimestamps', () => {
+    let newTimestamps: [string, number, number?][];
+
+    beforeAll(() => {
+      newTimestamps = calculateNewTimestamps(FILLER_TIMESTAMPS, newFades, now, logger);
+    });
+
+    it('calculates blockUntilTimestamp for each filler', () => {
+      expect(newTimestamps).toMatchObject([
+        ['filler1', now, now + BLOCK_PER_FADE_SECS * 3],
+        ['filler2', now, now + BLOCK_PER_FADE_SECS * 1],
+      ]);
+    });
+
+    it('ignores fillers with blockUntilTimestamp > current timestamp', () => {
+      expect(newTimestamps).toHaveLength(2);
+      expect(newTimestamps).not.toMatchObject([['filler3', expect.anything(), expect.anything()]]);
     });
   });
 });

--- a/test/repositories/shared.ts
+++ b/test/repositories/shared.ts
@@ -1,0 +1,10 @@
+import { DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
+
+export const DYNAMO_CONFIG: DynamoDBClientConfig = {
+  endpoint: 'http://localhost:8000',
+  region: 'local',
+  credentials: {
+    accessKeyId: 'fakeMyKeyId',
+    secretAccessKey: 'fakeSecretAccessKey',
+  },
+};

--- a/test/repositories/switch-repository.test.ts
+++ b/test/repositories/switch-repository.test.ts
@@ -1,19 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { DynamoDBClient, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
 import { SynthSwitchQueryParams } from '../../lib/handlers/synth-switch';
 import { SwitchRepository } from '../../lib/repositories/switch-repository';
-
-const dynamoConfig: DynamoDBClientConfig = {
-  endpoint: 'http://localhost:8000',
-  region: 'local',
-  credentials: {
-    accessKeyId: 'fakeMyKeyId',
-    secretAccessKey: 'fakeSecretAccessKey',
-  },
-};
+import { DYNAMO_CONFIG } from './shared';
 
 const SWITCH: SynthSwitchQueryParams = {
   tokenIn: 'USDC',
@@ -33,7 +25,7 @@ const NONEXISTENT_SWITCH: SynthSwitchQueryParams = {
   type: 'EXACT_OUTPUT',
 };
 
-const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient(dynamoConfig), {
+const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient(DYNAMO_CONFIG), {
   marshallOptions: {
     convertEmptyValues: true,
   },
@@ -62,7 +54,7 @@ describe('put switch tests', () => {
 
     const enabled = await switchRepository.syntheticQuoteForTradeEnabled(SWITCH);
     expect(enabled).toBe(false);
-  })
+  });
 
   it('should return false for non-existent switch', async () => {
     await expect(switchRepository.syntheticQuoteForTradeEnabled(NONEXISTENT_SWITCH)).resolves.toBe(false);
@@ -72,12 +64,12 @@ describe('put switch tests', () => {
 describe('static helper function tests', () => {
   it('correctly serializes key from trade', () => {
     expect(SwitchRepository.getKey(SWITCH)).toBe('usdc#1#uni#1#EXACT_INPUT');
-  })
+  });
 
   it('should throw error for invalid key on parse', () => {
     expect(() => {
       // missing type
       SwitchRepository.parseKey('token0#1#token1#1');
     }).toThrowError('Invalid key: token0#1#token1#1');
-  })
-})
+  });
+});

--- a/test/repositories/timestamp-repository.test.ts
+++ b/test/repositories/timestamp-repository.test.ts
@@ -17,15 +17,26 @@ const repo = TimestampRepository.create(documentClient);
 
 describe('Dynamo TimestampRepo tests', () => {
   it('should batch put timestamps', async () => {
-    const toUpdate: [string, number][] = [
+    const toUpdate: [string, number, number?][] = [
       ['0x1', 1],
-      ['0x2', 2],
-      ['0x3', 3],
+      ['0x2', 2, 5],
+      ['0x3', 3, 6],
     ];
-    await expect(repo.updateTimestampsBatch(toUpdate, 4)).resolves.not.toThrow();
-    const row = await repo.getFillerTimestamps('0x1');
+    await expect(repo.updateTimestampsBatch(toUpdate)).resolves.not.toThrow();
+    let row = await repo.getFillerTimestamps('0x1');
     expect(row).toBeDefined();
     expect(row?.lastPostTimestamp).toBe(1);
+    expect(row?.blockUntilTimestamp).toBe(NaN);
+
+    row = await repo.getFillerTimestamps('0x2');
+    expect(row).toBeDefined();
+    expect(row?.lastPostTimestamp).toBe(2);
+    expect(row?.blockUntilTimestamp).toBe(5);
+
+    row = await repo.getFillerTimestamps('0x3');
+    expect(row).toBeDefined();
+    expect(row?.lastPostTimestamp).toBe(3);
+    expect(row?.blockUntilTimestamp).toBe(6);
   });
 
   it('should batch get timestamps', async () => {
@@ -36,17 +47,17 @@ describe('Dynamo TimestampRepo tests', () => {
         {
           hash: '0x1',
           lastPostTimestamp: 1,
-          blockUntilTimestamp: 4,
+          blockUntilTimestamp: NaN,
         },
         {
           hash: '0x2',
           lastPostTimestamp: 2,
-          blockUntilTimestamp: 4,
+          blockUntilTimestamp: 5,
         },
         {
           hash: '0x3',
           lastPostTimestamp: 3,
-          blockUntilTimestamp: 4,
+          blockUntilTimestamp: 6,
         },
       ])
     );

--- a/test/repositories/timestamp-repository.test.ts
+++ b/test/repositories/timestamp-repository.test.ts
@@ -1,0 +1,54 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+import { TimestampRepository } from '../../lib/repositories/timestamp-repository';
+import { DYNAMO_CONFIG } from './shared';
+
+const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient(DYNAMO_CONFIG), {
+  marshallOptions: {
+    convertEmptyValues: true,
+  },
+  unmarshallOptions: {
+    wrapNumbers: true,
+  },
+});
+
+const repo = TimestampRepository.create(documentClient);
+
+describe('Dynamo TimestampRepo tests', () => {
+  it('should batch put timestamps', async () => {
+    const toUpdate: [string, number][] = [
+      ['0x1', 1],
+      ['0x2', 2],
+      ['0x3', 3],
+    ];
+    await expect(repo.updateTimestampsBatch(toUpdate, 4)).resolves.not.toThrow();
+    const row = await repo.getFillerTimestamps('0x1');
+    expect(row).toBeDefined();
+    expect(row?.lastPostTimestamp).toBe(1);
+  });
+
+  it('should batch get timestamps', async () => {
+    const res = await repo.getTimestampsBatch(['0x1', '0x2', '0x3']);
+    expect(res.length).toBe(3);
+    expect(res).toEqual(
+      expect.arrayContaining([
+        {
+          hash: '0x1',
+          lastPostTimestamp: 1,
+          blockUntilTimestamp: 4,
+        },
+        {
+          hash: '0x2',
+          lastPostTimestamp: 2,
+          blockUntilTimestamp: 4,
+        },
+        {
+          hash: '0x3',
+          lastPostTimestamp: 3,
+          blockUntilTimestamp: 4,
+        },
+      ])
+    );
+  });
+});


### PR DESCRIPTION
creates a `Timestamp` Dynamo table that tracks filler hash, lastCheckedPostTimestamp (last time the row is updated), and the timestamp that each filler should be blocked until.

The fade-rate cron job now calculates related timestamps based on recent order data from Redshift and `Timestamp` table

![cb](https://github.com/Uniswap/uniswapx-parameterization-api/assets/11896690/11725f7f-8eea-43a9-957d-1f9cbcaebe80)
