### PR TITLE
feat: include Dutch_V3 orders in circuit breaker fade tracking

### DIFF
--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -67,10 +67,9 @@ export class FadesRepository extends BaseRedshiftRepository {
 }
 
 /**
- * Computes per-filler fade signals for the circuit breaker. Despite the "V2"
- * name (kept for backwards compatibility), this covers both Dutch_V2 (time-based
- * decay) and Dutch_V3 (block-based decay) orders. Fades are aggregated per filler
- * across all order types and all production chains.
+ * Computes per-filler fade signals for the circuit breaker. Covers both
+ * Dutch_V2 (time-based decay) and Dutch_V3 (block-based decay) orders. Fades are
+ * aggregated per filler across all order types and all production chains.
  */
 export class V2FadesRepository extends BaseRedshiftRepository {
   static log: Logger;

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -1,7 +1,7 @@
 import { GetStatementResultCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 import Logger from 'bunyan';
 
-import { PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
+import { OrderType, PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
 import { BaseRedshiftRepository, SharedConfigs } from './base';
 
 // Number of recent orders to evaluate per filler for fade rate calculation
@@ -178,7 +178,7 @@ CREATE OR REPLACE VIEW latestRfqsV2
 AS (
 WITH latestOrdersV2 AS (
   SELECT * FROM (
-    SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders WHERE ordertype IN ('Dutch_V2', 'Dutch_V3')
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders WHERE ordertype IN ('${OrderType.Dutch_V2}', '${OrderType.Dutch_V3}')
   )
   WHERE row_num <= ${ORDERS_PER_FILLER_LIMIT}
   AND deadline < EXTRACT(EPOCH FROM GETDATE()) -- exclude orders that can still be filled
@@ -214,9 +214,9 @@ SELECT
       WHEN fillTimestamp IS NULL THEN 1
       -- Dutch_V3 decays by block, not by time: a fill at a block on or after
       -- the cosigned decayStartBlock means the price had begun decaying => fade.
-      WHEN orderType = 'Dutch_V3' AND fillBlock >= decayStartBlock THEN 1
+      WHEN orderType = '${OrderType.Dutch_V3}' AND fillBlock >= decayStartBlock THEN 1
       -- Dutch_V2 (time-based decay): filled after decay start => fade.
-      WHEN orderType = 'Dutch_V2' AND decayStartTime < fillTimestamp THEN 1
+      WHEN orderType = '${OrderType.Dutch_V2}' AND decayStartTime < fillTimestamp THEN 1
       ELSE 0
     END AS faded
 FROM latestRfqsV2

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -66,6 +66,12 @@ export class FadesRepository extends BaseRedshiftRepository {
   }
 }
 
+/**
+ * Computes per-filler fade signals for the circuit breaker. Despite the "V2"
+ * name (kept for backwards compatibility), this covers both Dutch_V2 (time-based
+ * decay) and Dutch_V3 (block-based decay) orders. Fades are aggregated per filler
+ * across all order types and all production chains.
+ */
 export class V2FadesRepository extends BaseRedshiftRepository {
   static log: Logger;
 
@@ -172,14 +178,14 @@ CREATE OR REPLACE VIEW latestRfqsV2
 AS (
 WITH latestOrdersV2 AS (
   SELECT * FROM (
-    SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders WHERE ordertype = 'Dutch_V2'
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders WHERE ordertype IN ('Dutch_V2', 'Dutch_V3')
   )
   WHERE row_num <= ${ORDERS_PER_FILLER_LIMIT}
   AND deadline < EXTRACT(EPOCH FROM GETDATE()) -- exclude orders that can still be filled
   LIMIT 5000
 )
 SELECT
-    latestOrdersV2.chainid as chainId, latestOrdersV2.filler as rfqFiller, latestOrdersV2.startTime as decayStartTime, latestOrdersV2.quoteid, archivedorders.filler as actualFiller, latestOrdersV2.createdat as postTimestamp, latestOrdersV2.deadline as deadline, archivedorders.txhash as txHash, archivedOrders.fillTimestamp as fillTimestamp, archivedOrders.tokenIn as tokenIn, archivedOrders.tokenOut as tokenOut,
+    latestOrdersV2.chainid as chainId, latestOrdersV2.ordertype as orderType, latestOrdersV2.filler as rfqFiller, latestOrdersV2.startTime as decayStartTime, latestOrdersV2.startBlock as decayStartBlock, latestOrdersV2.quoteid, archivedorders.filler as actualFiller, latestOrdersV2.createdat as postTimestamp, latestOrdersV2.deadline as deadline, archivedorders.txhash as txHash, archivedOrders.fillTimestamp as fillTimestamp, archivedorders.blockNumber as fillBlock, archivedOrders.tokenIn as tokenIn, archivedOrders.tokenOut as tokenOut,
     CASE
       WHEN latestOrdersV2.inputstartamount = latestOrdersV2.inputendamount THEN 'EXACT_INPUT'
       ELSE 'EXACT_OUTPUT'
@@ -203,10 +209,15 @@ SELECT
     rfqFiller,
     postTimestamp,
     deadline,
-    CASE 
+    CASE
+      -- Never filled (any order type) => fade.
       WHEN fillTimestamp IS NULL THEN 1
-      WHEN decayStartTime < fillTimestamp THEN 1
-      ELSE 0 
+      -- Dutch_V3 decays by block, not by time: a fill at a block on or after
+      -- the cosigned decayStartBlock means the price had begun decaying => fade.
+      WHEN orderType = 'Dutch_V3' AND fillBlock >= decayStartBlock THEN 1
+      -- Dutch_V2 (time-based decay): filled after decay start => fade.
+      WHEN orderType = 'Dutch_V2' AND decayStartTime < fillTimestamp THEN 1
+      ELSE 0
     END AS faded
 FROM latestRfqsV2
 WHERE LOWER(tokenIn) NOT IN (${PERMISSIONED_TOKENS.map((token) => `'${token.address.toLowerCase()}'`).join(',')})


### PR DESCRIPTION
## Summary

The circuit breaker's fade-rate cron (`fade-rate-v2`) only counted **Dutch_V2** fades — its Redshift view filtered `postedorders WHERE ordertype = 'Dutch_V2'`. As a result, **DutchV3 fades never contributed to filler blocks**: a filler that faded only on V3 would never trip the breaker. (Fades were already aggregated across all production chains; the gap was purely order type.)

This PR broadens the fade view to include `Dutch_V3` and adds block-based fade detection for it.

## What changed

`lib/repositories/fades-repository.ts` (`V2FadesRepository`):

1. **Order-type filter**: `ordertype = 'Dutch_V2'` → `ordertype IN ('Dutch_V2', 'Dutch_V3')`. The latest-50-per-filler window now spans both order types, so fades aggregate per filler across V2 **and** V3.
2. **New view columns**: `ordertype`, `decayStartBlock` (← `postedorders.startblock`), and `fillBlock` (← `archivedorders.blocknumber`).
3. **Block-based fade detection for V3**. DutchV3 decays by block, not by time, so the `faded` CASE now branches on order type:
   - **Any type** — `fillTimestamp IS NULL` ⇒ fade (never filled)
   - **Dutch_V3** — `fillBlock >= decayStartBlock` ⇒ fade (filled on/after decay start block)
   - **Dutch_V2** — `decayStartTime < fillTimestamp` ⇒ fade (existing time-based logic, unchanged)

## Column mapping (from `x-service` analytics)

- `analytics-service.ts` emits `startBlock: order.cosignerData.decayStartBlock` for V3 posted orders → Redshift `postedorders.startblock`.
- The fill event emits `blockNumber: fill.blockNumber` → Redshift `archivedorders.blocknumber`.

## Notes / scope

- The downstream TypeScript (`getFillersNewFades`, `calculateNewTimestamps`) is order-type agnostic — it consumes the already-computed `faded` value — so no logic changes there, and `V2FadesRowType` / `getFades()` output columns are unchanged.
- Block state remains **per filler** (no per-chain or per-order-type breakdown). A block earned via any order type/chain applies everywhere, as before.
- The `V2FadesRepository` / `latestRfqsV2` names are intentionally kept (now cover V2+V3) to avoid a wide rename; a doc comment clarifies the broadened scope.
- The fade SQL runs against Redshift and isn't unit-tested; existing fade-rate unit tests pass unchanged. Worth a sanity check of the `startblock` / `blocknumber` column names against the live `postedorders` / `archivedorders` schema before/after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)