### PR TITLE
feat: Use dynamic filler address mapping in fade-rate-v2 cron

### DIFF
--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -10,6 +10,7 @@ import { CircuitBreakerMetricDimension } from '../entities';
 import { checkDefined } from '../preconditions/preconditions';
 import { S3WebhookConfigurationProvider } from '../providers';
 import { SharedConfigs, TimestampRepoRow, V2FadesRepository, V2FadesRowType } from '../repositories';
+import { DynamoFillerAddressRepository } from '../repositories/filler-address-repository';
 import { TimestampRepository } from '../repositories/timestamp-repository';
 import { STAGE } from '../util/stage';
 
@@ -17,6 +18,26 @@ export type FillerFades = Record<string, number>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
 
 export const BLOCK_PER_FADE_SECS = 60 * 5; // 5 minutes
+
+const log = Logger.createLogger({
+  name: 'FadeRate',
+  serializers: Logger.stdSerializers,
+});
+
+/* set up aws clients */
+const stage = process.env['stage'];
+const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
+const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
+const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+  marshallOptions: {
+    convertEmptyValues: true,
+  },
+  unmarshallOptions: {
+    wrapNumbers: true,
+  },
+});
+const fillerAddressRepo = DynamoFillerAddressRepository.create(documentClient);
+const timestampDB = TimestampRepository.create(documentClient);
 
 export const handler: ScheduledHandler = metricScope((metrics) => async (_event: EventBridgeEvent<string, void>) => {
   await main(metrics);
@@ -26,24 +47,6 @@ async function main(metrics: MetricsLogger) {
   metrics.setNamespace('Uniswap');
   metrics.setDimensions(CircuitBreakerMetricDimension);
 
-  const log = Logger.createLogger({
-    name: 'FadeRate',
-    serializers: Logger.stdSerializers,
-  });
-  const stage = process.env['stage'];
-  const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
-  const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
-  await webhookProvider.fetchEndpoints();
-  const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
-    marshallOptions: {
-      convertEmptyValues: true,
-    },
-    unmarshallOptions: {
-      wrapNumbers: true,
-    },
-  });
-  const timestampDB = TimestampRepository.create(documentClient);
-
   const sharedConfig: SharedConfigs = {
     Database: checkDefined(process.env.REDSHIFT_DATABASE),
     ClusterIdentifier: checkDefined(process.env.REDSHIFT_CLUSTER_IDENTIFIER),
@@ -51,6 +54,7 @@ async function main(metrics: MetricsLogger) {
   };
   const fadesRepository = V2FadesRepository.create(sharedConfig);
   await fadesRepository.createFadesView();
+  await webhookProvider.fetchEndpoints();
   /*
    query redshift for recent orders
         | fillerAddress |    faded  |   postTimestamp |
@@ -62,14 +66,14 @@ async function main(metrics: MetricsLogger) {
 
   if (result) {
     const fillerHashes = webhookProvider.fillers();
+    const addressToFillerMap = await fillerAddressRepo.getAddressToFillerMap(fillerHashes);
     const fillerTimestamps = await timestampDB.getFillerTimestampsMap(fillerHashes);
-    const addressToFillerHash = await webhookProvider.addressToFillerHash();
 
     // get fillers new fades from last checked timestamp:
     //  | hash    |     faded  |   postTimestamp  |
     //  |---- foo ------|---- 3 ----|---- 12345678 ----|
     //  |---- bar ------|---- 1 ----|---- 12222222 ----|
-    const fillersNewFades = getFillersNewFades(result, addressToFillerHash, fillerTimestamps, log);
+    const fillersNewFades = getFillersNewFades(result, fillerTimestamps, addressToFillerMap);
 
     //  | hash        |lastPostTimestamp|blockUntilTimestamp|
     //  |---- foo ----|---- 1300000 ----|---- now + fades * block_per_fade ----|
@@ -83,6 +87,39 @@ async function main(metrics: MetricsLogger) {
     log.info({ updatedTimestamps }, 'filler for which to update timestamp');
     await timestampDB.updateTimestampsBatch(updatedTimestamps);
   }
+}
+
+/* find the number of new fades, for each filler entity, from 
+   the last time this cron is run
+   @param rows: info about individual orders: filler address, faded or not, post timestamp
+   @param fillerTimestamps: last post timestamp and block until timestamp for each filler
+   @param addressToFillerMap: map of address to filler hash
+*/
+export function getFillersNewFades(
+  rows: V2FadesRowType[],
+  fillerTimestamps: FillerTimestamps,
+  addressToFillerMap: Map<string, string>,
+  log?: Logger
+): FillerFades {
+  const newFadesMap: FillerFades = {}; // filler hash -> # of new fades
+  rows.forEach((row) => {
+    const fillerAddr = row.fillerAddress.toLowerCase();
+    const fillerHash = addressToFillerMap.get(fillerAddr);
+    if (!fillerHash) {
+      log?.info({ fillerAddr }, 'filler address not found in webhook config');
+    } else if (
+      (fillerTimestamps.has(fillerHash) && row.postTimestamp > fillerTimestamps.get(fillerHash)!.lastPostTimestamp) ||
+      !fillerTimestamps.has(fillerHash)
+    ) {
+      if (!newFadesMap[fillerHash]) {
+        newFadesMap[fillerHash] = row.faded;
+      } else {
+        newFadesMap[fillerHash] += row.faded;
+      }
+    }
+  });
+  log?.info({ newFadesMap }, '# of new fades by filler');
+  return newFadesMap;
 }
 
 /* compute blockUntil timestamp for each filler
@@ -109,34 +146,4 @@ export function calculateNewTimestamps(
   });
   log?.info({ updatedTimestamps }, 'updated timestamps');
   return updatedTimestamps;
-}
-
-/* find the number of new fades, for each filler entity, from 
-   the last time this cron is run
-*/
-export function getFillersNewFades(
-  rows: V2FadesRowType[],
-  addressToFillerHash: Map<string, string>,
-  fillerTimestamps: FillerTimestamps,
-  log?: Logger
-): FillerFades {
-  const newFadesMap: FillerFades = {}; // filler hash -> # of new fades
-  rows.forEach((row) => {
-    const fillerAddr = row.fillerAddress.toLowerCase();
-    const fillerHash = addressToFillerHash.get(fillerAddr);
-    if (!fillerHash) {
-      log?.info({ fillerAddr }, 'filler address not found in webhook config');
-    } else if (
-      (fillerTimestamps.has(fillerHash) && row.postTimestamp > fillerTimestamps.get(fillerHash)!.lastPostTimestamp) ||
-      !fillerTimestamps.has(fillerHash)
-    ) {
-      if (!newFadesMap[fillerHash]) {
-        newFadesMap[fillerHash] = row.faded;
-      } else {
-        newFadesMap[fillerHash] += row.faded;
-      }
-    }
-  });
-  log?.info({ newFadesMap }, '# of new fades by filler');
-  return newFadesMap;
 }

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -99,8 +99,8 @@ export class V2FadesRepository extends BaseRedshiftRepository {
     const formattedResult = result.map((row) => {
       const formattedRow: V2FadesRowType = {
         fillerAddress: row[0].stringValue as string,
-        faded: Number(row[1].longValue as number),
-        postTimestamp: Number(row[2].longValue as number),
+        postTimestamp: Number(row[1].longValue as number),
+        faded: Number(row[2].longValue as number),
       };
       return formattedRow;
     });

--- a/lib/repositories/filler-address-repository.ts
+++ b/lib/repositories/filler-address-repository.ts
@@ -14,6 +14,7 @@ export interface FillerAddressRepository {
   getFillerByAddress(address: string): Promise<string | undefined>;
   addNewAddressToFiller(address: string, filler?: string): Promise<void>;
   getFillerAddressesBatch(fillers: string[]): Promise<Map<string, Set<string>>>;
+  getAddressToFillerMap(fillers: string[]): Promise<Map<string, string>>;
 }
 /*
  * Dynamo repository for managing filler addresses
@@ -105,6 +106,15 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
     });
     return resMap;
   }
+
+  async getAddressToFillerMap(fillers: string[]): Promise<Map<string, string>> {
+    const fillerAddresses = await this.getFillerAddressesBatch(fillers);
+    const addrToFillerMap = new Map<string, string>();
+    fillerAddresses.forEach((addresses, hash) => {
+      addresses.forEach((addr) => addrToFillerMap.set(addr, hash));
+    });
+    return addrToFillerMap;
+  }
 }
 
 export class MockFillerAddressRepository implements FillerAddressRepository {
@@ -150,5 +160,14 @@ export class MockFillerAddressRepository implements FillerAddressRepository {
       }
     }
     return res;
+  }
+
+  async getAddressToFillerMap(fillers: string[]): Promise<Map<string, string>> {
+    const fillerAddresses = await this.getFillerAddressesBatch(fillers);
+    const addrToFillerMap = new Map<string, string>();
+    fillerAddresses.forEach((addresses, hash) => {
+      addresses.forEach((addr) => addrToFillerMap.set(addr, hash));
+    });
+    return addrToFillerMap;
   }
 }

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -55,7 +55,7 @@ logger.level(Logger.FATAL);
 describe('FadeRateCron test', () => {
   let newFades: FillerFades;
   beforeAll(() => {
-    newFades = getFillersNewFades(FADES_ROWS, ADDRESS_TO_FILLER, FILLER_TIMESTAMPS, logger);
+    newFades = getFillersNewFades(FADES_ROWS, FILLER_TIMESTAMPS, ADDRESS_TO_FILLER, logger);
   });
 
   describe('getFillersNewFades', () => {

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -69,9 +69,9 @@ describe('filler address repository test', () => {
   it('should batch get filler to addresses map', async () => {
     const resMap = await repository.getFillerAddressesBatch(['filler1', 'filler2', 'filler3']);
     expect(resMap.size).toBe(3);
-    expect(resMap.get('filler1')).toEqual(['addr1', 'addr2']);
-    expect(resMap.get('filler2')).toEqual(['addr3']);
-    expect(resMap.get('filler3')).toEqual(['addr4', 'addr5']);
+    expect(resMap.get('filler1')).toEqual(new Set(['addr1', 'addr2']));
+    expect(resMap.get('filler2')).toEqual(new Set(['addr3']));
+    expect(resMap.get('filler3')).toEqual(new Set(['addr4', 'addr5']));
   });
 
   it("if address already exists, doesn't modify state", async () => {

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -66,6 +66,14 @@ describe('filler address repository test', () => {
     expect(filler5).toEqual('filler3');
   });
 
+  it('should batch get filler to addresses map', async () => {
+    const resMap = await repository.getFillerAddressesBatch(['filler1', 'filler2', 'filler3']);
+    expect(resMap.size).toBe(3);
+    expect(resMap.get('filler1')).toEqual(['addr1', 'addr2']);
+    expect(resMap.get('filler2')).toEqual(['addr3']);
+    expect(resMap.get('filler3')).toEqual(['addr4', 'addr5']);
+  });
+
   it("if address already exists, doesn't modify state", async () => {
     await repository.addNewAddressToFiller('addr1', 'filler1');
     const addresses = await repository.getFillerAddresses('filler1');


### PR DESCRIPTION
With #314 we started dynamically tracking addresses of each filler, but we've yet to use them. This PR replaces the static filler -> address config we store in S3 with the dynamic mapping we've been tracking in dynamoDB.