### PR TITLE
Pull optional dynamic compliance list

### DIFF
--- a/lib/providers/compliance/index.ts
+++ b/lib/providers/compliance/index.ts
@@ -1,6 +1,10 @@
 export interface FillerComplianceConfiguration {
   endpoints: string[];
   addresses: string[];
+  complianceListUrl?: string;
+}
+export interface FillerComplianceList {
+  addresses: string[];
 }
 
 export interface FillerComplianceConfigurationProvider {


### PR DESCRIPTION
Adds a new property `complianceListUrl` to the `FillerComplianceConfiguration`:
```
interface FillerComplianceConfiguration {
  endpoints: string[];
  addresses: string[];
  complianceListUrl?: string;
}
```
Every 5 mins this endpoint is polled to get the latest version of the compliance list and added to the list in the static config.