### PR TITLE
feat: lower V3 exclusivity override to 0.25%

### DIFF
--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -35,7 +35,7 @@ import {
 } from './schema';
 
 const DEFAULT_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(100); // non-exclusive fillers must override price by this much (V2)
-const V3_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(25); // 0.25% — tighter than V2 to fit V3's short, block-paced decay window
+const V3_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(25);
 const RESPONSE_LOG_TYPE = 'HardResponse';
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,

--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -34,7 +34,8 @@ import {
   HardQuoteResponseDataJoi,
 } from './schema';
 
-const DEFAULT_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(100); // non-exclusive fillers must override price by this much
+const DEFAULT_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(100); // non-exclusive fillers must override price by this much (V2)
+const V3_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(25); // 0.25% — tighter than V2 to fit V3's short, block-paced decay window
 const RESPONSE_LOG_TYPE = 'HardResponse';
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,
@@ -267,7 +268,7 @@ export async function getCosignerData(
       const v3Data: V3CosignerData = {
         decayStartBlock,
         exclusiveFiller: filler,
-        exclusivityOverrideBps: DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
+        exclusivityOverrideBps: V3_EXCLUSIVITY_OVERRIDE_BPS,
         inputOverride,
         outputOverrides,
       };


### PR DESCRIPTION
## Summary

- Introduce a V3-specific `V3_EXCLUSIVITY_OVERRIDE_BPS = 25` (0.25%) constant in `lib/handlers/hard-quote/handler.ts` and use it for the V3 RFQ-cosigned data path.
- V2 keeps its existing `DEFAULT_EXCLUSIVITY_OVERRIDE_BPS = 100` (1%).

## Why

V3 Dutch orders decay block-by-block over a short window (8s at typical block times). The V2-style 1% override is too wide a moat for V3 — non-exclusive fillers can't profitably compete until the curve has already decayed substantially, leading to worse fills for swappers. 0.25% gives the exclusive filler a meaningful edge without effectively gating out the rest of the auction.

## Scope

Only the V3 RFQ-cosigned path (line ~270 in `handler.ts`) is affected. Untouched:
- V2 RFQ-cosigned path — still 100 bps
- V2 default cosigner — still 100 bps
- V3 default cosigner (no RFQ / open orders) — still 0 (no exclusivity)

## Test plan

- [ ] `yarn build` / `yarn test` pass locally
- [ ] Verify on staging that V3 cosigned orders carry `exclusivityOverrideBps: 25` in the signed cosigner data
- [ ] Confirm non-exclusive fillers can compete earlier in the decay curve on V3
- [ ] V2 orders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)