### PR TITLE
fix(deps): pin elliptic to 6.6.1 (GHSA-vjh7-7g9h-fjfh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,8 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "resolutions": {
+    "elliptic": "6.6.1"
   }
 }


### PR DESCRIPTION
## Summary

Pin transitive dependency `elliptic` to `6.6.1` to close [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh) (**CRITICAL**: *Elliptic's private key extraction in ECDSA upon signing a malformed input*).

`elliptic` lands here transitively via `@uniswap/uniswapx-sdk` → `ethers@5` → `@ethersproject/signing-key` → `elliptic`. This pin mirrors what's already in place on `Uniswap/universe`, `Uniswap/interface`, `Uniswap/backend`, and `Uniswap/uniswapx-service`.

## Threat model

The advisory's exploit path is: ECDSA signing of an attacker-influenced malformed input (a string instead of a Buffer) → private-key extraction → key reuse on a subsequent normal signing. The pin removes the underlying primitive's vulnerability regardless of input-shape discipline elsewhere in the codebase.

## What this does

One-line addition to root `package.json` forcing `elliptic` to resolve to `6.6.1` instead of the v5-pinned-vulnerable `6.5.x` shipped via `ethers@5`'s `@ethersproject/signing-key`.

## Lockfile

The lockfile is not updated in this PR — couldn't run a local install on the authoring machine. Cleanest merge path:

1. `git checkout fix/pin-elliptic-ghsa-vjh7-7g9h-fjfh`
2. Run your repo's install command (refreshes the lockfile to honor the pin)
3. Commit the updated lockfile
4. Merge

Verify with `yarn why elliptic` / `npm ls elliptic` / `bun pm ls elliptic` — should show `6.6.1`.

## Why `6.6.1` specifically

First patched version per the advisory. Exact pin (not `^6.6.1`) matches the Uniswap convention for security-driven pins.

## Related

Part of a fleet-wide pin rollout across all `@uniswap/uniswapx-sdk` consumers identified in a security review. Durable upstream fix is on the ethers side — either a v5 maintenance patch or migration to v6 (which drops the `elliptic` dependency). Tracked separately.
