### PR TITLE
fix: pass in envVars to all lambdas

### DIFF
--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -393,6 +393,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
+        ...props.envVars,
       },
     });
 
@@ -410,6 +411,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
+        ...props.envVars,
       },
     });
 
@@ -427,6 +429,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
+        ...props.envVars,
       },
     });
 
@@ -444,6 +447,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
+        ...props.envVars,
       },
     });
 


### PR DESCRIPTION
Some of the firehose log processor lambdas have been failing with the following error:
```
        "errorMessage": "ORDER_SERVICE_URL is not defined",
        "stack": [
            "Error: ORDER_SERVICE_URL is not defined",
            "    at checkDefined (/lib/preconditions/preconditions.ts:3:11)",
            "    at BA.buildContainerInjected (/lib/handlers/hard-quote/injector.ts:47:29)",
```
which is bizarre because
1) the hard-quote lambda does have `ORDER_SERVICE_URL` in its envVar (confirmed in aws console)
2) it should have nothing to do with the log processor lambdas

We attempt to fix them by passing in the envVars from the stack, which contains `ORDER_SERVICE_URL`, to all processor lambdas.