### PR TITLE
fix: decouple handler exports

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -10,9 +10,9 @@ import * as aws_lambda from 'aws-cdk-lib/aws-lambda';
 import * as aws_lambda_nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as aws_logs from 'aws-cdk-lib/aws-logs';
 import * as aws_waf from 'aws-cdk-lib/aws-wafv2';
-import { KmsStack } from './kms-stack'
 import { Construct } from 'constructs';
 import * as path from 'path';
+import { KmsStack } from './kms-stack';
 
 import { Metric } from '../../lib/entities';
 import { STAGE } from '../../lib/util/stage';
@@ -156,7 +156,7 @@ export class APIStack extends cdk.Stack {
     });
 
     // KMS initialization
-    const kmsStack = new KmsStack(this, `${SERVICE_NAME}HardQuoteCosignerKey-1`)
+    const kmsStack = new KmsStack(this, `${SERVICE_NAME}HardQuoteCosignerKey-1`);
 
     /*
      * Firehose Initialization
@@ -184,7 +184,7 @@ export class APIStack extends cdk.Stack {
         actions: ['kms:GetPublicKey', 'kms:Sign'],
         effect: aws_iam.Effect.ALLOW,
       })
-    )
+    );
 
     lambdaRole.addToPolicy(
       new aws_iam.PolicyStatement({
@@ -237,7 +237,7 @@ export class APIStack extends cdk.Stack {
     const quoteLambda = new aws_lambda_nodejs.NodejsFunction(this, 'Quote', {
       role: lambdaRole,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
+      entry: path.join(__dirname, '../../lib/handlers/quote/exports.ts'),
       handler: 'quoteHandler',
       vpc,
       vpcSubnets: {
@@ -299,7 +299,7 @@ export class APIStack extends cdk.Stack {
     const switchLambda = new aws_lambda_nodejs.NodejsFunction(this, 'Switch', {
       role: lambdaRole,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
+      entry: path.join(__dirname, '../../lib/handlers/synth-switch/exports.ts'),
       handler: 'switchHandler',
       memorySize: 512,
       bundling: {
@@ -325,7 +325,7 @@ export class APIStack extends cdk.Stack {
     const mockQuoteLambda = new aws_lambda_nodejs.NodejsFunction(this, 'mockQuote', {
       role: lambdaRole,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
+      entry: path.join(__dirname, '../../lib/handlers/quote/exports.ts'),
       handler: 'mockQuoteHandler',
       memorySize: 512,
       bundling: {
@@ -351,7 +351,7 @@ export class APIStack extends cdk.Stack {
     const integrationRfqLambda = new aws_lambda_nodejs.NodejsFunction(this, 'Rfq', {
       role: lambdaRole,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
+      entry: path.join(__dirname, '../../lib/handlers/integration/rfq/exports.ts'),
       handler: 'rfqHandler',
       memorySize: 512,
       bundling: {

--- a/lib/handlers/index.ts
+++ b/lib/handlers/index.ts
@@ -4,29 +4,10 @@ import {
   postOrderProcessor,
   quoteProcessor,
 } from './blueprints/cw-log-firehose-processor';
-import { RfqHandler, RfqInjector } from './integration/rfq';
-import { MockQuoteInjector, QuoteHandler, QuoteInjector } from './quote';
-import { SwitchHandler, SwitchInjector } from './synth-switch';
-
-const quoteInjectorPromise = new QuoteInjector('quoteInjector').build();
-const quoteHandler = new QuoteHandler('quoteHandler', quoteInjectorPromise);
-
-const switchInjectorPromise = new SwitchInjector('switchInjector').build();
-const switchHandler = new SwitchHandler('SwitchHandler', switchInjectorPromise);
-
-const mockQuoteInjectorPromise = new MockQuoteInjector('integrationQuoteInjector').build();
-const mockQuoteHandler = new QuoteHandler('mockQuoteHandler', mockQuoteInjectorPromise);
-
-const rfqInjectorPromise = new RfqInjector('rfqInjector').build();
-const rfqHandler = new RfqHandler('rfqHandler', rfqInjectorPromise);
 
 module.exports = {
   fillEventProcessor: fillEventProcessor,
   postOrderProcessor: postOrderProcessor,
   quoteProcessor: quoteProcessor,
   botOrderEventsProcessor: botOrderEventsProcessor,
-  quoteHandler: quoteHandler.handler,
-  mockQuoteHandler: mockQuoteHandler.handler,
-  rfqHandler: rfqHandler.handler,
-  switchHandler: switchHandler.handler,
 };

--- a/lib/handlers/integration/rfq/exports.ts
+++ b/lib/handlers/integration/rfq/exports.ts
@@ -1,0 +1,9 @@
+import { RfqHandler } from './handler';
+import { RfqInjector } from './injector';
+
+const rfqInjectorPromise = new RfqInjector('rfqInjector').build();
+const rfqHandler = new RfqHandler('rfqHandler', rfqInjectorPromise);
+
+module.exports = {
+  rfqHandler: rfqHandler.handler,
+};

--- a/lib/handlers/quote/exports.ts
+++ b/lib/handlers/quote/exports.ts
@@ -1,0 +1,13 @@
+import { QuoteHandler } from './handler';
+import { MockQuoteInjector, QuoteInjector } from './injector';
+
+const quoteInjectorPromise = new QuoteInjector('quoteInjector').build();
+const mockQuoteInjectorPromise = new MockQuoteInjector('integrationQuoteInjector').build();
+
+const quoteHandler = new QuoteHandler('quoteHandler', quoteInjectorPromise);
+const mockQuoteHandler = new QuoteHandler('mockQuoteHandler', mockQuoteInjectorPromise);
+
+module.exports = {
+  quoteHandler: quoteHandler.handler,
+  mockQuoteHandler: mockQuoteHandler.handler,
+};

--- a/lib/handlers/synth-switch/exports.ts
+++ b/lib/handlers/synth-switch/exports.ts
@@ -1,0 +1,9 @@
+import { SwitchHandler } from './handler';
+import { SwitchInjector } from './injector';
+
+const switchInjectorPromise = new SwitchInjector('switchInjector').build();
+const switchHandler = new SwitchHandler('SwitchHandler', switchInjectorPromise);
+
+module.exports = {
+  switchHandler: switchHandler.handler,
+};


### PR DESCRIPTION
Decouples lambda handlers by moving the exports to individual files, and completes #283 