### PR TITLE
Decreasing auction duration to 10 sec

### DIFF
--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -221,6 +221,8 @@ function getDecayEndTime(chainId: number, startTime: number): number {
   switch (chainId) {
     case ChainId.MAINNET:
       return startTime + 60; // 5 blocks
+    case ChainId.ARBITRUM_ONE:
+      return startTime + 10; // 10 seconds
     default:
       return startTime + 30; // 30 seconds
   }


### PR DESCRIPTION
10-15 secs is too long on Arbitrum.. shorten the duration to see how that impacts fill time.