### PR TITLE
feat: bump SDK for new cosigner digest

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@uniswap/signer": "0.0.3-beta.4",
     "@uniswap/smart-order-router": "^3.3.0",
     "@uniswap/token-lists": "^1.0.0-beta.31",
-    "@uniswap/uniswapx-sdk": "2.1.0-beta.20",
+    "@uniswap/uniswapx-sdk": "2.1.0-beta.22",
     "@uniswap/v3-sdk": "^3.9.0",
     "aws-cdk-lib": "2.85.0",
     "aws-embedded-metrics": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,10 +5312,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz#966ba96c9ccc8f0e9e09809890b438203f2b1911"
   integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
 
-"@uniswap/uniswapx-sdk@2.1.0-beta.20":
-  version "2.1.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.1.0-beta.20.tgz#9cfa3a51821ffbf316eb50481b4980a94ea60065"
-  integrity sha512-T07Z3GV7JlWVeq7WSOqBYvS9KMGltmtfH6xvw0hTuRtqXloGA5Qd7ruNzG0IKSqWCr8x+YGuVTpy/xvbX7uMzQ==
+"@uniswap/uniswapx-sdk@2.1.0-beta.22":
+  version "2.1.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.1.0-beta.22.tgz#ddcdf036c66ddf49c97b916a08c2ddc4e68cb09b"
+  integrity sha512-g6a+/gGJnVjGgDhnKsC5NcyeHaPz0wK+Lzu1zCJiPUcvVcMskshlepBMwYTyGu2OEVeTOhkvw/1df4sjovRizw==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"


### PR DESCRIPTION
Recently updated the SDK cosigner digest to align with Dutch V3 contracts on replay protection. Needed for `cosignatureHash()` to work properly