### PR TITLE
feat: add KMS stack

### DIFF
--- a/bin/stacks/kms-stack.ts
+++ b/bin/stacks/kms-stack.ts
@@ -1,0 +1,28 @@
+import * as cdk from 'aws-cdk-lib';
+import { CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
+import { KeySpec, KeyUsage } from 'aws-cdk-lib/aws-kms';
+import { Construct } from 'constructs';
+
+export class KmsStack extends cdk.NestedStack {
+  public readonly key: cdk.aws_kms.Key;
+
+  constructor(parent: Construct, name: string) {
+    super(parent, name);
+
+    /**
+     * Unless absolutely necessary, DO NOT change this construct.
+     * This uses the 'Retain' DeletionPolicy, which will cause the resource to be retained
+     * in the account, but orphaned from the stack if the Key construct is ever changed.
+     */
+    this.key = new cdk.aws_kms.Key(this, name, {
+      removalPolicy: RemovalPolicy.RETAIN,
+      keySpec: KeySpec.ECC_SECG_P256K1,
+      keyUsage: KeyUsage.SIGN_VERIFY,
+      alias: name,
+    });
+
+    new CfnOutput(this, `${name}KeyId`, {
+      value: this.key.keyId,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds KMS stack to generate the co-signer key

## TODO
- Once we know where we want to use this key we will pass the keyId into the lambda env
- Add the signer package dependency and then we can pass the KEY_ID to the KmsSigner class
- Then boom we have a secure signer in this service

### See example in [this repo](https://github.com/Uniswap/fee-collector)
- KMS Key ID passing - [link](https://github.com/Uniswap/fee-collector/blob/49c955983d6c737f21849214a9bc5557f473cfb6/bin/stacks/cron-stack.ts#L77)
- Using the KmsSigner from signer pkg - [link](https://github.com/Uniswap/fee-collector/pull/57/files#diff-4a07f99c79219b3a7f3f6018073077040f69a1d203cf376b80b802dd2f5c4258R43)