### PR TITLE
[TO-BE-REVERTED]: Temporarily remove lambda

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -134,26 +134,26 @@ export class APIPipeline extends Stack {
 
     this.addIntegTests(code, betaUsEast2Stage, betaUsEast2AppStage, STAGE.BETA);
 
-    // Prod us-east-2
-    const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
-      env: { account: '830217277613', region: 'us-east-2' },
-      provisionedConcurrency: 70,
-      internalApiKey: internalApiKey.secretValue.toString(),
-      chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
-      envVars: {
-        RFQ_WEBHOOK_CONFIG: rfqWebhookConfig.secretValue.toString(),
-        ORDER_SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_PROD').toString(),
-        FILL_LOG_SENDER_ACCOUNT: '316116520258',
-        ORDER_LOG_SENDER_ACCOUNT: '316116520258',
-        URA_ACCOUNT: '652077092967',
-        BOT_ACCOUNT: '456809954954',
-      },
-      stage: STAGE.PROD,
-    });
+    // // Prod us-east-2
+    // const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
+    //   env: { account: '830217277613', region: 'us-east-2' },
+    //   provisionedConcurrency: 70,
+    //   internalApiKey: internalApiKey.secretValue.toString(),
+    //   chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
+    //   envVars: {
+    //     RFQ_WEBHOOK_CONFIG: rfqWebhookConfig.secretValue.toString(),
+    //     ORDER_SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_PROD').toString(),
+    //     FILL_LOG_SENDER_ACCOUNT: '316116520258',
+    //     ORDER_LOG_SENDER_ACCOUNT: '316116520258',
+    //     URA_ACCOUNT: '652077092967',
+    //     BOT_ACCOUNT: '456809954954',
+    //   },
+    //   stage: STAGE.PROD,
+    // });
 
-    const prodUsEast2AppStage = pipeline.addStage(prodUsEast2Stage);
+    // const prodUsEast2AppStage = pipeline.addStage(prodUsEast2Stage);
 
-    this.addIntegTests(code, prodUsEast2Stage, prodUsEast2AppStage, STAGE.PROD);
+    // this.addIntegTests(code, prodUsEast2Stage, prodUsEast2AppStage, STAGE.PROD);
 
     pipeline.buildPipeline();
 

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
 import * as aws_apigateway from 'aws-cdk-lib/aws-apigateway';
 import { MethodLoggingLevel } from 'aws-cdk-lib/aws-apigateway';
-import * as aws_asg from 'aws-cdk-lib/aws-applicationautoscaling';
+//import * as aws_asg from 'aws-cdk-lib/aws-applicationautoscaling';
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as aws_dynamo from 'aws-cdk-lib/aws-dynamodb';
 import { CfnEIP, NatProvider, Vpc } from 'aws-cdk-lib/aws-ec2';

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -331,20 +331,20 @@ export class APIStack extends cdk.Stack {
     });
 
     if (provisionedConcurrency > 0) {
-      const quoteTarget = new aws_asg.ScalableTarget(this, 'QuoteProvConcASG', {
-        serviceNamespace: aws_asg.ServiceNamespace.LAMBDA,
-        maxCapacity: provisionedConcurrency * 10,
-        minCapacity: provisionedConcurrency,
-        resourceId: `function:${quoteLambdaAlias.lambda.functionName}:${quoteLambdaAlias.aliasName}`,
-        scalableDimension: 'lambda:function:ProvisionedConcurrency',
-      });
+      // const quoteTarget = new aws_asg.ScalableTarget(this, 'QuoteProvConcASG', {
+      //   serviceNamespace: aws_asg.ServiceNamespace.LAMBDA,
+      //   maxCapacity: provisionedConcurrency * 10,
+      //   minCapacity: provisionedConcurrency,
+      //   resourceId: `function:${quoteLambdaAlias.lambda.functionName}:${quoteLambdaAlias.aliasName}`,
+      //   scalableDimension: 'lambda:function:ProvisionedConcurrency',
+      // });
 
-      quoteTarget.node.addDependency(quoteLambdaAlias);
+      // quoteTarget.node.addDependency(quoteLambdaAlias);
 
-      quoteTarget.scaleToTrackMetric('QuoteProvConcTracking', {
-        targetValue: 0.7,
-        predefinedMetric: aws_asg.PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION,
-      });
+      // quoteTarget.scaleToTrackMetric('QuoteProvConcTracking', {
+      //   targetValue: 0.7,
+      //   predefinedMetric: aws_asg.PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION,
+      // });
     }
 
     /*


### PR DESCRIPTION
Beta environment is unable to deploy. This PR temporarily removes prod deployment from the pipeline (only Beta deployment) and removes the quote lambda.

`Stack:arn:aws:cloudformation:us-east-2:801328487475:stack/beta-us-east-2-GoudaParameterizationAPI/65c88a20-b2cb-11ed-94f4-024b19b40162 is in UPDATE_ROLLBACK_FAILED state and can not be updated.`