### PR TITLE
feat: add ProtocolVersion.V3 and derive protocol from order type in HardQuoteRequest

### DIFF
--- a/lib/entities/HardQuoteRequest.ts
+++ b/lib/entities/HardQuoteRequest.ts
@@ -41,7 +41,7 @@ export class HardQuoteRequest {
       type: TradeType[this.type],
       numOutputs: this.numOutputs,
       ...(this.quoteId && { quoteId: this.quoteId }),
-      protocol: ProtocolVersion.V2,
+      protocol: this.protocol,
     };
   }
 
@@ -135,6 +135,16 @@ export class HardQuoteRequest {
 
   public get numOutputs(): number {
     return this.order.info.outputs.length;
+  }
+
+  public get protocol(): ProtocolVersion {
+    if (this.order instanceof UnsignedV2DutchOrder) {
+      return ProtocolVersion.V2;
+    } else if (this.order instanceof UnsignedV3DutchOrder) {
+      return ProtocolVersion.V3;
+    } else {
+      throw new Error('Unsupported order type');
+    }
   }
 
   public get cosigner(): string {

--- a/lib/entities/HardQuoteRequest.ts
+++ b/lib/entities/HardQuoteRequest.ts
@@ -10,6 +10,7 @@ import { ProtocolVersion } from '../providers';
 export class HardQuoteRequest {
   public order: UnsignedV2DutchOrder | UnsignedV3DutchOrder;
   private data: HardQuoteRequestBody;
+  private readonly _protocol: ProtocolVersion;
 
   public static fromHardRequestBody(body: HardQuoteRequestBody, orderType: OrderType): HardQuoteRequest {
     return new HardQuoteRequest(body, orderType);
@@ -22,8 +23,10 @@ export class HardQuoteRequest {
     };
     if (orderType === OrderType.Dutch_V2) {
       this.order = UnsignedV2DutchOrder.parse(_data.encodedInnerOrder, _data.tokenInChainId);
+      this._protocol = ProtocolVersion.V2;
     } else if (orderType === OrderType.Dutch_V3) {
       this.order = UnsignedV3DutchOrder.parse(_data.encodedInnerOrder, _data.tokenInChainId);
+      this._protocol = ProtocolVersion.V3;
     } else {
       throw new Error('Unsupported order type');
     }
@@ -138,13 +141,7 @@ export class HardQuoteRequest {
   }
 
   public get protocol(): ProtocolVersion {
-    if (this.order instanceof UnsignedV2DutchOrder) {
-      return ProtocolVersion.V2;
-    } else if (this.order instanceof UnsignedV3DutchOrder) {
-      return ProtocolVersion.V3;
-    } else {
-      throw new Error('Unsupported order type');
-    }
+    return this._protocol;
   }
 
   public get cosigner(): string {

--- a/lib/providers/webhook/index.ts
+++ b/lib/providers/webhook/index.ts
@@ -8,6 +8,7 @@ type WebhookOverrides = {
 export enum ProtocolVersion {
   V1 = 'v1',
   V2 = 'v2',
+  V3 = 'v3',
 }
 
 export interface WebhookConfiguration {

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -370,7 +370,7 @@ function isNonQuote(request: QuoteRequest, hookResponse: AxiosResponse, parsedRe
 
 export function getEndpointSupportedProtocols(e: WebhookConfiguration) {
   if (!e.supportedVersions || e.supportedVersions.length == 0) {
-    return [ProtocolVersion.V2];
+    return [ProtocolVersion.V2, ProtocolVersion.V3];
   }
   return e.supportedVersions;
 }

--- a/test/entities/HardQuoteRequest.test.ts
+++ b/test/entities/HardQuoteRequest.test.ts
@@ -1,5 +1,11 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { OrderType, UnsignedV2DutchOrder, UnsignedV2DutchOrderInfo } from '@uniswap/uniswapx-sdk';
+import {
+  OrderType,
+  UnsignedV2DutchOrder,
+  UnsignedV2DutchOrderInfo,
+  UnsignedV3DutchOrder,
+  V3DutchOrderBuilder,
+} from '@uniswap/uniswapx-sdk';
 import { BigNumber, ethers } from 'ethers';
 
 import { HardQuoteRequest } from '../../lib/entities';
@@ -43,21 +49,59 @@ export const getOrderInfo = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV
   );
 };
 
-const makeRequest = (data: Partial<HardQuoteRequestBody>): HardQuoteRequest => {
+const makeRequest = (
+  data: Partial<HardQuoteRequestBody>,
+  orderType: OrderType = OrderType.Dutch_V2,
+  chainId: number = CHAIN_ID
+): HardQuoteRequest => {
   return new HardQuoteRequest(
     Object.assign(
       {
         requestId: REQUEST_ID,
         quoteId: QUOTE_ID,
-        tokenInChainId: CHAIN_ID,
-        tokenOutChainId: CHAIN_ID,
+        tokenInChainId: chainId,
+        tokenOutChainId: chainId,
         encodedInnerOrder: '0x',
         innerSig: '0x',
       },
       data
     ),
-    OrderType.Dutch_V2
+    orderType
   );
+};
+
+const V3_CHAIN_ID = 42161;
+
+const getV3Order = (swapper: string): UnsignedV3DutchOrder => {
+  const now = Math.floor(new Date().getTime() / 1000);
+  return new V3DutchOrderBuilder(V3_CHAIN_ID)
+    .cosigner(ethers.constants.AddressZero)
+    .deadline(now + 1000)
+    .swapper(swapper)
+    .nonce(BigNumber.from(100))
+    .startingBaseFee(BigNumber.from(0))
+    .input({
+      token: TOKEN_IN,
+      startAmount: RAW_AMOUNT,
+      curve: {
+        relativeBlocks: [],
+        relativeAmounts: [],
+      },
+      maxAmount: RAW_AMOUNT,
+      adjustmentPerGweiBaseFee: BigNumber.from(0),
+    })
+    .output({
+      token: TOKEN_OUT,
+      startAmount: RAW_AMOUNT,
+      curve: {
+        relativeBlocks: [4],
+        relativeAmounts: [BigInt(4)],
+      },
+      recipient: ethers.constants.AddressZero,
+      minAmount: RAW_AMOUNT.sub(4),
+      adjustmentPerGweiBaseFee: BigNumber.from(0),
+    })
+    .buildPartial();
 };
 
 describe('QuoteRequest', () => {
@@ -124,6 +168,71 @@ describe('QuoteRequest', () => {
       type: 'EXACT_OUTPUT',
       numOutputs: 1,
       protocol: ProtocolVersion.V2,
+    });
+  });
+
+  it('exposes protocol v2 for Dutch_V2 orders', () => {
+    const order = new UnsignedV2DutchOrder(
+      getOrderInfo({
+        swapper: SWAPPER,
+      }),
+      CHAIN_ID
+    );
+    const request = makeRequest({ encodedInnerOrder: order.serialize(), innerSig: '0x' });
+    expect(request.protocol).toEqual(ProtocolVersion.V2);
+  });
+
+  it('exposes protocol v3 for Dutch_V3 orders', () => {
+    const order = getV3Order(SWAPPER);
+    const request = makeRequest(
+      { encodedInnerOrder: order.serialize(), innerSig: '0x' },
+      OrderType.Dutch_V3,
+      V3_CHAIN_ID
+    );
+    expect(request.protocol).toEqual(ProtocolVersion.V3);
+  });
+
+  it('toCleanJSON sets protocol v3 for Dutch_V3 orders', () => {
+    const order = getV3Order(SWAPPER);
+    const request = makeRequest(
+      { encodedInnerOrder: order.serialize(), innerSig: '0x' },
+      OrderType.Dutch_V3,
+      V3_CHAIN_ID
+    );
+    expect(request.toCleanJSON()).toEqual({
+      tokenInChainId: V3_CHAIN_ID,
+      tokenOutChainId: V3_CHAIN_ID,
+      requestId: REQUEST_ID,
+      quoteId: QUOTE_ID,
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amount: RAW_AMOUNT.toString(),
+      swapper: ethers.constants.AddressZero,
+      type: 'EXACT_INPUT',
+      numOutputs: 1,
+      protocol: ProtocolVersion.V3,
+    });
+  });
+
+  it('toOpposingCleanJSON sets protocol v3 for Dutch_V3 orders', () => {
+    const order = getV3Order(SWAPPER);
+    const request = makeRequest(
+      { encodedInnerOrder: order.serialize(), innerSig: '0x' },
+      OrderType.Dutch_V3,
+      V3_CHAIN_ID
+    );
+    expect(request.toOpposingCleanJSON()).toEqual({
+      tokenInChainId: V3_CHAIN_ID,
+      tokenOutChainId: V3_CHAIN_ID,
+      requestId: REQUEST_ID,
+      quoteId: QUOTE_ID,
+      tokenIn: TOKEN_OUT,
+      tokenOut: TOKEN_IN,
+      amount: RAW_AMOUNT.toString(),
+      swapper: ethers.constants.AddressZero,
+      type: 'EXACT_OUTPUT',
+      numOutputs: 1,
+      protocol: ProtocolVersion.V3,
     });
   });
 });

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -482,7 +482,7 @@ describe('WebhookQuoter tests', () => {
         headers: {},
         timeout: 500,
       });
-      // empty supportedVersions defaults to v2 only
+      // empty supportedVersions defaults to v2 and v3
       expect(mockedAxios.post).not.toBeCalledWith(WEBHOOK_URL_FOO, request.toCleanJSON(), {
         headers: {},
         timeout: 500,
@@ -521,7 +521,7 @@ describe('WebhookQuoter tests', () => {
           timeout: 500,
         }
       );
-      // empty config defaults to v2 only
+      // empty config defaults to v2 and v3
       expect(mockedAxios.post).toBeCalledWith(
         WEBHOOK_URL_FOO,
         { quoteId: expect.any(String), ...request.toCleanJSON() },
@@ -564,8 +564,8 @@ describe('WebhookQuoter tests', () => {
           timeout: 500,
         }
       );
-      // empty config defaults to v2 only
-      expect(mockedAxios.post).not.toBeCalledWith(
+      // empty config defaults to v2 and v3
+      expect(mockedAxios.post).toBeCalledWith(
         WEBHOOK_URL_FOO,
         { quoteId: expect.any(String), ...request.toCleanJSON() },
         {

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -424,7 +424,7 @@ describe('WebhookQuoter tests', () => {
         endpoint: WEBHOOK_URL,
         headers: {},
         hash: '0xuni',
-        supportedVersions: [ProtocolVersion.V1, ProtocolVersion.V2],
+        supportedVersions: [ProtocolVersion.V1, ProtocolVersion.V2, ProtocolVersion.V3],
       },
       { name: '1inch', endpoint: WEBHOOK_URL_ONEINCH, headers: {}, hash: '0x1inch' },
       {
@@ -523,6 +523,49 @@ describe('WebhookQuoter tests', () => {
       );
       // empty config defaults to v2 only
       expect(mockedAxios.post).toBeCalledWith(
+        WEBHOOK_URL_FOO,
+        { quoteId: expect.any(String), ...request.toCleanJSON() },
+        {
+          headers: {},
+          timeout: 500,
+        }
+      );
+    });
+
+    it('v3 quote request only sent to fillers supporting v3', async () => {
+      mockedAxios.post
+        .mockImplementationOnce((_endpoint, _req, _options) => {
+          return Promise.resolve({
+            data: quote,
+          });
+        })
+        .mockImplementationOnce((_endpoint, _req, _options) => {
+          return Promise.resolve({
+            data: {
+              ...quote,
+              tokenIn: request.tokenOut,
+              tokenOut: request.tokenIn,
+            },
+          });
+        });
+
+      const request = makeQuoteRequest({ protocol: ProtocolVersion.V3 });
+      await webhookQuoter.quote(request);
+      expect(mockedAxios.post).toBeCalledWith(
+        WEBHOOK_URL,
+        { quoteId: expect.any(String), ...request.toCleanJSON() },
+        { headers: {}, timeout: 500 }
+      );
+      expect(mockedAxios.post).not.toBeCalledWith(
+        WEBHOOK_URL_SEARCHER,
+        { quoteId: expect.any(String), ...request.toCleanJSON() },
+        {
+          headers: {},
+          timeout: 500,
+        }
+      );
+      // empty config defaults to v2 only
+      expect(mockedAxios.post).not.toBeCalledWith(
         WEBHOOK_URL_FOO,
         { quoteId: expect.any(String), ...request.toCleanJSON() },
         {


### PR DESCRIPTION
## Summary

The hard-quote handler already parses and cosigns UniswapX DutchV3 orders, but the RFQ webhook side had no notion of a V3 protocol version: the `ProtocolVersion` enum stopped at V2, and `HardQuoteRequest.toCleanJSON()` hardcoded `protocol: 'v2'` even when the inner order was a DutchV3 order. As a result, V3 hard quotes were mislabeled as `v2` and routed using V2 support filters, and fillers had no way to opt into V3 RFQs.

## Changes

- **`lib/providers/webhook/index.ts`** — add `V3 = 'v3'` to the `ProtocolVersion` enum. This automatically flows into the Joi `FieldValidator.protocol` (validated against `Object.values(ProtocolVersion)`), so the indicative-quote API accepts `protocol: "v3"` and webhook configs can declare `supportedVersions: ['v3']`.
- **`lib/entities/HardQuoteRequest.ts`** — replace the hardcoded `protocol: ProtocolVersion.V2` in `toCleanJSON()` with a `protocol` getter backed by a `private readonly _protocol` field set in the constructor's existing orderType branch (`Dutch_V2` → `v2`, `Dutch_V3` → `v3`).
- **`lib/quoters/WebhookQuoter.ts`** — `getEndpointSupportedProtocols` now defaults unconfigured fillers to `[v2, v3]` (previously `[v2]`), so v3 hard quotes get RFQ pricing without each filler having to update their webhook config first. Fillers with an explicit `supportedVersions` list are unaffected and must include `v3` to receive V3 RFQs.

## Testing

- `test/entities/HardQuoteRequest.test.ts`: new V3 order fixture (`V3DutchOrderBuilder`, Arbitrum) with tests for the `protocol` getter and `toCleanJSON`/`toOpposingCleanJSON` emitting `v3`.
- `test/providers/quoters/WebhookQuoter.test.ts`: new test that a `v3` quote request is sent to fillers declaring V3 support and to default-config fillers, but not to fillers with an explicit V1/V2-only list.
- `tsc --noEmit` clean; all 25 unit test suites pass (integ suites require a deployed `UNISWAP_API` and were not run).

## Rollout note

Because the default now includes `v3`, fillers that never set `supportedVersions` will start receiving DutchV3 RFQs (block-based decay, 0.25% exclusivity override) as soon as this deploys. Fillers with an explicit `supportedVersions` config must add `v3` to participate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
