### PR TITLE
feat: create data tables from Unimind logs

### DIFF
--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -1202,7 +1202,8 @@ export class AnalyticsStack extends cdk.NestedStack {
       });
     }
 
-    if (props.envVars['UNIMIND_LOG_SENDER_ACCOUNT']) {
+    // Use ORDER_LOG_SENDER_ACCOUNT since uniswapx-service is in the same account as order-service
+    if (props.envVars['ORDER_LOG_SENDER_ACCOUNT']) {
       unimindResponseDestination.destinationPolicy = JSON.stringify({
         Version: '2012-10-17',
         Statement: [
@@ -1210,7 +1211,7 @@ export class AnalyticsStack extends cdk.NestedStack {
             Sid: '',
             Effect: 'Allow',
             Principal: {
-              AWS: props.envVars['UNIMIND_LOG_SENDER_ACCOUNT'],
+              AWS: props.envVars['ORDER_LOG_SENDER_ACCOUNT'],
             },
             Action: 'logs:PutSubscriptionFilter',
             Resource: '*',
@@ -1224,7 +1225,7 @@ export class AnalyticsStack extends cdk.NestedStack {
             Sid: '',
             Effect: 'Allow',
             Principal: {
-              AWS: props.envVars['UNIMIND_LOG_SENDER_ACCOUNT'],
+              AWS: props.envVars['ORDER_LOG_SENDER_ACCOUNT'],
             },
             Action: 'logs:PutSubscriptionFilter',
             Resource: '*',
@@ -1286,9 +1287,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     });
     new CfnOutput(this, 'BOT_ACCOUNT', {
       value: props.envVars['BOT_ACCOUNT'],
-    });
-    new CfnOutput(this, 'UNIMIND_LOG_SENDER_ACCOUNT', {
-      value: props.envVars['UNIMIND_LOG_SENDER_ACCOUNT'],
     });
   }
 }

--- a/lib/handlers/blueprints/cw-log-firehose-processor.js
+++ b/lib/handlers/blueprints/cw-log-firehose-processor.js
@@ -229,3 +229,5 @@ export const botOrderEventsProcessor = async (event, context) => handler(event, 
 export const quoteProcessor = async (event, context) => handler(event, context, transformLogEvent);
 export const fillEventProcessor = async (event, context) => handler(event, context, transformFillLogEvent);
 export const postOrderProcessor = async (event, context) => handler(event, context, transformPostOrderLogEvent);
+export const unimindResponseProcessor = async (event, context) => handler(event, context, transformLogEvent);
+export const unimindParameterUpdateProcessor = async (event, context) => handler(event, context, transformLogEvent);

--- a/lib/handlers/blueprints/transformations.js
+++ b/lib/handlers/blueprints/transformations.js
@@ -15,3 +15,5 @@ export function transformFillLogEvent(logEvent) {
 }
 
 export const transformPostOrderLogEvent = transformLogEvent;
+export const transformUnimindResponseLogEvent = transformLogEvent;
+export const transformUnimindParameterUpdateLogEvent = transformLogEvent;

--- a/lib/handlers/index.ts
+++ b/lib/handlers/index.ts
@@ -3,6 +3,8 @@ import {
   fillEventProcessor,
   postOrderProcessor,
   quoteProcessor,
+  unimindResponseProcessor,
+  unimindParameterUpdateProcessor,
 } from './blueprints/cw-log-firehose-processor';
 
 module.exports = {
@@ -10,4 +12,6 @@ module.exports = {
   postOrderProcessor: postOrderProcessor,
   quoteProcessor: quoteProcessor,
   botOrderEventsProcessor: botOrderEventsProcessor,
+  unimindResponseProcessor: unimindResponseProcessor,
+  unimindParameterUpdateProcessor: unimindParameterUpdateProcessor,
 };


### PR DESCRIPTION
Reads Unimind logs from order service to create S3 buckets and set up Redshift

After merging this PR, we need to get the destination ARNs and then use them to create a subscription filter in order service. These filters watch the Lambda logs and send matching events to the S3 buckets