### PR TITLE
bug(DutchV3): Fix bug in exact_out detection

### DIFF
--- a/lib/entities/HardQuoteRequest.ts
+++ b/lib/entities/HardQuoteRequest.ts
@@ -122,10 +122,9 @@ export class HardQuoteRequest {
         : TradeType.EXACT_OUTPUT
     } 
     else if (this.order instanceof UnsignedV3DutchOrder) {
-      const startAmount = this.order.info.input.startAmount;
-      // If curve doesn't exist OR startAmount equals minAmountOut, then it's EXACT_INPUT
+      // If curve doesn't exist OR has all relative amounts are zero, then it's EXACT_INPUT
       return !this.order.info.input.curve || 
-          startAmount.eq(V3DutchOrderBuilder.getMinAmountOut(startAmount, this.order.info.input.curve.relativeAmounts))
+          !this.order.info.input.curve.relativeAmounts.some(relativeAmount => relativeAmount !== BigInt(0))
         ? TradeType.EXACT_INPUT 
         : TradeType.EXACT_OUTPUT;
     }

--- a/lib/entities/HardQuoteRequest.ts
+++ b/lib/entities/HardQuoteRequest.ts
@@ -1,5 +1,5 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { OrderType, UnsignedV2DutchOrder, UnsignedV3DutchOrder, V3DutchOrderBuilder } from '@uniswap/uniswapx-sdk';
+import { OrderType, UnsignedV2DutchOrder, UnsignedV3DutchOrder } from '@uniswap/uniswapx-sdk';
 import { BigNumber, ethers, utils } from 'ethers';
 import { v4 as uuidv4 } from 'uuid';
 


### PR DESCRIPTION
For EXACT_OUT orders, the input relative amounts are negative. This means that `getMinAmountOut()` will return the start amount if you pass in the input. Instead, to detect EXACT_IN, I check that either the input curve is undefined or all the values are 0.