### PR TITLE
Feat: Adjust concurrencies

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -131,7 +131,7 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '830217277613', region: 'us-east-2' },
-      provisionedConcurrency: 150,
+      provisionedConcurrency: 70,
       internalApiKey: internalApiKey.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       envVars: {

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -274,7 +274,7 @@ export class APIStack extends cdk.Stack {
     const switchLambdaAlias = new aws_lambda.Alias(this, `SwitchLiveAlias`, {
       aliasName: 'live',
       version: switchLambda.currentVersion,
-      provisionedConcurrentExecutions: provisionedConcurrency > 0 ? provisionedConcurrency : undefined,
+      provisionedConcurrentExecutions: 0,
     });
 
     const mockQuoteLambda = new aws_lambda_nodejs.NodejsFunction(this, 'mockQuote', {
@@ -326,7 +326,7 @@ export class APIStack extends cdk.Stack {
     const rfqLambdaAlias = new aws_lambda.Alias(this, `RfqLiveAlias`, {
       aliasName: 'live',
       version: integrationRfqLambda.currentVersion,
-      provisionedConcurrentExecutions: provisionedConcurrency > 0 ? provisionedConcurrency : undefined,
+      provisionedConcurrentExecutions: 0,
     });
 
     if (provisionedConcurrency > 0) {
@@ -341,7 +341,7 @@ export class APIStack extends cdk.Stack {
       quoteTarget.node.addDependency(quoteLambdaAlias);
 
       quoteTarget.scaleToTrackMetric('QuoteProvConcTracking', {
-        targetValue: 0.8,
+        targetValue: 0.7,
         predefinedMetric: aws_asg.PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION,
       });
     }

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -332,7 +332,7 @@ export class APIStack extends cdk.Stack {
     if (provisionedConcurrency > 0) {
       const quoteTarget = new aws_asg.ScalableTarget(this, 'QuoteProvConcASG', {
         serviceNamespace: aws_asg.ServiceNamespace.LAMBDA,
-        maxCapacity: provisionedConcurrency * 5,
+        maxCapacity: provisionedConcurrency * 10,
         minCapacity: provisionedConcurrency,
         resourceId: `function:${quoteLambdaAlias.lambda.functionName}:${quoteLambdaAlias.aliasName}`,
         scalableDimension: 'lambda:function:ProvisionedConcurrency',


### PR DESCRIPTION
Context: https://www.notion.so/uniswaplabs/AWS-Lambda-Best-Practices-781917c67edf4dcb96d22e38a6e46411

Adjust provisioned concurrencies for two lambdas that are not currently in use. ([slack thread](https://uniswapteam.slack.com/archives/C064HPY2B5H/p1707141838049609?thread_ts=1707141121.652199&cid=C064HPY2B5H)) 

For quote lambda, make the autoscaler more sensitive and allow it to move between 70-700. In otther words, reduce the minimum provisioned concurrency and allow for more fluctuation. The past 3 days the concurrencies never exceeded 150.

<img width="511" alt="Screenshot 2024-02-05 at 16 16 12" src="https://github.com/Uniswap/uniswapx-parameterization-api/assets/128516174/257672da-ee61-4644-8158-a936a84fab21">

Link: https://us-east-2.console.aws.amazon.com/lambda/home?region=us-east-2#/functions/prod-us-east-2-GoudaParameterization-QuoteE2906A56-glqABjbF8MQv/aliases/live?tab=monitoring