### PR TITLE
feat: add requestId/quoteId to WebhookQuoter logs

### DIFF
--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -2,9 +2,10 @@ import { TradeType } from '@uniswap/sdk-core';
 import { metric, MetricLoggerUnit } from '@uniswap/smart-order-router';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import Logger from 'bunyan';
-import { v4 as uuidv4 } from 'uuid';
 import { ethers } from 'ethers';
+import { v4 as uuidv4 } from 'uuid';
 
+import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk';
 import { Quoter, QuoterType } from '.';
 import { getWebhookTimeoutMs, NOTIFICATION_TIMEOUT_MS } from '../constants';
 import {
@@ -22,9 +23,8 @@ import { FirehoseLogger } from '../providers/analytics';
 import { CircuitBreakerConfigurationProvider, EndpointStatuses } from '../providers/circuit-breaker';
 import { FillerComplianceConfigurationProvider } from '../providers/compliance';
 import { FillerAddressRepository } from '../repositories/filler-address-repository';
-import { timestampInMstoISOString } from '../util/time';
-import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk';
 import { RFQValidator } from '../util/rfqValidator';
+import { timestampInMstoISOString } from '../util/time';
 
 // Quoter which fetches quotes from http endpoints
 // endpoints must return well-formed QuoteResponse JSON
@@ -42,13 +42,19 @@ export class WebhookQuoter implements Quoter {
     this.log = _log.child({ quoter: 'WebhookQuoter' });
   }
 
-  public async quote(request: QuoteRequest, provider?: ethers.providers.StaticJsonRpcProvider): Promise<QuoteResponse[]> {
+  public async quote(
+    request: QuoteRequest,
+    provider?: ethers.providers.StaticJsonRpcProvider
+  ): Promise<QuoteResponse[]> {
     const statuses = await this.getEndpointStatuses();
     const endpointToAddrsMap = await this.complianceProvider.getEndpointToExcludedAddrsMap();
     // Ignore endpoint status if token is permissioned
-    const isPermissionedToken = PermissionedTokenValidator.isPermissionedToken(request.tokenIn, request.tokenInChainId) 
-    || PermissionedTokenValidator.isPermissionedToken(request.tokenOut, request.tokenOutChainId);
-    const baseFillerSet = isPermissionedToken ? statuses.enabled.concat(statuses.disabled.map(e => e.webhook)) : statuses.enabled;
+    const isPermissionedToken =
+      PermissionedTokenValidator.isPermissionedToken(request.tokenIn, request.tokenInChainId) ||
+      PermissionedTokenValidator.isPermissionedToken(request.tokenOut, request.tokenOutChainId);
+    const baseFillerSet = isPermissionedToken
+      ? statuses.enabled.concat(statuses.disabled.map((e) => e.webhook))
+      : statuses.enabled;
     const enabledEndpoints = baseFillerSet.filter(
       (e) =>
         passFillerCompliance(e, endpointToAddrsMap, request.swapper) &&
@@ -58,7 +64,7 @@ export class WebhookQuoter implements Quoter {
     const disabledEndpoints = statuses.disabled;
 
     this.log.info(
-      { enabled: enabledEndpoints, disabled: disabledEndpoints },
+      { requestId: request.requestId, enabled: enabledEndpoints, disabled: disabledEndpoints },
       `Fetching quotes from ${enabledEndpoints.length} endpoints and notifying disabled endpoints`
     );
 
@@ -67,7 +73,7 @@ export class WebhookQuoter implements Quoter {
     // should not await and block
     if (!isPermissionedToken) {
       Promise.allSettled(disabledEndpoints.map((e) => this.notifyBlock(e))).then((results) => {
-        this.log.info({ results }, 'Notified disabled endpoints');
+        this.log.info({ requestId: request.requestId, results }, 'Notified disabled endpoints');
       });
     }
 
@@ -83,18 +89,22 @@ export class WebhookQuoter implements Quoter {
     return this.circuitBreakerProvider.getEndpointStatuses(endpoints);
   }
 
-  private async fetchQuote(config: WebhookConfiguration, request: QuoteRequest, provider?: ethers.providers.StaticJsonRpcProvider): Promise<QuoteResponse | null> {
+  private async fetchQuote(
+    config: WebhookConfiguration,
+    request: QuoteRequest,
+    provider?: ethers.providers.StaticJsonRpcProvider
+  ): Promise<QuoteResponse | null> {
     const { name, endpoint, headers } = config;
     if (config.chainIds !== undefined && !config.chainIds.includes(request.tokenInChainId)) {
       this.log.debug(
-        { configuredChainIds: config.chainIds, chainId: request.tokenInChainId },
+        { requestId: request.requestId, configuredChainIds: config.chainIds, chainId: request.tokenInChainId },
         `chainId not configured for ${endpoint}`
       );
       return null;
     }
     if (!getEndpointSupportedProtocols(config).includes(request.protocol)) {
       this.log.debug(
-        { config: config, requestdProtocol: request.protocol },
+        { requestId: request.requestId, config: config, requestdProtocol: request.protocol },
         `endpoint doesn't support the requested protocol`
       );
       return null;
@@ -108,8 +118,11 @@ export class WebhookQuoter implements Quoter {
     const opposingCleanRequest = request.toOpposingCleanJSON();
     opposingCleanRequest.quoteId = uuidv4();
 
-    this.log.info({ request: cleanRequest, headers }, `Webhook request to: ${endpoint}`);
-    this.log.info({ request: opposingCleanRequest, headers }, `Webhook request to: ${endpoint}`);
+    // Child logger so every log line in this RFQ attempt carries the request and quote ids.
+    const log = this.log.child({ requestId: cleanRequest.requestId, quoteId: cleanRequest.quoteId });
+
+    log.info({ request: cleanRequest, headers }, `Webhook request to: ${endpoint}`);
+    log.info({ request: opposingCleanRequest, headers }, `Webhook request to: ${endpoint}`);
 
     const before = Date.now();
     const timeoutOverride = config.overrides?.timeout;
@@ -141,10 +154,7 @@ export class WebhookQuoter implements Quoter {
         MetricLoggerUnit.Milliseconds
       );
 
-      this.log.info(
-        { response: hookResponse.data, status: hookResponse.status },
-        `Raw webhook response from: ${endpoint}`
-      );
+      log.info({ response: hookResponse.data, status: hookResponse.status }, `Raw webhook response from: ${endpoint}`);
       const rawResponse = {
         status: hookResponse.status,
         data: hookResponse.data,
@@ -171,14 +181,14 @@ export class WebhookQuoter implements Quoter {
         request.amount,
         response.amountOut,
         provider,
-        this.log
+        log
       );
 
       // RFQ provider explicitly elected not to quote
       if (isNonQuote(request, hookResponse, response)) {
         metric.putMetric(Metric.RFQ_NON_QUOTE, 1, MetricLoggerUnit.Count);
         metric.putMetric(metricContext(Metric.RFQ_NON_QUOTE, name), 1, MetricLoggerUnit.Count);
-        this.log.info(
+        log.info(
           {
             response: hookResponse.data,
             responseStatus: hookResponse.status,
@@ -200,7 +210,7 @@ export class WebhookQuoter implements Quoter {
         const error = validationError || validatePermissionedTokensError;
         metric.putMetric(Metric.RFQ_FAIL_VALIDATION, 1, MetricLoggerUnit.Count);
         metric.putMetric(metricContext(Metric.RFQ_FAIL_VALIDATION, name), 1, MetricLoggerUnit.Count);
-        this.log.error(
+        log.error(
           {
             error,
             response,
@@ -222,7 +232,7 @@ export class WebhookQuoter implements Quoter {
       if (response.requestId !== request.requestId) {
         metric.putMetric(Metric.RFQ_FAIL_REQUEST_MATCH, 1, MetricLoggerUnit.Count);
         metric.putMetric(metricContext(Metric.RFQ_FAIL_REQUEST_MATCH, name), 1, MetricLoggerUnit.Count);
-        this.log.error(
+        log.error(
           {
             requestId: request.requestId,
             responseRequestId: response.requestId,
@@ -244,7 +254,7 @@ export class WebhookQuoter implements Quoter {
 
       metric.putMetric(Metric.RFQ_SUCCESS, 1, MetricLoggerUnit.Count);
       metric.putMetric(metricContext(Metric.RFQ_SUCCESS, name), 1, MetricLoggerUnit.Count);
-      this.log.info(
+      log.info(
         {
           response: response.toLog(),
           endpoint: endpoint,
@@ -279,7 +289,7 @@ export class WebhookQuoter implements Quoter {
         !opposingResponse.validationError
       ) {
         opposingResponse.response.setFillerResponseLatencyMs(rawResponse.latencyMs);
-        this.log.info({
+        log.info({
           eventType: 'QuoteResponse',
           body: {
             ...opposingResponse.response.toLog(),
@@ -300,7 +310,7 @@ export class WebhookQuoter implements Quoter {
         latencyMs: Date.now() - before,
       };
       if (e instanceof AxiosError) {
-        this.log.error(
+        log.error(
           { endpoint, status: e.response?.status?.toString() },
           `Axios error fetching quote from ${endpoint}: ${e}`
         );
@@ -317,7 +327,7 @@ export class WebhookQuoter implements Quoter {
           })
         );
       } else {
-        this.log.error({ endpoint }, `Error fetching quote from ${endpoint}: ${e}`);
+        log.error({ endpoint }, `Error fetching quote from ${endpoint}: ${e}`);
         this.firehose.sendAnalyticsEvent(
           new AnalyticsEvent(AnalyticsEventType.WEBHOOK_RESPONSE, {
             ...requestContext,

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -95,16 +95,20 @@ export class WebhookQuoter implements Quoter {
     provider?: ethers.providers.StaticJsonRpcProvider
   ): Promise<QuoteResponse | null> {
     const { name, endpoint, headers } = config;
+    // Child logger so every log line in this RFQ attempt carries the request id.
+    // quoteId is added once it's generated below (it's per-RFQ, so it doesn't exist
+    // for the config-mismatch early returns that bail before any RFQ is sent).
+    let log = this.log.child({ requestId: request.requestId });
     if (config.chainIds !== undefined && !config.chainIds.includes(request.tokenInChainId)) {
-      this.log.debug(
-        { requestId: request.requestId, configuredChainIds: config.chainIds, chainId: request.tokenInChainId },
+      log.debug(
+        { configuredChainIds: config.chainIds, chainId: request.tokenInChainId },
         `chainId not configured for ${endpoint}`
       );
       return null;
     }
     if (!getEndpointSupportedProtocols(config).includes(request.protocol)) {
-      this.log.debug(
-        { requestId: request.requestId, config: config, requestdProtocol: request.protocol },
+      log.debug(
+        { config: config, requestdProtocol: request.protocol },
         `endpoint doesn't support the requested protocol`
       );
       return null;
@@ -118,8 +122,8 @@ export class WebhookQuoter implements Quoter {
     const opposingCleanRequest = request.toOpposingCleanJSON();
     opposingCleanRequest.quoteId = uuidv4();
 
-    // Child logger so every log line in this RFQ attempt carries the request and quote ids.
-    const log = this.log.child({ requestId: cleanRequest.requestId, quoteId: cleanRequest.quoteId });
+    // Enrich the logger with the now-generated quoteId so all subsequent logs carry both ids.
+    log = log.child({ quoteId: cleanRequest.quoteId });
 
     log.info({ request: cleanRequest, headers }, `Webhook request to: ${endpoint}`);
     log.info({ request: opposingCleanRequest, headers }, `Webhook request to: ${endpoint}`);

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -2,6 +2,7 @@ import { TradeType } from '@uniswap/sdk-core';
 import axios from 'axios';
 import { BigNumber, ethers } from 'ethers';
 
+import { PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
 import { NOTIFICATION_TIMEOUT_MS } from '../../../lib/constants';
 import { AnalyticsEventType, QuoteRequest, WebhookResponseType } from '../../../lib/entities';
 import { MockWebhookConfigurationProvider, ProtocolVersion } from '../../../lib/providers';
@@ -16,7 +17,6 @@ import {
   WEBHOOK_URL_ONEINCH,
   WEBHOOK_URL_SEARCHER,
 } from '../../fixtures';
-import { PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
 
 jest.mock('axios');
 jest.mock('../../../lib/providers/analytics');
@@ -62,7 +62,7 @@ describe('WebhookQuoter tests', () => {
     },
   ]);
 
-  const logger = { child: () => logger, info: jest.fn(), error: jest.fn(), debug: jest.fn() } as any;
+  const logger = { child: jest.fn(() => logger), info: jest.fn(), error: jest.fn(), debug: jest.fn() } as any;
   const mockFirehoseLogger = new FirehoseLogger(logger, 'arn:aws:deliverystream/dummy');
   const webhookQuoter = new WebhookQuoter(
     logger,
@@ -306,7 +306,7 @@ describe('WebhookQuoter tests', () => {
             },
           });
         });
-      
+
       const permissionedTokenRequest = makeQuoteRequest({
         tokenIn: PERMISSIONED_TOKENS[0].address,
         protocol: ProtocolVersion.V2,
@@ -349,7 +349,7 @@ describe('WebhookQuoter tests', () => {
             },
           });
         });
-      
+
       const permissionedTokenRequest = makeQuoteRequest({
         tokenOut: PERMISSIONED_TOKENS[0].address,
         protocol: ProtocolVersion.V2,
@@ -392,7 +392,7 @@ describe('WebhookQuoter tests', () => {
             },
           });
         });
-      
+
       const permissionedTokenRequest = makeQuoteRequest({
         tokenIn: PERMISSIONED_TOKENS[0].address,
         protocol: ProtocolVersion.V1, // 1Inch only supports v2
@@ -708,6 +708,7 @@ describe('WebhookQuoter tests', () => {
 
     expect(logger.debug).toHaveBeenCalledWith(
       {
+        requestId: request.requestId,
         configuredChainIds: [4, 5, 6],
         chainId: request.tokenInChainId,
       },
@@ -832,6 +833,11 @@ describe('WebhookQuoter tests', () => {
       });
     });
     const response = await webhookQuoter.quote(request);
+    // logs in fetchQuote go through a child logger bound with the request + quote ids
+    expect(logger.child).toHaveBeenCalledWith({
+      requestId: request.requestId,
+      quoteId: expect.any(String),
+    });
     expect(logger.info).toHaveBeenCalledWith(
       {
         response: '',

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -706,9 +706,10 @@ describe('WebhookQuoter tests', () => {
 
     expect(response.length).toEqual(0);
 
+    // requestId is bound on the child logger (asserted via logger.child elsewhere), not on the log object.
+    expect(logger.child).toHaveBeenCalledWith({ requestId: request.requestId });
     expect(logger.debug).toHaveBeenCalledWith(
       {
-        requestId: request.requestId,
         configuredChainIds: [4, 5, 6],
         chainId: request.tokenInChainId,
       },
@@ -833,11 +834,9 @@ describe('WebhookQuoter tests', () => {
       });
     });
     const response = await webhookQuoter.quote(request);
-    // logs in fetchQuote go through a child logger bound with the request + quote ids
-    expect(logger.child).toHaveBeenCalledWith({
-      requestId: request.requestId,
-      quoteId: expect.any(String),
-    });
+    // logs in fetchQuote go through a child logger bound with the request id, then enriched with the quote id
+    expect(logger.child).toHaveBeenCalledWith({ requestId: request.requestId });
+    expect(logger.child).toHaveBeenCalledWith({ quoteId: expect.any(String) });
     expect(logger.info).toHaveBeenCalledWith(
       {
         response: '',


### PR DESCRIPTION
## Problem

The `WebhookQuoter` logs — including the **`Webhook elected not to quote`** line — don't carry `requestId` or `quoteId`, making them hard to correlate with a specific request/RFQ.

Root cause: `WebhookQuoter` is constructed once at container-injection time (`injector.ts:74`) with the **base** logger. The per-request child logger that binds `requestId` is created later, per-request, in `getRequestInjected` (`injector.ts:106`) and is never handed to the quoter. So `this.log` only has `{ quoter: 'WebhookQuoter' }` bound — no `requestId`, no `quoteId`.

## Change

In `fetchQuote`, create a child logger bound with the request + per-RFQ quote ids and route every per-RFQ log through it:

```ts
const log = this.log.child({ requestId: cleanRequest.requestId, quoteId: cleanRequest.quoteId });
```

- All per-RFQ logs now go through `log` (raw response, elected-not-to-quote, validation failure, response-id mismatch, success, opposing-side, axios error, other error) — so each carries `requestId` + `quoteId`.
- The `RFQValidator.validatePermissionedTokens` call is passed this child logger too, so its logs are traceable as well.
- The two pre-dispatch `debug` logs (chainId not configured / protocol unsupported) and the request-level logs in `quote()` (`Fetching quotes…`, `Notified disabled endpoints`) get `requestId` added directly — there's no per-RFQ `quoteId` at that point (it's generated per endpoint inside `fetchQuote`).

No behavior change beyond logging.

## Tests

- Updated the `chainId not configured` debug assertion to include `requestId`.
- Made the test logger's `child` a spy and added an assertion that `fetchQuote` binds `{ requestId, quoteId }` — locking in that the ids are actually attached (the mock returns self, so without this the bound fields aren't otherwise observed in tests).
- `WebhookQuoter` suite: 21/21 passing; build + eslint clean.

## Scope

Scoped to `WebhookQuoter` (the source of the cited log) — the coherent unit where the ids were missing. Handler-level logs already bind `requestId` via the injector. Happy to extend to other spots if you want a broader sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)