### PR TITLE
fix(integ): send x-internal-service-secret header on hard-quote test RPC provider

### DIFF
--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -5,6 +5,7 @@ import chaiSubset from 'chai-subset';
 import { BigNumber, ethers } from 'ethers';
 import { v4 as uuidv4 } from 'uuid';
 
+import { RPC_HEADERS } from '../../lib/constants';
 import { HardQuoteRequestBody } from '../../lib/handlers/hard-quote';
 import { checkDefined } from '../../lib/preconditions/preconditions';
 import AxiosUtils from '../util/axios';
@@ -61,7 +62,11 @@ let faucetSigner: ethers.Wallet;
 
 describe('Hard Quote endpoint integration test', function () {
   before(async () => {
-    provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC, SEPOLIA);
+    // The RPC gateway requires the x-internal-service-secret header (see
+    // RPC_HEADERS in lib/constants.ts), so attach it the same way the Lambda
+    // injectors do. Without it the gateway rejects requests and ethers reports
+    // "could not detect network".
+    provider = new ethers.providers.JsonRpcProvider({ url: SEPOLIA_RPC, headers: RPC_HEADERS }, SEPOLIA);
     faucetSigner = faucetWallet.connect(provider);
 
     // Generate a fresh wallet for tests that post orders to avoid TOO_MANY_OPEN_ORDERS


### PR DESCRIPTION
## Summary

Fixes the staging integ-test failure introduced after #442:

```
Failed to refund faucet wallet: Error: could not detect network (event="noNetwork", code=NETWORK_ERROR)
```

## Root cause

The Lambda injectors construct their RPC providers with `RPC_HEADERS` (`StaticJsonRpcProvider({ url, headers: RPC_HEADERS }, chainId)`), which since #442 includes the `x-internal-service-secret` header. The hard-quote **integration test**, however, built its own provider without any headers:

```ts
provider = new ethers.providers.JsonRpcProvider(SEPOLIA_RPC, SEPOLIA);
```

The RPC gateway now rejects unauthenticated requests, so the test's `eth_chainId` call fails and ethers reports `could not detect network` — surfacing in the funding (`before`) and refund (`after`) hooks.

## Fix

Attach `RPC_HEADERS` to the test provider, matching the injector pattern:

```ts
provider = new ethers.providers.JsonRpcProvider({ url: SEPOLIA_RPC, headers: RPC_HEADERS }, SEPOLIA);
```

The integ-test CodeBuild already receives `RPC_HEADER_SECRET` (wired in #442), so the secret is present in `RPC_HEADERS` at module load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)