### PR TITLE
fix: raise default webhook timeout from 250ms to 500ms on all chains

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -38,10 +38,10 @@ export const POST_ORDER_ERROR_REASON = {
   INSUFFICIENT_FUNDS: 'Onchain validation failed: InsufficientFunds',
 };
 
-// Per-chain webhook (RFQ) timeout. Default 250 ms so a slow MM can't drag the
-// whole quote-aggregation step on fast chains; Mainnet 500 ms to accommodate
-// higher MM latency.
-const WEBHOOK_TIMEOUT_MS_DEFAULT = 250;
+// Per-chain webhook (RFQ) timeout. 500 ms across all chains — the previous
+// 250 ms default on non-mainnet chains was too tight for MMs to respond,
+// causing quote requests to time out and return no quotes.
+const WEBHOOK_TIMEOUT_MS_DEFAULT = 500;
 const WEBHOOK_TIMEOUT_MS_MAINNET = 500;
 
 export function getWebhookTimeoutMs(chainId: number): number {

--- a/test/util/constants.test.ts
+++ b/test/util/constants.test.ts
@@ -24,17 +24,17 @@ describe('V3 chain constants', () => {
     it('keeps mainnet at 500 ms', () => {
       expect(getWebhookTimeoutMs(ChainId.MAINNET)).toEqual(500);
     });
-    it('tightens arbitrum to 250 ms', () => {
-      expect(getWebhookTimeoutMs(ChainId.ARBITRUM_ONE)).toEqual(250);
+    it('uses 500 ms on arbitrum', () => {
+      expect(getWebhookTimeoutMs(ChainId.ARBITRUM_ONE)).toEqual(500);
     });
-    it('tightens tempo to 250 ms', () => {
-      expect(getWebhookTimeoutMs(ChainId.TEMPO)).toEqual(250);
+    it('uses 500 ms on tempo', () => {
+      expect(getWebhookTimeoutMs(ChainId.TEMPO)).toEqual(500);
     });
-    it('tightens base to 250 ms', () => {
-      expect(getWebhookTimeoutMs(ChainId.BASE)).toEqual(250);
+    it('uses 500 ms on base', () => {
+      expect(getWebhookTimeoutMs(ChainId.BASE)).toEqual(500);
     });
-    it('defaults to 250 ms for unknown chains', () => {
-      expect(getWebhookTimeoutMs(99999)).toEqual(250);
+    it('defaults to 500 ms for unknown chains', () => {
+      expect(getWebhookTimeoutMs(99999)).toEqual(500);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Bump `WEBHOOK_TIMEOUT_MS_DEFAULT` from 250ms to 500ms, matching the existing mainnet timeout
- Update `getWebhookTimeoutMs` tests to expect 500ms on all chains

## Motivation
Quote requests on non-mainnet chains (observed on BNB chain 56) were returning `404 No quotes available` — the full webhook fan-out resolved at exactly the 250ms timeout boundary, meaning fillers were being cut off by the axios timeout before they could respond. 250ms proved too tight for filler RFQ latency, so this aligns all chains with the 500ms mainnet setting. Per-filler `overrides.timeout` config still takes precedence.

## Testing
- `yarn jest test/util/constants.test.ts` — 9/9 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)