### PR TITLE
Fix S3 clock skew and tighten 5xx alerts

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -443,10 +443,10 @@ export class APIStack extends cdk.Stack {
       alarmName: 'UniswapXParameterizationAPI-SEV2-5XX',
       metric: api.metricServerError({
         period: Duration.minutes(5),
-        // For this metric 'avg' represents error rate.
-        statistic: 'avg',
+        // For this metric 'sum' represents error count.
+        statistic: 'sum',
       }),
-      threshold: 0.5,
+      threshold: 100,
       // Beta has much less traffic so is more susceptible to transient errors.
       evaluationPeriods: stage == STAGE.BETA ? 5 : 3,
     });
@@ -458,7 +458,7 @@ export class APIStack extends cdk.Stack {
         // For this metric 'sum' represents error count.
         statistic: 'sum',
       }),
-      threshold: 100,
+      threshold: 20,
       // Beta has much less traffic so is more susceptible to transient errors.
       evaluationPeriods: stage == STAGE.BETA ? 5 : 3,
     });

--- a/lib/handlers/hard-quote/injector.ts
+++ b/lib/handlers/hard-quote/injector.ts
@@ -42,11 +42,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     const orderServiceUrl = checkDefined(process.env.ORDER_SERVICE_URL, 'ORDER_SERVICE_URL is not defined');
 
     const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
-    await webhookProvider.fetchEndpoints();
-    const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(
-      log,
-      webhookProvider.fillerEndpoints()
-    );
+    const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(log, webhookProvider);
 
     const orderServiceProvider = new UniswapXServiceProvider(log, orderServiceUrl);
 

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -45,11 +45,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
 
     const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
-    await webhookProvider.fetchEndpoints();
-    const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(
-      log,
-      webhookProvider.fillerEndpoints()
-    );
+    const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(log, webhookProvider);
 
     const complianceKey = stage === STAGE.BETA ? BETA_COMPLIANCE_S3_KEY : PROD_COMPLIANCE_S3_KEY;
     const fillerComplianceProvider = new S3FillerComplianceConfigurationProvider(


### PR DESCRIPTION
- ClockSkew fix
  - Remove usage of S3 client from the injector
- Alerting updates
  - switched sev2 to use sum instead of avg and threshold of 100
  - tighten sev3 to threshold of 20