### PR TITLE
fix: do not log axios timeout errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,7 @@
     "import/no-duplicates": "error",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/ban-types": "warn",
-    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/ban-ts-comment": "off"
   }
 }

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -322,8 +322,8 @@ export class WebhookQuoter implements Quoter {
         },
         axiosConfig
       )
-      .catch((e) => {
-        this.log.error({ endpoint: status.webhook.endpoint, error: e }, `Axios error notifying block`);
+      .catch((_e) => {
+        return;
       });
   }
 }


### PR DESCRIPTION
Takes too long (500ms+) to log the axios errors within `.catch` for some reason