### PR TITLE
feat: separate hard quote exports

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -267,7 +267,7 @@ export class APIStack extends cdk.Stack {
     const hardQuoteLambda = new aws_lambda_nodejs.NodejsFunction(this, 'HardQuote', {
       role: lambdaRole,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
+      entry: path.join(__dirname, '../../lib/handlers/hard-quote/exports.ts'),
       handler: 'hardQuoteHandler',
       vpc,
       vpcSubnets: {

--- a/lib/handlers/hard-quote/exports.ts
+++ b/lib/handlers/hard-quote/exports.ts
@@ -1,0 +1,9 @@
+import { QuoteHandler } from './handler';
+import { QuoteInjector } from './injector';
+
+const hardQuoteInjectorPromise = new QuoteInjector('hardQuoteInjector').build();
+const hardQuoteHandler = new QuoteHandler('hardQuoteHandler', hardQuoteInjectorPromise);
+
+module.exports = {
+  hardQuoteHandler: hardQuoteHandler.handler,
+};

--- a/lib/handlers/hard-quote/index.ts
+++ b/lib/handlers/hard-quote/index.ts
@@ -1,3 +1,3 @@
 export { QuoteHandler as HardQuoteHandler } from './handler';
-export { ContainerInjected, QuoteInjector as HardQuoteInjector, RequestInjected } from './injector';
+export { RequestInjected, ContainerInjected, QuoteInjector as HardQuoteInjector } from './injector';
 export * from './schema';

--- a/lib/handlers/index.ts
+++ b/lib/handlers/index.ts
@@ -4,16 +4,12 @@ import {
   postOrderProcessor,
   quoteProcessor,
 } from './blueprints/cw-log-firehose-processor';
-import { HardQuoteHandler, HardQuoteInjector } from './hard-quote';
 import { RfqHandler, RfqInjector } from './integration/rfq';
 import { MockQuoteInjector, QuoteHandler, QuoteInjector } from './quote';
 import { SwitchHandler, SwitchInjector } from './synth-switch';
 
 const quoteInjectorPromise = new QuoteInjector('quoteInjector').build();
 const quoteHandler = new QuoteHandler('quoteHandler', quoteInjectorPromise);
-
-const hardQuoteInjectorPromise = new HardQuoteInjector('hardQuoteInjector').build();
-const hardQuoteHandler = new HardQuoteHandler('hardQuoteHandler', hardQuoteInjectorPromise);
 
 const switchInjectorPromise = new SwitchInjector('switchInjector').build();
 const switchHandler = new SwitchHandler('SwitchHandler', switchInjectorPromise);
@@ -30,7 +26,6 @@ module.exports = {
   quoteProcessor: quoteProcessor,
   botOrderEventsProcessor: botOrderEventsProcessor,
   quoteHandler: quoteHandler.handler,
-  hardQuoteHandler: hardQuoteHandler.handler,
   mockQuoteHandler: mockQuoteHandler.handler,
   rfqHandler: rfqHandler.handler,
   switchHandler: switchHandler.handler,


### PR DESCRIPTION
previously hard quote injector was built in the same index exports file
as the indicative quote injector, causing even indicative quote setup to
require a KMS_KEY_ID environment variable. This commit separates the
export into a separate file to decouple the env pulling.

Future improvement should do this same separation for rest of the
lambdas as well instead of having a global handlers/index
