### PR TITLE
feat: send x-internal-service-secret header on all RPC requests

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -118,9 +118,12 @@ export class APIPipeline extends Stack {
     });
 
     // The Lambda's getRpcUrl reads RPC_PREFIX_URL at runtime and appends the
-    // chainId to form per-chain RPC URLs.
+    // chainId to form per-chain RPC URLs. RPC_HEADER_SECRET authenticates those
+    // outbound requests via the `x-internal-service-secret` header (see
+    // RPC_HEADERS in lib/constants.ts).
     const jsonRpcProviders = {
       RPC_PREFIX_URL: rpcUrls.secretValueFromJson('RPC_PREFIX_URL').toString(),
+      RPC_HEADER_SECRET: rpcUrls.secretValueFromJson('RPC_HEADER_SECRET').toString(),
     } as {[chainKey: string]: string};
 
     // Beta us-east-2
@@ -224,6 +227,10 @@ export class APIPipeline extends Stack {
             value: 'prod/param-api/rpc-urls:RPC_PREFIX_URL',
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
+          RPC_HEADER_SECRET: {
+            value: 'prod/param-api/rpc-urls:RPC_HEADER_SECRET',
+            type: BuildEnvironmentVariableType.SECRETS_MANAGER,
+          },
         },
       },
       rolePolicyStatements: [
@@ -269,9 +276,11 @@ envVars['URA_ACCOUNT'] = process.env['URA_ACCOUNT'] || '';
 envVars['BOT_ACCOUNT'] = process.env['BOT_ACCOUNT'] || '';
 envVars['UNISWAP_API'] = process.env['UNISWAP_API'] || '';
 envVars['ORDER_SERVICE_URL'] = process.env['ORDER_SERVICE_URL'] || '';
-// Local dev: Lambda runtime reads RPC_PREFIX_URL via getRpcUrl.
+// Local dev: Lambda runtime reads RPC_PREFIX_URL via getRpcUrl. RPC_HEADER_SECRET
+// is optional locally and omitted from RPC_HEADERS when unset.
 const jsonRpcProviders: {[chainKey: string]: string} = {
   RPC_PREFIX_URL: process.env['RPC_PREFIX_URL'] || '',
+  RPC_HEADER_SECRET: process.env['RPC_HEADER_SECRET'] || '',
 };
 
 new APIStack(app, `${SERVICE_NAME}Stack`, {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -61,6 +61,10 @@ export function getV3BlockBuffer(chainId: number): number {
   return secondsToBlocks(V3_DECAY_START_BUFFER_SECS, chainId);
 }
 
-export const RPC_HEADERS = {
+export const RPC_HEADERS: { [key: string]: string } = {
   'x-uni-service-id': 'x_parameterization_api',
-} as const
+  // Authenticate RPC requests against internal providers. The value is provided
+  // via the RPC_HEADER_SECRET env var (sourced from Secrets Manager); omitted
+  // when unset (e.g. local dev / unit tests).
+  ...(process.env.RPC_HEADER_SECRET ? { 'x-internal-service-secret': process.env.RPC_HEADER_SECRET } : {}),
+}

--- a/test/util/rpc-headers.test.ts
+++ b/test/util/rpc-headers.test.ts
@@ -1,0 +1,30 @@
+// RPC_HEADERS reads RPC_HEADER_SECRET at module load, so each case sets the env
+// and re-imports the module after resetting the module registry.
+describe('RPC_HEADERS', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    jest.resetModules();
+  });
+
+  const loadHeaders = async (): Promise<{ [key: string]: string }> => {
+    jest.resetModules();
+    return (await import('../../lib/constants')).RPC_HEADERS;
+  };
+
+  it('always sets the service id header', async () => {
+    delete process.env.RPC_HEADER_SECRET;
+    expect((await loadHeaders())['x-uni-service-id']).toEqual('x_parameterization_api');
+  });
+
+  it('adds the x-internal-service-secret header when RPC_HEADER_SECRET is set', async () => {
+    process.env.RPC_HEADER_SECRET = 'super-secret-value';
+    expect((await loadHeaders())['x-internal-service-secret']).toEqual('super-secret-value');
+  });
+
+  it('omits the x-internal-service-secret header when RPC_HEADER_SECRET is unset', async () => {
+    delete process.env.RPC_HEADER_SECRET;
+    expect(await loadHeaders()).not.toHaveProperty('x-internal-service-secret');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `x-internal-service-secret` authentication header to **all** outbound RPC requests, sourced from a new `RPC_HEADER_SECRET` env var. Ports [Uniswap/uniswapx-service#674](https://github.com/Uniswap/uniswapx-service/pull/674) to this repo.

## How it works

Both RPC providers in this service (the `quote` and `hard-quote` injectors) are constructed with the shared `RPC_HEADERS` object from `lib/constants.ts`. Adding the header there wires it into every RPC request through a single change:

```ts
export const RPC_HEADERS: { [key: string]: string } = {
  'x-uni-service-id': 'x_parameterization_api',
  ...(process.env.RPC_HEADER_SECRET ? { 'x-internal-service-secret': process.env.RPC_HEADER_SECRET } : {}),
}
```

The header is **omitted** when `RPC_HEADER_SECRET` is unset (local dev / unit tests), so behavior is unchanged where the secret isn't provided.

## CDK wiring (`bin/app.ts`)

`RPC_HEADER_SECRET` is read from the existing `prod/param-api/rpc-urls` secret (new JSON key, alongside `RPC_PREFIX_URL`) and passed as a Lambda env var to:
- **beta** and **prod** stages (via the `jsonRpcProviders` object)
- the **integ-test** CodeBuild (so e2e RPC calls carry the header)
- the **local dev** stack (from `process.env`)

## Tests

- New `test/util/rpc-headers.test.ts` verifies the header is present when the secret is set and absent when unset.

## Required before deploy

⚠️ Add the `RPC_HEADER_SECRET` JSON key to the `prod/param-api/rpc-urls` secret before deploying, or the `secretValueFromJson` lookups will fail.
✅  DONE

## Testing

- `yarn build` ✅
- `npx jest test/util/rpc-headers.test.ts` — 3 new tests pass ✅
- `eslint` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)