### PR TITLE
fix: add stage env to all lambdas

### DIFF
--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -39,6 +39,7 @@ export interface AnalyticsStackProps extends cdk.NestedStackProps {
   quoteLambda: aws_lambda_nodejs.NodejsFunction;
   envVars: Record<string, string>;
   analyticsStreamArn: string;
+  stage: string;
 }
 
 /**
@@ -57,7 +58,7 @@ export class AnalyticsStack extends cdk.NestedStack {
 
   constructor(scope: Construct, id: string, props: AnalyticsStackProps) {
     super(scope, id, props);
-    const { quoteLambda, analyticsStreamArn } = props;
+    const { quoteLambda, analyticsStreamArn, stage } = props;
 
     /* S3 Initialization */
     const rfqRequestBucket = new aws_s3.Bucket(this, 'RfqRequestBucket');
@@ -394,6 +395,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
         ...props.envVars,
+        stage,
       },
     });
 
@@ -412,6 +414,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
         ...props.envVars,
+        stage,
       },
     });
 
@@ -430,6 +433,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
         ...props.envVars,
+        stage,
       },
     });
 
@@ -448,6 +452,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
         ANALYTICS_STREAM_ARN: analyticsStreamArn,
         ...props.envVars,
+        stage,
       },
     });
 

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -445,6 +445,7 @@ export class APIStack extends cdk.Stack {
       quoteLambda,
       envVars: props.envVars,
       analyticsStreamArn: firehoseStack.analyticsStreamArn,
+      stage,
     });
 
     const cronStack = new CronStack(this, 'CronStack', {


### PR DESCRIPTION
#277  fixed most of the firehose log processor lambda executions, but there are still a very small chance of getting the following error message:

```
"reason": {
        "errorType": "NoSuchBucket",
        "errorMessage": "The specified bucket does not exist",
},
"Code": "NoSuchBucket",
"BucketName": "rfq-config-undefined-1",
```

again, very confusing because the log processors have nothing to do with rfq-config, but at least we know fix like #277 works 🤷 
