### PR TITLE
chore: no external lambda dep

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -234,6 +234,7 @@ export class APIStack extends cdk.Stack {
       bundling: {
         minify: true,
         sourceMap: true,
+        externalModules: [],
       },
       environment: {
         VERSION: '2',


### PR DESCRIPTION
attempt to reduce lambda cold start time, see  https://github.com/aws/aws-cdk/issues/25492