### PR TITLE
Increase memory on lambdas to improve latency

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -251,7 +251,7 @@ export class APIStack extends cdk.Stack {
       vpcSubnets: {
         subnets: [...vpc.privateSubnets],
       },
-      memorySize: 1024,
+      memorySize: 2048,
       bundling: {
         minify: true,
         sourceMap: true,
@@ -281,7 +281,7 @@ export class APIStack extends cdk.Stack {
       vpcSubnets: {
         subnets: [...vpc.privateSubnets],
       },
-      memorySize: 1024,
+      memorySize: 2048,
       bundling: {
         minify: true,
         sourceMap: true,


### PR DESCRIPTION
We have suspicions that there is netowrk congestion because of too many webhook calls; running a test we saw an improvement in latency so we'd like to keep it that way!

![image](https://github.com/user-attachments/assets/bc746195-a74d-49d8-8d61-275307167153)
