### PR TITLE
fix: increase read capacity of timestamps table

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -6,5 +6,5 @@ export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
   fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 20, writeCapacity: 100 },
   fadeRate: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 5 },
   synthSwitch: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 5 },
-  timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 50 },
+  timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 100, writeCapacity: 50 },
 };


### PR DESCRIPTION
now that soft quoting depends on this table too, we need higher read capacity
<img width="367" alt="Screenshot 2024-07-18 at 12 52 29 PM" src="https://github.com/user-attachments/assets/a58350c0-7581-44b3-8f9b-eef19aa02c7f">
