### PR TITLE
chore: remove nonsense metrics

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -576,36 +576,12 @@ export class APIStack extends cdk.Stack {
           success: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
             metricName: `${Metric.RFQ_SUCCESS}`,
-            dimensionsMap: { Service: SERVICE_NAME },
+            dimensionsMap: dimension,
             unit: aws_cloudwatch.Unit.COUNT,
             statistic: 'sum',
           }),
         },
       });
-
-      const rfqOverallSuccessRateAlarmSev2 = new aws_cloudwatch.Alarm(
-        this,
-        `${dimension.Service}-SEV2-RFQ-SuccessRate`,
-        {
-          alarmName: `${dimension.Service}-SEV2-RFQ-SuccessRate`,
-          metric: rfqOverallSuccessMetric,
-          threshold: 80,
-          comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-          evaluationPeriods: 3,
-        }
-      );
-
-      const rfqOverallSuccessRateAlarmSev3 = new aws_cloudwatch.Alarm(
-        this,
-        `${dimension.Service}-SEV3-RFQ-SuccessRate`,
-        {
-          alarmName: `${dimension.Service}-SEV3-RFQ-SuccessRate`,
-          metric: rfqOverallSuccessMetric,
-          threshold: 90,
-          comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-          evaluationPeriods: 3,
-        }
-      );
 
       const rfqOverallNonQuoteMetric = new aws_cloudwatch.MathExpression({
         expression: '100*(nonQuote/invocations)',
@@ -634,7 +610,7 @@ export class APIStack extends cdk.Stack {
         {
           alarmName: `${dimension.Service}-SEV2-RFQ-NonQuoteRate`,
           metric: rfqOverallNonQuoteMetric,
-          threshold: 30,
+          threshold: 85,
           comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
           evaluationPeriods: 3,
         }
@@ -699,8 +675,6 @@ export class APIStack extends cdk.Stack {
       }
 
       if (chatBotTopic) {
-        rfqOverallSuccessRateAlarmSev2.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
-        rfqOverallSuccessRateAlarmSev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
         rfqOverallNonQuoteRateAlarmSev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
         quoteLatencyAlarmSev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
       }

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -562,27 +562,6 @@ export class APIStack extends cdk.Stack {
     /* custom metric alarms */
     // Alarm on calls to RFQ providers
     for (const dimension of [SoftQuoteMetricDimension, HardQuoteMetricDimension]) {
-      const rfqOverallSuccessMetric = new aws_cloudwatch.MathExpression({
-        expression: '100*(success/invocations)',
-        period: Duration.minutes(5),
-        usingMetrics: {
-          invocations: new aws_cloudwatch.Metric({
-            namespace: 'Uniswap',
-            metricName: `${Metric.RFQ_REQUESTED}`,
-            dimensionsMap: dimension,
-            unit: aws_cloudwatch.Unit.COUNT,
-            statistic: 'sum',
-          }),
-          success: new aws_cloudwatch.Metric({
-            namespace: 'Uniswap',
-            metricName: `${Metric.RFQ_SUCCESS}`,
-            dimensionsMap: dimension,
-            unit: aws_cloudwatch.Unit.COUNT,
-            statistic: 'sum',
-          }),
-        },
-      });
-
       const rfqOverallNonQuoteMetric = new aws_cloudwatch.MathExpression({
         expression: '100*(nonQuote/invocations)',
         period: Duration.minutes(5),


### PR DESCRIPTION
So the `rfqOverallSuccessRate` doesn't really make sense because in most cases we get 0 quote back, and `NonQuoteRate` alarm should cover the extreme case when our fillers all become offline.