### PR TITLE
fix: V3 fade detection uses fillTimeBlocks, not non-existent startBlock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+Guidance for AI agents (and humans) working in this repo.
+
+## Redshift analytics tables are defined in another repo — verify columns before using them
+
+This service reads Redshift tables (`postedorders`, `archivedorders`, `rfqrequests`,
+`rfqresponses`, etc.) via raw SQL in `lib/repositories/*.ts` (see `BaseRedshiftRepository`)
+and `lib/cron/*.ts`. These tables are **not defined here**. Their schemas are owned by the
+`data-eng-workflows` repo, in the load configs:
+
+```
+data-eng-workflows/lib/spaces/uniswap_x/functions/uniswap_x_hourly_config/tables/load/*.yaml
+```
+
+Table → YAML mapping (table names are lowercased in Redshift; YAML uses snake_case):
+
+| Redshift table   | Load schema YAML       |
+|------------------|------------------------|
+| `postedorders`   | `posted_orders.yaml`   |
+| `archivedorders` | `archived_orders.yaml` |
+| `rfqrequests`    | `rfq_requests.yaml`    |
+| `rfqresponses`   | `rfq_responses.yaml`   |
+
+**Rule: before referencing any column in Redshift SQL, confirm it exists as a `name:` field
+in the corresponding YAML.** The view/query column references are validated only at runtime
+against the live cluster — there is no compile-time or unit-test check — so a typo or a
+non-loaded column fails the cron in production (and a column that exists but is null for the
+relevant rows fails *silently*).
+
+### The trap: "emitted" ≠ "loaded"
+
+A field being emitted by `x-service`'s `analytics-service.ts` does **not** mean it lands in
+the table. Only fields listed in the load YAML are loaded; the rest are dropped. Concretely,
+V3 emits `startBlock` (= `cosignerData.decayStartBlock`), but `posted_orders.yaml` has no
+`startBlock` column, so it does not exist in `postedorders`. Likewise, a column may exist but
+only be populated for some order types (e.g. `auctionStartBlock` is emitted for Priority/Hybrid
+orders but is null for Dutch_V3). Check both that the column exists **and** that it is populated
+for the rows you care about.
+
+### How to verify
+
+1. If `../data-eng-workflows` is checked out locally, grep the matching `*.yaml` for the column.
+2. Otherwise (or to be sure it's populated), query the live cluster:
+   ```sql
+   SELECT column_name FROM information_schema.columns
+   WHERE table_name = '<table>' AND column_name = '<column>';
+   -- and, for null-for-some-rows risk:
+   SELECT ordertype, COUNT(*), COUNT(<column>) FROM <table> GROUP BY 1;
+   ```
+3. New columns must be added to the `data-eng-workflows` load YAML (and the table) **before**
+   any SQL here references them.

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -184,7 +184,7 @@ WITH latestOrdersV2 AS (
   LIMIT 5000
 )
 SELECT
-    latestOrdersV2.chainid as chainId, latestOrdersV2.ordertype as orderType, latestOrdersV2.filler as rfqFiller, latestOrdersV2.startTime as decayStartTime, latestOrdersV2.startBlock as decayStartBlock, latestOrdersV2.quoteid, archivedorders.filler as actualFiller, latestOrdersV2.createdat as postTimestamp, latestOrdersV2.deadline as deadline, archivedorders.txhash as txHash, archivedOrders.fillTimestamp as fillTimestamp, archivedorders.blockNumber as fillBlock, archivedOrders.tokenIn as tokenIn, archivedOrders.tokenOut as tokenOut,
+    latestOrdersV2.chainid as chainId, latestOrdersV2.ordertype as orderType, latestOrdersV2.filler as rfqFiller, latestOrdersV2.startTime as decayStartTime, latestOrdersV2.quoteid, archivedorders.filler as actualFiller, latestOrdersV2.createdat as postTimestamp, latestOrdersV2.deadline as deadline, archivedorders.txhash as txHash, archivedOrders.fillTimestamp as fillTimestamp, archivedorders.fillTimeBlocks as fillTimeBlocks, archivedOrders.tokenIn as tokenIn, archivedOrders.tokenOut as tokenOut,
     CASE
       WHEN latestOrdersV2.inputstartamount = latestOrdersV2.inputendamount THEN 'EXACT_INPUT'
       ELSE 'EXACT_OUTPUT'
@@ -211,9 +211,11 @@ SELECT
     CASE
       -- Never filled (any order type) => fade.
       WHEN fillTimestamp IS NULL THEN 1
-      -- Dutch_V3 decays by block, not by time: a fill at a block on or after
-      -- the cosigned decayStartBlock means the price had begun decaying => fade.
-      WHEN orderType = '${OrderType.Dutch_V3}' AND fillBlock >= decayStartBlock THEN 1
+      -- Dutch_V3 decays by block, not by time. fillTimeBlocks is computed
+      -- upstream as (fillBlock - decayStartBlock), so >= 0 means the fill landed
+      -- on or after the cosigned decayStartBlock i.e. the price had begun
+      -- decaying => fade.
+      WHEN orderType = '${OrderType.Dutch_V3}' AND fillTimeBlocks >= 0 THEN 1
       -- Dutch_V2 (time-based decay): filled after decay start => fade.
       WHEN orderType = '${OrderType.Dutch_V2}' AND decayStartTime < fillTimestamp THEN 1
       ELSE 0


### PR DESCRIPTION
## Problem

The circuit-breaker fade cron started failing in the service after #451:

```
latestordersv2.startblock does not exist","msg":"Failed to execute command"
```

#451 keyed Dutch_V3 fade detection off `postedorders.startBlock` (intended to be the cosigned `decayStartBlock`). But that column **is never loaded into the analytics tables** — `data-eng-workflows/.../tables/load/posted_orders.yaml` defines `auctionStartBlock`/`auctionTargetBlock` but no `startBlock`/`decayStartBlock`. So `CREATE VIEW latestRfqsV2` referenced a non-existent column and the cron threw on every run.

## Fix

`archived_orders` already materializes **`fillTimeBlocks`** (it's in the load schema and has existed for all order types). Upstream, for Dutch_V3 it is computed exactly as `fillBlock - decayStartBlock` (`x-service` `check-order-status/service.ts:173-174`, marked "Exact"). Therefore:

> `fillTimeBlocks >= 0`  ⟺  `fillBlock >= decayStartBlock`  ⟺  filled on/after decay start ⟹ **fade**

— exactly the rule we want, using an existing, stable column instead of one that was never loaded.

Changes:
- View: drop `startBlock as decayStartBlock` and `blockNumber as fillBlock`; select `archivedorders.fillTimeBlocks`.
- Fade `CASE`: V3 branch becomes `WHEN orderType = 'Dutch_V3' AND fillTimeBlocks >= 0 THEN 1`.
- V2 (time-based) and the `fillTimestamp IS NULL` (unfilled) branches are unchanged.

## Why it didn't get caught, and how to prevent recurrence

The view's column references are validated **only at runtime against the live Redshift schema** — there's no compile-time or CI check, and the Redshift/analytics schema is owned by a different repo (`data-eng-workflows`). Options discussed in the PR thread:
1. Treat the `data-eng-workflows` load YAMLs as the source of truth — only reference columns defined there; add new columns to the load schema (and table) *before* the query references them.
2. Add a preflight in `createFadesView()` that checks `information_schema.columns` for the required columns and throws a clear "missing column X" error (still alarms via the existing FadeRateV2Cron Sev3 error alarm, but with an actionable message).
3. Add an integration test that runs the view creation against beta Redshift and fails CI on a missing column.

This PR prefers a stable, already-loaded column as the immediate mitigation; happy to follow up with a preflight check (option 2) if we want a guardrail.

## Verification
- `yarn build`, eslint, prettier: clean
- `test/crons/fade-rate-v2.test.ts`: passing (TS aggregation logic unchanged)
- ⚠️ Recommend confirming against the live schema before/after deploy: `SELECT column_name FROM information_schema.columns WHERE table_name = 'archivedorders' AND column_name = 'filltimeblocks';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)