### PR TITLE
feat: separate soft and hard quote alarms; fix broken alarms

### DIFF
--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -17,6 +17,14 @@ export const CircuitBreakerMetricDimension = {
   Service: 'CircuitBreaker',
 };
 
+export const SoftQuoteMetricDimension = {
+  Service: 'SoftQuote',
+};
+
+export const HardQuoteMetricDimension = {
+  Service: 'HardQuote',
+};
+
 export class AWSMetricsLogger implements IMetric {
   constructor(private awsMetricLogger: AWSEmbeddedMetricsLogger) {}
 
@@ -35,18 +43,12 @@ export enum Metric {
   QUOTE_404 = 'QUOTE_404',
   QUOTE_500 = 'QUOTE_500',
 
-  HARD_QUOTE_200 = 'HARD_QUOTE_200',
-  HARD_QUOTE_400 = 'HARD_QUOTE_400',
-  HARD_QUOTE_404 = 'HARD_QUOTE_404',
-  HARD_QUOTE_500 = 'HARD_QUOTE_500',
-
   QUOTE_REQUESTED = 'QUOTE_REQUESTED',
   QUOTE_LATENCY = 'QUOTE_LATENCY',
   QUOTE_RESPONSE_COUNT = 'QUOTE_RESPONSE_COUNT',
 
-  HARD_QUOTE_REQUESTED = 'HARD_QUOTE_REQUESTED',
-  HARD_QUOTE_LATENCY = 'HARD_QUOTE_LATENCY',
-  HARD_QUOTE_RESPONSE_COUNT = 'HARD_QUOTE_RESPONSE_COUNT',
+  QUOTE_POST_ERROR = 'QUOTE_POST_ERROR',
+  QUOTE_POST_ATTEMPT = 'QUOTE_POST_ATTEMPT',
 
   RFQ_REQUESTED = 'RFQ_REQUESTED',
   RFQ_SUCCESS = 'RFQ_SUCCESS',

--- a/lib/handlers/hard-quote/injector.ts
+++ b/lib/handlers/hard-quote/injector.ts
@@ -12,7 +12,7 @@ import {
   PRODUCTION_S3_KEY,
   WEBHOOK_CONFIG_BUCKET,
 } from '../../constants';
-import { AWSMetricsLogger, UniswapXParamServiceMetricDimension } from '../../entities/aws-metrics-logger';
+import { AWSMetricsLogger, HardQuoteMetricDimension } from '../../entities/aws-metrics-logger';
 import { checkDefined } from '../../preconditions/preconditions';
 import { OrderServiceProvider, S3WebhookConfigurationProvider, UniswapXServiceProvider } from '../../providers';
 import { FirehoseLogger } from '../../providers/analytics';
@@ -111,7 +111,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     setGlobalLogger(log);
 
     metricsLogger.setNamespace('Uniswap');
-    metricsLogger.setDimensions(UniswapXParamServiceMetricDimension);
+    metricsLogger.setDimensions(HardQuoteMetricDimension);
     const metric = new AWSMetricsLogger(metricsLogger);
     setGlobalMetric(metric);
 

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -10,14 +10,14 @@ import {
   FADE_RATE_BUCKET,
   FADE_RATE_S3_KEY,
   INTEGRATION_S3_KEY,
-  PROD_COMPLIANCE_S3_KEY,
   PRODUCTION_S3_KEY,
+  PROD_COMPLIANCE_S3_KEY,
   WEBHOOK_CONFIG_BUCKET,
 } from '../../constants';
 import {
   AWSMetricsLogger,
+  SoftQuoteMetricDimension,
   UniswapXParamServiceIntegrationMetricDimension,
-  UniswapXParamServiceMetricDimension,
 } from '../../entities/aws-metrics-logger';
 import { S3WebhookConfigurationProvider } from '../../providers';
 import { FirehoseLogger } from '../../providers/analytics';
@@ -92,7 +92,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     setGlobalLogger(log);
 
     metricsLogger.setNamespace('Uniswap');
-    metricsLogger.setDimensions(UniswapXParamServiceMetricDimension);
+    metricsLogger.setDimensions(SoftQuoteMetricDimension);
     const metric = new AWSMetricsLogger(metricsLogger);
     setGlobalMetric(metric);
 


### PR DESCRIPTION
set up a series of alarms for both soft-quote and hard-quote endpoints.

also, the existing `rfqSuccess/NonQuote...` alarms are broken because they have the wrong dimension, so fixed those as well