### PR TITLE
Revert "chore: no external lambda dep"

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -234,7 +234,6 @@ export class APIStack extends cdk.Stack {
       bundling: {
         minify: true,
         sourceMap: true,
-        externalModules: [],
       },
       environment: {
         VERSION: '2',


### PR DESCRIPTION
Reverts Uniswap/uniswapx-parameterization-api#249