### PR TITLE
fix: bump V3_DECAY_START_BUFFER_SECS from 1s to 5s

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -53,7 +53,7 @@ export const NOTIFICATION_TIMEOUT_MS = 10;
 // Wallclock target between order receipt and the decay window opening.
 // Cosigners need a small lead so the swapper-signed `decayStartBlock` is
 // reliably in the future when the order is broadcast.
-export const V3_DECAY_START_BUFFER_SECS = 1;
+export const V3_DECAY_START_BUFFER_SECS = 5;
 
 // Number of blocks for the V3 decay-start buffer, derived from wallclock
 // duration / per-chain block time (sourced from @uniswap/sdk-core).

--- a/test/handlers/hard-quote/handlerDutchV3.cosigner.test.ts
+++ b/test/handlers/hard-quote/handlerDutchV3.cosigner.test.ts
@@ -183,7 +183,7 @@ describe('getCosignerData V3 (RFQ)', () => {
     expect(data.exclusiveFiller).toEqual(ethers.constants.AddressZero);
   });
 
-  it('Mainnet: decayStartBlock buffer = ceil(1s / 12s blocks) = 1', async () => {
+  it('Mainnet: decayStartBlock buffer = ceil(5s / 12s blocks) = 1', async () => {
     const req = makeRequest(ChainId.MAINNET, TradeType.EXACT_INPUT);
     const provider = makeProvider();
     const data = (await getCosignerData(
@@ -195,7 +195,7 @@ describe('getCosignerData V3 (RFQ)', () => {
     expect(data.decayStartBlock).toEqual(CURRENT_BLOCK + 1);
   });
 
-  it('Tempo: decayStartBlock buffer = ceil(1s / 0.5s blocks) = 2', async () => {
+  it('Tempo: decayStartBlock buffer = ceil(5s / 0.5s blocks) = 10', async () => {
     const req = makeRequest(ChainId.TEMPO, TradeType.EXACT_INPUT);
     const provider = makeProvider({ baseFee: TEMPO_BASE_FEE });
     const data = (await getCosignerData(
@@ -204,7 +204,7 @@ describe('getCosignerData V3 (RFQ)', () => {
       OrderType.Dutch_V3,
       provider
     )) as V3CosignerData;
-    expect(data.decayStartBlock).toEqual(CURRENT_BLOCK + 2);
+    expect(data.decayStartBlock).toEqual(CURRENT_BLOCK + 10);
   });
 
   it('Tempo: EXACT_INPUT better quote raises outputOverride and sets exclusiveFiller', async () => {
@@ -221,7 +221,7 @@ describe('getCosignerData V3 (RFQ)', () => {
     expect(data.outputOverrides[0].gte(req.order.info.outputs[0].startAmount)).toBe(true);
     expect(data.exclusiveFiller.toLowerCase()).toEqual(FILLER.toLowerCase());
     expect(data.inputOverride).toEqual(BigNumber.from(0));
-    expect(data.decayStartBlock).toEqual(CURRENT_BLOCK + 2);
+    expect(data.decayStartBlock).toEqual(CURRENT_BLOCK + 10);
   });
 
   it('multi-output (swapper + fee): EXACT_INPUT increase goes entirely to outputs[0]', async () => {

--- a/test/util/constants.test.ts
+++ b/test/util/constants.test.ts
@@ -6,14 +6,14 @@ import { ChainId } from '../../lib/util/chains';
 
 describe('V3 chain constants', () => {
   describe('getV3BlockBuffer', () => {
-    it('mainnet: ceil(1/12) = 1', () => {
+    it('mainnet: ceil(5/12) = 1', () => {
       expect(getV3BlockBuffer(ChainId.MAINNET)).toEqual(1);
     });
-    it('arbitrum: ceil(1/0.25) = 4', () => {
-      expect(getV3BlockBuffer(ChainId.ARBITRUM_ONE)).toEqual(4);
+    it('arbitrum: ceil(5/0.25) = 20', () => {
+      expect(getV3BlockBuffer(ChainId.ARBITRUM_ONE)).toEqual(20);
     });
-    it('tempo: ceil(1/0.5) = 2', () => {
-      expect(getV3BlockBuffer(ChainId.TEMPO)).toEqual(2);
+    it('tempo: ceil(5/0.5) = 10', () => {
+      expect(getV3BlockBuffer(ChainId.TEMPO)).toEqual(10);
     });
     it('throws on unknown chainId (propagated from sdk-core)', () => {
       expect(() => getV3BlockBuffer(99999)).toThrow(/unsupported chainId 99999/);


### PR DESCRIPTION
## Summary

Bumps `V3_DECAY_START_BUFFER_SECS` from 1 to 5 seconds. This is the wallclock target between order receipt and the decay window opening — cosigners need this lead so the swapper-signed `decayStartBlock` is reliably in the future when the order is broadcast. 1s was too tight.

Since the block buffer is derived per chain via `secondsToBlocks` (ceil of seconds / avg block time), the effective `decayStartBlock` offsets change:

| Chain | Block time | Buffer before | Buffer after |
| --- | --- | --- | --- |
| Mainnet | 12s | 1 block | 1 block |
| Arbitrum | 0.25s | 4 blocks | 20 blocks |
| Tempo | 0.5s | 2 blocks | 10 blocks |

## Changes

- `lib/constants.ts` — `V3_DECAY_START_BUFFER_SECS` 1 → 5
- `test/util/constants.test.ts` — updated `getV3BlockBuffer` expectations
- `test/handlers/hard-quote/handlerDutchV3.cosigner.test.ts` — updated `decayStartBlock` expectations

## Testing

`npx jest test/util/constants.test.ts test/handlers/hard-quote/handlerDutchV3.cosigner.test.ts` — 18/18 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)