### PR TITLE
Recreate KMSClient on each request

### DIFF
--- a/lib/handlers/hard-quote/injector.ts
+++ b/lib/handlers/hard-quote/injector.ts
@@ -20,14 +20,9 @@ import { STAGE } from '../../util/stage';
 import { ApiInjector, ApiRInj } from '../base/api-handler';
 import { HardQuoteRequestBody } from './schema';
 
-interface Cosigner {
-  signDigest(digest: Buffer | string): Promise<string>;
-}
-
 export interface ContainerInjected {
   quoters: Quoter[];
   firehose: FirehoseLogger;
-  cosigner: Cosigner;
   cosignerAddress: string;
   orderServiceProvider: OrderServiceProvider;
 }
@@ -91,7 +86,6 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     return {
       quoters: quoters,
       firehose: firehose,
-      cosigner,
       cosignerAddress,
       orderServiceProvider,
     };


### PR DESCRIPTION
I believe that when the lambda initializes, the KMSClient can end up in a bad state due to a temporary clock skew. The issue is not resolved until the next cold start causes a re-initialization.

See [incident doc](https://www.notion.so/uniswaplabs/GPA-Clock-Skew-31f2dc891d2e4bf2a672ec5634cd8f41?pvs=4) for more details.