### PR TITLE
feat: split dashboard metrics by chainId

### DIFF
--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -10,6 +10,7 @@ import {
   Metric,
   SoftQuoteMetricDimension,
 } from '../../lib/entities';
+import { ChainId, SUPPORTED_CHAINS } from '../../lib/util/chains';
 
 export const NAMESPACE = 'Uniswap';
 
@@ -49,6 +50,8 @@ export type LambdaWidget = {
 };
 
 const RFQ_SERVICES = [SoftQuoteMetricDimension, HardQuoteMetricDimension];
+
+const chainLabel = (chainId: ChainId): string => `${ChainId[chainId]} (${chainId})`;
 
 const LatencyWidget = (region: string): LambdaWidget[] =>
   RFQ_SERVICES.map((service) => {
@@ -114,6 +117,101 @@ const QuotesRequestedWidget = (region: string): LambdaWidget[] =>
         period: 300,
         stacked: false,
         title: `${service.Service} Quotes Requested | 5 minutes`,
+      },
+    };
+  });
+
+const LatencyByChainWidget = (region: string): LambdaWidget[] =>
+  RFQ_SERVICES.map((service) => {
+    return {
+      height: 11,
+      width: 12,
+      type: 'metric',
+      properties: {
+        metrics: SUPPORTED_CHAINS.map((chainId) => [
+          'Uniswap',
+          'QUOTE_LATENCY',
+          'Service',
+          service.Service,
+          'ChainId',
+          chainId.toString(),
+          { stat: 'p90', label: chainLabel(chainId) },
+        ]),
+        view: 'timeSeries',
+        stacked: false,
+        region,
+        period: 300,
+        title: `${service.Service} Quote Latency p90 by Chain | 5 minutes`,
+      },
+    };
+  });
+
+const QuotesRequestedByChainWidget = (region: string): LambdaWidget[] =>
+  RFQ_SERVICES.map((service) => {
+    return {
+      height: 11,
+      width: 12,
+      type: 'metric',
+      properties: {
+        metrics: SUPPORTED_CHAINS.map((chainId) => [
+          'Uniswap',
+          'QUOTE_REQUESTED',
+          'Service',
+          service.Service,
+          'ChainId',
+          chainId.toString(),
+          { label: chainLabel(chainId) },
+        ]),
+        view: 'timeSeries',
+        stacked: false,
+        region,
+        stat: 'Sum',
+        period: 300,
+        title: `${service.Service} Quotes Requested by Chain | 5 minutes`,
+      },
+    };
+  });
+
+const ErrorRatesByChainWidget = (region: string): LambdaWidget[] =>
+  RFQ_SERVICES.map((service) => {
+    return {
+      height: 10,
+      width: 12,
+      type: 'metric',
+      properties: {
+        metrics: SUPPORTED_CHAINS.flatMap((chainId, i) => [
+          [{ expression: `100*(notfound${i}/requested${i})`, label: chainLabel(chainId), id: `e${i}`, region }],
+          [
+            'Uniswap',
+            'QUOTE_404',
+            'Service',
+            service.Service,
+            'ChainId',
+            chainId.toString(),
+            { id: `notfound${i}`, visible: false },
+          ],
+          [
+            'Uniswap',
+            'QUOTE_REQUESTED',
+            'Service',
+            service.Service,
+            'ChainId',
+            chainId.toString(),
+            { id: `requested${i}`, visible: false },
+          ],
+        ]),
+        view: 'timeSeries',
+        stacked: false,
+        region,
+        stat: 'Sum',
+        period: 300,
+        title: `${service.Service} 404 Rates by Chain`,
+        yAxis: {
+          left: {
+            label: 'Percent',
+            showUnits: false,
+          },
+        },
       },
     };
   });
@@ -308,6 +406,9 @@ export class ParamDashboardStack extends cdk.NestedStack {
           RFQLatencyWidget(region, RFQ_PROVIDERS),
           QuotesRequestedWidget(region),
           ErrorRatesWidget(region),
+          LatencyByChainWidget(region),
+          QuotesRequestedByChainWidget(region),
+          ErrorRatesByChainWidget(region),
           RFQFailRatesWidget(region, RFQ_PROVIDERS),
           LambdaErrorRatesWidget(region, scope),
           FailingRFQLogsWidget(region, props.quoteLambda.logGroup.logGroupArn),

--- a/lib/handlers/hard-quote/injector.ts
+++ b/lib/handlers/hard-quote/injector.ts
@@ -111,6 +111,11 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
 
     metricsLogger.setNamespace('Uniswap');
     metricsLogger.setDimensions(HardQuoteMetricDimension);
+    // additional dimension set so every metric is also queryable per-chain
+    metricsLogger.putDimensions({
+      ...HardQuoteMetricDimension,
+      ChainId: requestBody.tokenInChainId.toString(),
+    });
     const metric = new AWSMetricsLogger(metricsLogger);
     setGlobalMetric(metric);
 

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -112,6 +112,11 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
 
     metricsLogger.setNamespace('Uniswap');
     metricsLogger.setDimensions(SoftQuoteMetricDimension);
+    // additional dimension set so every metric is also queryable per-chain
+    metricsLogger.putDimensions({
+      ...SoftQuoteMetricDimension,
+      ChainId: requestBody.tokenInChainId.toString(),
+    });
     const metric = new AWSMetricsLogger(metricsLogger);
     setGlobalMetric(metric);
 


### PR DESCRIPTION
## Summary
- Emit an additional `[Service, ChainId]` EMF dimension set in the soft-quote and hard-quote injectors (keyed off `requestBody.tokenInChainId`), so every metric (`QUOTE_REQUESTED`, `QUOTE_LATENCY`, `QUOTE_404`, `RFQ_*`, etc.) is also queryable per-chain
- Add per-chain widgets to `UniswapXParamDashboard` for both SoftQuote and HardQuote services:
  - **Quote Latency p90 by Chain**
  - **Quotes Requested by Chain**
  - **404 Rates by Chain** (`100 * QUOTE_404 / QUOTE_REQUESTED` per chain)
- Chain series are generated from `SUPPORTED_CHAINS` (single source of truth), labeled like `MAINNET (1)`, `BNB (56)`

## Notes
- The existing `[Service]` dimension set is untouched — `putDimensions` appends a second dimension set rather than replacing, so all current dashboard widgets and CloudWatch alarms keep working
- Motivated by debugging the BNB-chain v3 404s, where aggregate metrics couldn't show which chain was failing

## Testing
- `yarn build` (tsc) passes
- `yarn jest test/handlers/quote test/handlers/hard-quote` — 72 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)