### PR TITLE
chore: bump lambda VERSION env var from 5 to 6

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -257,7 +257,7 @@ export class APIStack extends cdk.Stack {
         sourceMap: true,
       },
       environment: {
-        VERSION: '5',
+        VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',
         ...props.envVars,
         stage,
@@ -287,7 +287,7 @@ export class APIStack extends cdk.Stack {
         sourceMap: true,
       },
       environment: {
-        VERSION: '5',
+        VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',
         REGION: region,
         KMS_KEY_ID: kmsStack.key.keyId,
@@ -315,7 +315,7 @@ export class APIStack extends cdk.Stack {
         sourceMap: true,
       },
       environment: {
-        VERSION: '5',
+        VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',
         ...props.envVars,
         stage,


### PR DESCRIPTION
## Summary
Bumps the `VERSION` environment variable from `5` to `6` for all three Lambda functions in `bin/stacks/api-stack.ts`:
- `quoteLambda`
- `hardQuoteLambda`
- `switchLambda`

Following the existing convention of bumping all three versions together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)