### PR TITLE
fix(filler-addr-repo): always checksum addresses during reads/writes

### DIFF
--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -69,7 +69,7 @@ async function main(metrics: MetricsLogger) {
     const fillerEndpoints = webhookProvider.fillerEndpoints();
     const addressToFillerMap = await fillerAddressRepo.getAddressToFillerMap(fillerEndpoints);
     log.info(
-      { map: addressToFillerMap.forEach((filler, addr) => [addr, filler]) },
+      { map: [...addressToFillerMap.entries()], size: addressToFillerMap.size },
       'address to filler map from dynamo'
     );
     const fillerTimestamps = await timestampDB.getFillerTimestampsMap(fillerEndpoints);

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -23,6 +23,15 @@ const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient(dynamoConf
 
 const repository = DynamoFillerAddressRepository.create(documentClient);
 
+const ADDR1 = '0x0000000000000000000000000000000000000001';
+const ADDR2 = '0x0000000000000000000000000000000000000002';
+const ADDR3 = '0x0000000000000000000000000000000000000003';
+const ADDR4 = '0x0000000000000000000000000000000000000004';
+const ADDR5 = '0x0000000000000000000000000000000000000005';
+
+const CHECKSUMED_ADDR = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
+const LOWER_CASE_ADDR = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
+
 describe('filler address repository test', () => {
   /*
    * filler1: [addr1, addr2]
@@ -31,64 +40,69 @@ describe('filler address repository test', () => {
    *
    */
   beforeAll(async () => {
-    await repository.addNewAddressToFiller('addr1', 'filler1');
-    await repository.addNewAddressToFiller('addr2', 'filler1');
-    await repository.addNewAddressToFiller('addr3', 'filler2');
-    await repository.addNewAddressToFiller('addr4', 'filler3');
-    await repository.addNewAddressToFiller('addr5', 'filler3');
+    await repository.addNewAddressToFiller(ADDR1, 'filler1');
+    await repository.addNewAddressToFiller(ADDR2, 'filler1');
+    await repository.addNewAddressToFiller(ADDR3, 'filler2');
+    await repository.addNewAddressToFiller(ADDR4, 'filler3');
+    await repository.addNewAddressToFiller(ADDR5, 'filler3');
+    await repository.addNewAddressToFiller(LOWER_CASE_ADDR, 'filler4');
   });
 
   it('should get filler addresses', async () => {
     const addresses = await repository.getFillerAddresses('filler1');
-    expect(addresses).toEqual(['addr1', 'addr2']);
+    expect(addresses).toEqual([ADDR1, ADDR2]);
 
     const addresses2 = await repository.getFillerAddresses('filler2');
-    expect(addresses2).toEqual(['addr3']);
+    expect(addresses2).toEqual([ADDR3]);
 
     const addresses3 = await repository.getFillerAddresses('filler3');
-    expect(addresses3).toEqual(['addr4', 'addr5']);
+    expect(addresses3).toEqual([ADDR4, ADDR5]);
   });
 
   it('should get filler by address', async () => {
-    const filler = await repository.getFillerByAddress('addr1');
+    const filler = await repository.getFillerByAddress(ADDR1);
     expect(filler).toEqual('filler1');
 
-    const filler2 = await repository.getFillerByAddress('addr2');
+    const filler2 = await repository.getFillerByAddress(ADDR2);
     expect(filler2).toEqual('filler1');
 
-    const filler3 = await repository.getFillerByAddress('addr3');
+    const filler3 = await repository.getFillerByAddress(ADDR3);
     expect(filler3).toEqual('filler2');
 
-    const filler4 = await repository.getFillerByAddress('addr4');
+    const filler4 = await repository.getFillerByAddress(ADDR4);
     expect(filler4).toEqual('filler3');
 
-    const filler5 = await repository.getFillerByAddress('addr5');
+    const filler5 = await repository.getFillerByAddress(ADDR5);
     expect(filler5).toEqual('filler3');
   });
 
   it('should batch get filler to addresses map', async () => {
     const resMap = await repository.getFillerAddressesBatch(['filler1', 'filler2', 'filler3']);
     expect(resMap.size).toBe(3);
-    expect(resMap.get('filler1')).toEqual(new Set(['addr1', 'addr2']));
-    expect(resMap.get('filler2')).toEqual(new Set(['addr3']));
-    expect(resMap.get('filler3')).toEqual(new Set(['addr4', 'addr5']));
+    expect(resMap.get('filler1')).toEqual(new Set([ADDR1, ADDR2]));
+    expect(resMap.get('filler2')).toEqual(new Set([ADDR3]));
+    expect(resMap.get('filler3')).toEqual(new Set([ADDR4, ADDR5]));
   });
 
   it('should get address to filler mapping', async () => {
     const res = await repository.getAddressToFillerMap(['filler1', 'filler2', 'filler3']);
     expect(res.size).toBe(5);
-    expect(res.get('addr1')).toEqual('filler1');
-    expect(res.get('addr2')).toEqual('filler1');
-    expect(res.get('addr3')).toEqual('filler2');
-    expect(res.get('addr4')).toEqual('filler3');
-    expect(res.get('addr5')).toEqual('filler3');
+    expect(res.get(ADDR1)).toEqual('filler1');
+    expect(res.get(ADDR2)).toEqual('filler1');
+    expect(res.get(ADDR3)).toEqual('filler2');
+    expect(res.get(ADDR4)).toEqual('filler3');
+    expect(res.get(ADDR5)).toEqual('filler3');
   });
 
   it("if address already exists, doesn't modify state", async () => {
-    await repository.addNewAddressToFiller('addr1', 'filler1');
+    await repository.addNewAddressToFiller(ADDR1, 'filler1');
     const addresses = await repository.getFillerAddresses('filler1');
-    expect(addresses).toEqual(['addr1', 'addr2']);
-    const filler = await repository.getFillerByAddress('addr1');
+    expect(addresses).toEqual([ADDR1, ADDR2]);
+    const filler = await repository.getFillerByAddress(ADDR1);
     expect(filler).toEqual('filler1');
+  });
+
+  it('should checksum address when adding to db', async () => {
+    expect(await repository.getFillerAddresses('filler4')).toEqual([CHECKSUMED_ADDR]);
   });
 });


### PR DESCRIPTION
most fillers return checksumed addresses but a few return all-lowercase ones, so we need to reconcile on the server side.