### PR TITLE
Increase order duration to 16s

### DIFF
--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -235,7 +235,7 @@ function getDecayEndTime(chainId: number, startTime: number): number {
     case ChainId.MAINNET:
       return startTime + 60; // 5 blocks
     case ChainId.ARBITRUM_ONE:
-      return startTime + 8; // 8 seconds
+      return startTime + 16; // 16 seconds
     default:
       return startTime + 30; // 30 seconds
   }


### PR DESCRIPTION
In statsig I'm doubling the slippage from 10 bps to 20 bps. To keep the same decay slope, I'm doubling the duration of the decay. The goal is to improve fill rate while keeping PI the same.