### PR TITLE
fix: await axios call

### DIFF
--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -314,7 +314,7 @@ export class WebhookQuoter implements Quoter {
       timeout: NOTIFICATION_TIMEOUT_MS,
       ...(!!status.webhook.headers && { headers: status.webhook.headers }),
     };
-    axios
+    await axios
       .post(
         status.webhook.endpoint,
         {


### PR DESCRIPTION
Rationale: I believe the `notifyBlock()` promise is resolving immediately without the `await`. Even though the axios error is ultimately caught, it's done so outside the original context (the `notifyBlock` call has already returned), leading to the `UnhandledPromiseRejection`.