### PR TITLE
fix: tweak dynamo tables' provisioned capacity

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -6,5 +6,5 @@ export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
   fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 200 },
   fadeRate: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 5 },
   synthSwitch: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 5 },
-  timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 100, writeCapacity: 50 },
+  timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 100, writeCapacity: 10 },
 };

--- a/bin/config.ts
+++ b/bin/config.ts
@@ -3,7 +3,7 @@ import { BillingMode } from 'aws-cdk-lib/aws-dynamodb';
 import { TableCapacityConfig } from './stacks/cron-stack';
 
 export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
-  fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 20, writeCapacity: 100 },
+  fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 200 },
   fadeRate: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 5 },
   synthSwitch: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 5 },
   timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 100, writeCapacity: 50 },


### PR DESCRIPTION
fillerAddress table been getting throttled because of overcapacity usage
<img width="468" alt="Screenshot 2024-07-29 at 2 08 22 PM" src="https://github.com/user-attachments/assets/909d51f0-4444-4ac3-a395-ba1f713f05a4">


on the other hand, read capacity usage of fillerCBTimestamps has been consistently under 1