### PR TITLE
[fix] fix firehose logger output by removing base64 encoding

### DIFF
--- a/lib/providers/analytics/firehose.ts
+++ b/lib/providers/analytics/firehose.ts
@@ -27,7 +27,7 @@ export class FirehoseLogger implements IAnalyticsLogger {
     const params = {
       DeliveryStreamName: this.streamName,
       Record: {
-        Data: Buffer.from(jsonString, 'base64'),
+        Data: Buffer.from(jsonString),
       },
     };
 

--- a/test/providers/analytics/firehose.test.ts
+++ b/test/providers/analytics/firehose.test.ts
@@ -45,7 +45,7 @@ describe('FirehoseLogger', () => {
     const input = {
       DeliveryStreamName: 'stream-name',
       Record: {
-        Data: Buffer.from(JSON.stringify(analyticsEvent) + '\n', 'base64'),
+        Data: Buffer.from(JSON.stringify(analyticsEvent) + '\n'),
       },
     };
 


### PR DESCRIPTION
Previously @ConjunctiveNormalForm put out a PR (https://github.com/Uniswap/uniswapx-parameterization-api/pull/253) to update the firehose client used to log quoter endpoint metrics to use aws v3 sdk. In doing so, he added encoding logic on the data being logged that resulted in it not being in plain text new-line JSON in the destination S3 buckets. Removing the `base64` the encoding parameter produces the right format.