### PR TITLE
Fix alert thresholds

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -440,10 +440,10 @@ export class APIStack extends cdk.Stack {
       alarmName: 'UniswapXParameterizationAPI-SEV2-5XX',
       metric: api.metricServerError({
         period: Duration.minutes(5),
-        // For this metric 'avg' represents error rate.
-        statistic: 'avg',
+        // For this metric 'sum' represents error count.
+        statistic: 'sum',
       }),
-      threshold: 0.03,
+      threshold: 200,
       // Beta has much less traffic so is more susceptible to transient errors.
       evaluationPeriods: stage == STAGE.BETA ? 5 : 3,
     });
@@ -452,7 +452,7 @@ export class APIStack extends cdk.Stack {
       alarmName: 'UniswapXParameterizationAPI-SEV3-5XX',
       metric: api.metricServerError({
         period: Duration.minutes(5),
-        // For this metric 'avg' represents error rate.
+        // For this metric 'sum' represents error count.
         statistic: 'sum',
       }),
       threshold: 100,
@@ -464,9 +464,9 @@ export class APIStack extends cdk.Stack {
       alarmName: 'UniswapXParameterizationAPI-SEV3-4XX',
       metric: api.metricClientError({
         period: Duration.minutes(5),
-        statistic: 'sum',
+        statistic: 'avg',
       }),
-      threshold: 50,
+      threshold: 0.98,
       evaluationPeriods: 3,
     });
 


### PR DESCRIPTION
[I previously mistakenly adjusted the 4xx error alert instead of the 5xx one](https://github.com/Uniswap/uniswapx-parameterization-api/pull/356/files#diff-0ef77a1240d62d5b5e9e03d81d8698cd9d54ef6e1f268a1c31814400abec72e8R469). This reverts the 4xx alert and adjusts the `UniswapXParameterizationAPI-SEV2-5XX` instead.