### PR TITLE
fix: use dynamic funded wallet for forceOpenOrder integ test

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -225,6 +225,10 @@ export class APIPipeline extends Stack {
             value: cosignerSecret,
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
+          RPC_11155111: {
+            value: 'prod/param-api/rpc-urls:RPC_11155111',
+            type: BuildEnvironmentVariableType.SECRETS_MANAGER,
+          },
         },
       },
       rolePolicyStatements: [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc -w",
     "test": "run-s build test:*",
     "test:unit": "jest --detectOpenHandles --forceExit --testPathIgnorePatterns test/integ dist/",
-    "test:integ": "ts-mocha -p tsconfig.cdk.json -r dotenv/config test/integ/**/*.test.ts --timeout 50000",
+    "test:integ": "ts-mocha -p tsconfig.cdk.json -r dotenv/config test/integ/**/*.test.ts --timeout 120000",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"lib/**/*.ts\" --write",
     "fix:prettiertest": "prettier \"test/**/*.ts\" --write",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/chai-subset": "^1.3.3",
     "@types/jest": "^29.2.0",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^20.14.8",
     "@types/qs": "^6.9.7",
     "@types/uuid": "^9.0.0",

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -1,7 +1,3 @@
-// Mocha globals not in @types/jest
-declare function before(fn: () => Promise<void>): void;
-declare function after(fn: () => Promise<void>): void;
-
 import { V2DutchOrderBuilder } from '@uniswap/uniswapx-sdk';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -42,6 +42,11 @@ const TOKEN_OUT = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'; // WETH on Sepol
 const AMOUNT = BigNumber.from('1');
 
 const PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3';
+const ERC20_ABI = [
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function balanceOf(address owner) view returns (uint256)',
+];
 
 // Amount of USDC (6 decimals) and ETH to fund the dynamic wallet
 const USDC_FUND_AMOUNT = BigNumber.from(100); // 100 wei of USDC (order only needs 1)
@@ -72,20 +77,12 @@ describe('Hard Quote endpoint integration test', function () {
       value: ETH_FUND_AMOUNT,
     });
     await ethTx.wait(1);
-    const usdc = new ethers.Contract(TOKEN_IN, [
-    'function transfer(address to, uint256 amount) returns (bool)',
-    'function approve(address spender, uint256 amount) returns (bool)',
-    'function balanceOf(address owner) view returns (uint256)',
-  ], faucetSigner);
+    const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, faucetSigner);
     const usdcTx = await usdc.transfer(dynamicWallet.address, USDC_FUND_AMOUNT);
     await usdcTx.wait(1);
 
     // Approve USDC to Permit2 so the order service's onchain validation passes
-    const usdcDynamic = new ethers.Contract(TOKEN_IN, [
-    'function transfer(address to, uint256 amount) returns (bool)',
-    'function approve(address spender, uint256 amount) returns (bool)',
-    'function balanceOf(address owner) view returns (uint256)',
-  ], dynamicSwapper);
+    const usdcDynamic = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
     const approveTx = await usdcDynamic.approve(PERMIT2_ADDRESS, ethers.constants.MaxUint256);
     await approveTx.wait(1);
 
@@ -97,11 +94,7 @@ describe('Hard Quote endpoint integration test', function () {
     this.timeout(60000);
     try {
       // Return USDC balance to faucet
-      const usdc = new ethers.Contract(TOKEN_IN, [
-    'function transfer(address to, uint256 amount) returns (bool)',
-    'function approve(address spender, uint256 amount) returns (bool)',
-    'function balanceOf(address owner) view returns (uint256)',
-  ], dynamicSwapper);
+      const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
       const usdcBalance: BigNumber = await usdc.balanceOf(dynamicWallet.address);
       if (usdcBalance.gt(0)) {
         const usdcTx = await usdc.transfer(FAUCET_ADDRESS, usdcBalance);

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -38,13 +38,6 @@ const TOKEN_IN = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'; // USDC on Sepoli
 const TOKEN_OUT = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'; // WETH on Sepolia
 const AMOUNT = BigNumber.from('1');
 
-// Minimal ERC20 ABI for transfer, approve, and balanceOf
-const ERC20_ABI = [
-  'function transfer(address to, uint256 amount) returns (bool)',
-  'function approve(address spender, uint256 amount) returns (bool)',
-  'function balanceOf(address owner) view returns (uint256)',
-];
-
 const PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3';
 
 // Amount of USDC (6 decimals) and ETH to fund the dynamic wallet
@@ -74,12 +67,20 @@ describe('Hard Quote endpoint integration test', function () {
       to: dynamicWallet.address,
       value: ETH_FUND_AMOUNT,
     });
-    const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, faucetSigner);
+    const usdc = new ethers.Contract(TOKEN_IN, [
+    'function transfer(address to, uint256 amount) returns (bool)',
+    'function approve(address spender, uint256 amount) returns (bool)',
+    'function balanceOf(address owner) view returns (uint256)',
+  ], faucetSigner);
     const usdcTx = await usdc.transfer(dynamicWallet.address, USDC_FUND_AMOUNT);
     await Promise.all([ethTx.wait(1), usdcTx.wait(1)]);
 
     // Approve USDC to Permit2 so the order service's onchain validation passes
-    const usdcDynamic = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
+    const usdcDynamic = new ethers.Contract(TOKEN_IN, [
+    'function transfer(address to, uint256 amount) returns (bool)',
+    'function approve(address spender, uint256 amount) returns (bool)',
+    'function balanceOf(address owner) view returns (uint256)',
+  ], dynamicSwapper);
     const approveTx = await usdcDynamic.approve(PERMIT2_ADDRESS, ethers.constants.MaxUint256);
     await approveTx.wait(1);
 
@@ -91,7 +92,11 @@ describe('Hard Quote endpoint integration test', function () {
     this.timeout(60000);
     try {
       // Return USDC balance to faucet
-      const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
+      const usdc = new ethers.Contract(TOKEN_IN, [
+    'function transfer(address to, uint256 amount) returns (bool)',
+    'function approve(address spender, uint256 amount) returns (bool)',
+    'function balanceOf(address owner) view returns (uint256)',
+  ], dynamicSwapper);
       const usdcBalance: BigNumber = await usdc.balanceOf(dynamicWallet.address);
       if (usdcBalance.gt(0)) {
         const usdcTx = await usdc.transfer(FAUCET_ADDRESS, usdcBalance);

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -27,7 +27,10 @@ const UNISWAP_API = checkDefined(
 );
 
 const SEPOLIA = 11155111;
-const SEPOLIA_RPC = 'https://sepolia.infura.io/v3/84842078b09946638c03157f83405213';
+const SEPOLIA_RPC = checkDefined(
+  process.env.RPC_11155111,
+  'Must set RPC_11155111 env variable for integ tests. See README'
+);
 const PARAM_API = `${UNISWAP_API}hard-quote`;
 
 const REQUEST_ID = uuidv4();
@@ -62,18 +65,20 @@ describe('Hard Quote endpoint integration test', function () {
     console.log(`Dynamic test wallet: ${dynamicWallet.address}`);
     console.log(`Dynamic test wallet PK: ${dynamicWallet.privateKey}`);
 
-    // Fund the dynamic wallet with ETH and USDC from the faucet wallet
+    // Fund the dynamic wallet with ETH and USDC from the faucet wallet.
+    // Send sequentially to avoid nonce conflicts with public RPCs.
     const ethTx = await faucetSigner.sendTransaction({
       to: dynamicWallet.address,
       value: ETH_FUND_AMOUNT,
     });
+    await ethTx.wait(1);
     const usdc = new ethers.Contract(TOKEN_IN, [
     'function transfer(address to, uint256 amount) returns (bool)',
     'function approve(address spender, uint256 amount) returns (bool)',
     'function balanceOf(address owner) view returns (uint256)',
   ], faucetSigner);
     const usdcTx = await usdc.transfer(dynamicWallet.address, USDC_FUND_AMOUNT);
-    await Promise.all([ethTx.wait(1), usdcTx.wait(1)]);
+    await usdcTx.wait(1);
 
     // Approve USDC to Permit2 so the order service's onchain validation passes
     const usdcDynamic = new ethers.Contract(TOKEN_IN, [

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -27,19 +27,97 @@ const UNISWAP_API = checkDefined(
 );
 
 const SEPOLIA = 11155111;
+const SEPOLIA_RPC = 'https://sepolia.infura.io/v3/84842078b09946638c03157f83405213';
 const PARAM_API = `${UNISWAP_API}hard-quote`;
 
 const REQUEST_ID = uuidv4();
 const now = Math.floor(Date.now() / 1000);
-const swapper = new ethers.Wallet(INTEG_TEST_PK);
-const SWAPPER_ADDRESS = swapper.address;
+const faucetWallet = new ethers.Wallet(INTEG_TEST_PK);
+const FAUCET_ADDRESS = faucetWallet.address;
 const TOKEN_IN = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'; // USDC on Sepolia
 const TOKEN_OUT = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'; // WETH on Sepolia
 const AMOUNT = BigNumber.from('1');
 
+// Minimal ERC20 ABI for transfer, approve, and balanceOf
+const ERC20_ABI = [
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function balanceOf(address owner) view returns (uint256)',
+];
+
+const PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3';
+
+// Amount of USDC (6 decimals) and ETH to fund the dynamic wallet
+const USDC_FUND_AMOUNT = BigNumber.from(100); // 100 wei of USDC (order only needs 1)
+const ETH_FUND_AMOUNT = ethers.utils.parseEther('0.001'); // enough for gas
+
 let builder: V2DutchOrderBuilder;
+let provider: ethers.providers.JsonRpcProvider;
+let dynamicWallet: ethers.Wallet;
+let dynamicSwapper: ethers.Wallet;
+let faucetSigner: ethers.Wallet;
 
 describe('Hard Quote endpoint integration test', function () {
+  before(async function () {
+    this.timeout(120000);
+    provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC, SEPOLIA);
+    faucetSigner = faucetWallet.connect(provider);
+
+    // Generate a fresh wallet for tests that post orders to avoid TOO_MANY_OPEN_ORDERS
+    dynamicWallet = ethers.Wallet.createRandom();
+    dynamicSwapper = dynamicWallet.connect(provider);
+    console.log(`Dynamic test wallet: ${dynamicWallet.address}`);
+    console.log(`Dynamic test wallet PK: ${dynamicWallet.privateKey}`);
+
+    // Fund the dynamic wallet with ETH and USDC from the faucet wallet
+    const ethTx = await faucetSigner.sendTransaction({
+      to: dynamicWallet.address,
+      value: ETH_FUND_AMOUNT,
+    });
+    const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, faucetSigner);
+    const usdcTx = await usdc.transfer(dynamicWallet.address, USDC_FUND_AMOUNT);
+    await Promise.all([ethTx.wait(1), usdcTx.wait(1)]);
+
+    // Approve USDC to Permit2 so the order service's onchain validation passes
+    const usdcDynamic = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
+    const approveTx = await usdcDynamic.approve(PERMIT2_ADDRESS, ethers.constants.MaxUint256);
+    await approveTx.wait(1);
+
+    const balance = await usdcDynamic.balanceOf(dynamicWallet.address);
+    console.log(`Funded dynamic wallet (USDC balance: ${balance.toString()})`);
+  });
+
+  after(async function () {
+    this.timeout(60000);
+    try {
+      // Return USDC balance to faucet
+      const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
+      const usdcBalance: BigNumber = await usdc.balanceOf(dynamicWallet.address);
+      if (usdcBalance.gt(0)) {
+        const usdcTx = await usdc.transfer(FAUCET_ADDRESS, usdcBalance);
+        await usdcTx.wait();
+      }
+
+      // Return remaining ETH to faucet (minus gas for this tx)
+      const ethBalance = await provider.getBalance(dynamicWallet.address);
+      const gasPrice = await provider.getGasPrice();
+      const gasCost = gasPrice.mul(21000);
+      const refundAmount = ethBalance.sub(gasCost);
+      if (refundAmount.gt(0)) {
+        const ethTx = await dynamicSwapper.sendTransaction({
+          to: FAUCET_ADDRESS,
+          value: refundAmount,
+          gasLimit: 21000,
+          gasPrice,
+        });
+        await ethTx.wait();
+      }
+      console.log('Refunded faucet wallet');
+    } catch (e) {
+      console.error('Failed to refund faucet wallet:', e);
+    }
+  });
+
   beforeEach(() => {
     builder = new V2DutchOrderBuilder(SEPOLIA);
   });
@@ -48,11 +126,11 @@ describe('Hard Quote endpoint integration test', function () {
     it('missing signature', async () => {
       const v2Order = builder
         .input({ token: TOKEN_IN, startAmount: AMOUNT, endAmount: AMOUNT })
-        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: SWAPPER_ADDRESS })
+        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: FAUCET_ADDRESS })
         .nonce(BigNumber.from(100))
         .cosigner(ethers.constants.AddressZero)
         .deadline(now + 1000)
-        .swapper(SWAPPER_ADDRESS)
+        .swapper(FAUCET_ADDRESS)
         .buildPartial();
 
       const quoteReq = {
@@ -83,14 +161,14 @@ describe('Hard Quote endpoint integration test', function () {
     it('missing requestId', async () => {
       const v2Order = builder
         .input({ token: TOKEN_IN, startAmount: AMOUNT, endAmount: AMOUNT })
-        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: SWAPPER_ADDRESS })
+        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: FAUCET_ADDRESS })
         .nonce(BigNumber.from(100))
         .cosigner(ethers.constants.AddressZero)
         .deadline(now + 1000)
-        .swapper(SWAPPER_ADDRESS)
+        .swapper(FAUCET_ADDRESS)
         .buildPartial();
       const { domain, types, values } = v2Order.permitData();
-      const signature = await swapper._signTypedData(domain, types, values);
+      const signature = await faucetWallet._signTypedData(domain, types, values);
 
       const quoteReq = {
         encodedInnerOrder: v2Order.serialize(),
@@ -107,14 +185,14 @@ describe('Hard Quote endpoint integration test', function () {
     it('unknown cosigner', async () => {
       const v2Order = builder
         .input({ token: TOKEN_IN, startAmount: AMOUNT, endAmount: AMOUNT })
-        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: SWAPPER_ADDRESS })
+        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: FAUCET_ADDRESS })
         .nonce(BigNumber.from(100))
         .cosigner(ethers.constants.AddressZero)
         .deadline(now + 1000)
-        .swapper(SWAPPER_ADDRESS)
+        .swapper(FAUCET_ADDRESS)
         .buildPartial();
       const { domain, types, values } = v2Order.permitData();
-      const signature = await swapper._signTypedData(domain, types, values);
+      const signature = await faucetWallet._signTypedData(domain, types, values);
 
       const quoteReq: HardQuoteRequestBody = {
         requestId: REQUEST_ID,
@@ -134,15 +212,15 @@ describe('Hard Quote endpoint integration test', function () {
     it.skip('successfully posts to order service', async () => {
       const prebuildOrder = builder
         .input({ token: TOKEN_IN, startAmount: AMOUNT, endAmount: AMOUNT })
-        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: SWAPPER_ADDRESS })
+        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: FAUCET_ADDRESS })
         .nonce(BigNumber.from(100))
         .cosigner(COSIGNER_ADDR)
         .deadline(now + 1000)
-        .swapper(SWAPPER_ADDRESS);
+        .swapper(FAUCET_ADDRESS);
 
       const v2Order = prebuildOrder.buildPartial();
       const { domain, types, values } = v2Order.permitData();
-      const signature = await swapper._signTypedData(domain, types, values);
+      const signature = await faucetWallet._signTypedData(domain, types, values);
 
       const quoteReq: HardQuoteRequestBody = {
         requestId: REQUEST_ID,
@@ -163,15 +241,15 @@ describe('Hard Quote endpoint integration test', function () {
     it('successfully skips quotes with forceOpenOrder', async () => {
       const prebuildOrder = builder
         .input({ token: TOKEN_IN, startAmount: AMOUNT, endAmount: AMOUNT })
-        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: SWAPPER_ADDRESS })
+        .output({ token: TOKEN_OUT, startAmount: AMOUNT, endAmount: AMOUNT, recipient: dynamicWallet.address })
         .nonce(BigNumber.from(100))
         .cosigner(COSIGNER_ADDR)
-        .deadline(now + 60)
-        .swapper(SWAPPER_ADDRESS);
+        .deadline(now + 1000)
+        .swapper(dynamicWallet.address);
 
       const v2Order = prebuildOrder.buildPartial();
       const { domain, types, values } = v2Order.permitData();
-      const signature = await swapper._signTypedData(domain, types, values);
+      const signature = await dynamicWallet._signTypedData(domain, types, values);
 
       const quoteReq: HardQuoteRequestBody = {
         requestId: REQUEST_ID,
@@ -185,14 +263,6 @@ describe('Hard Quote endpoint integration test', function () {
 
       const { data, status } = await AxiosUtils.callPassThroughFail('POST', PARAM_API, quoteReq);
       console.log(data);
-      if (status === 400 && data.errorCode === 'TOO_MANY_OPEN_ORDERS') {
-        // Each run creates an open order that counts against the swapper's limit.
-        // We use a short deadline (60s) so orders expire quickly, but rapid
-        // consecutive runs (e.g. local testing) can still hit the cap before
-        // prior orders expire. This is an order service constraint, not a
-        // handler bug, so we treat it as a pass.
-        return;
-      }
       expect(status).to.be.oneOf([200, 201]);
       expect(data.chainId).to.equal(SEPOLIA);
       expect(data.orderHash).to.match(/0x[0-9a-fA-F]{64}/);

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -1,3 +1,7 @@
+// Mocha globals not in @types/jest
+declare function before(fn: () => Promise<void>): void;
+declare function after(fn: () => Promise<void>): void;
+
 import { V2DutchOrderBuilder } from '@uniswap/uniswapx-sdk';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -59,8 +63,7 @@ let dynamicSwapper: ethers.Wallet;
 let faucetSigner: ethers.Wallet;
 
 describe('Hard Quote endpoint integration test', function () {
-  before(async function () {
-    this.timeout(120000);
+  before(async () => {
     provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC, SEPOLIA);
     faucetSigner = faucetWallet.connect(provider);
 
@@ -90,8 +93,7 @@ describe('Hard Quote endpoint integration test', function () {
     console.log(`Funded dynamic wallet (USDC balance: ${balance.toString()})`);
   });
 
-  after(async function () {
-    this.timeout(60000);
+  after(async () => {
     try {
       // Return USDC balance to faucet
       const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3710,6 +3710,11 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/mocha@^10.0.10":
+  version "10.0.10"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.10.tgz#91f62905e8d23cbd66225312f239454a23bebfa0"
+  integrity sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==
+
 "@types/node@*":
   version "24.3.1"
   resolved "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz#b0a3fb2afed0ef98e8d7f06d46ef6349047709f3"


### PR DESCRIPTION
## Summary
- The faucet wallet (`INTEG_TEST_PK`) accumulated open orders on the beta order service from repeated test runs, permanently hitting `TOO_MANY_OPEN_ORDERS`
- Each test run now generates a fresh wallet, funds it with ETH + USDC from the faucet, approves USDC to Permit2, and runs the test against this clean wallet
- After tests complete (pass or fail), all funds are returned to the faucet wallet
- The dynamic wallet's private key is logged for manual fund recovery if the refund fails

## Test plan
- [x] Unit tests pass (145/145)
- [x] Integ tests pass locally (11/11) including forceOpenOrder
- [x] Funds successfully refunded to faucet after each run
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)