### PR TITLE
feat: trigger circuit breaker on Laplace-smoothed fade rate

### DIFF
--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -59,7 +59,7 @@ export class CronStack extends cdk.NestedStack {
       bucketName: `${FADE_RATE_BUCKET}-${stage}-1`,
     });
 
-    const chatbotTopic = chatbotSNSArn 
+    const chatbotTopic = chatbotSNSArn
       ? cdk.aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn)
       : undefined;
 
@@ -199,6 +199,22 @@ export class CronStack extends cdk.NestedStack {
       ...PROD_TABLE_CAPACITY.timestamps,
     });
     this.alarmsPerTable(fillerCBTimestampsTable, DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS, chatbotTopic);
+
+    // V2 circuit-breaker state table, created alongside (not replacing) the V1 table above so
+    // the rate-based breaker can be rolled back cleanly. Same key schema; state is derived and
+    // starts empty. Remove the V1 table in a follow-up once V2 is confirmed stable.
+    const fillerCBTimestampsV2Table = new aws_dynamo.Table(this, `${SERVICE_NAME}FillerCBTimestampsV2Table`, {
+      tableName: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS_V2,
+      partitionKey: {
+        name: 'hash',
+        type: aws_dynamo.AttributeType.STRING,
+      },
+      deletionProtection: true,
+      pointInTimeRecovery: true,
+      contributorInsightsEnabled: true,
+      ...PROD_TABLE_CAPACITY.timestamps,
+    });
+    this.alarmsPerTable(fillerCBTimestampsV2Table, DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS_V2, chatbotTopic);
   }
 
   private alarmsPerTable(table: aws_dynamo.Table, name: string, chatbotSNSTopic?: ITopic): void {

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -200,9 +200,8 @@ export class CronStack extends cdk.NestedStack {
     });
     this.alarmsPerTable(fillerCBTimestampsTable, DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS, chatbotTopic);
 
-    // V2 circuit-breaker state table, created alongside (not replacing) the V1 table above so
-    // the rate-based breaker can be rolled back cleanly. Same key schema; state is derived and
-    // starts empty. Remove the V1 table in a follow-up once V2 is confirmed stable.
+    // V2 circuit-breaker state table, separate from the V1 table so the rate-based breaker's
+    // state is isolated for independent rollout/rollback. State is derived and starts empty.
     const fillerCBTimestampsV2Table = new aws_dynamo.Table(this, `${SERVICE_NAME}FillerCBTimestampsV2Table`, {
       tableName: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS_V2,
       partitionKey: {

--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -10,6 +10,7 @@ import {
   Metric,
   SoftQuoteMetricDimension,
 } from '../../lib/entities';
+import { FADE_RATE_BLOCK_THRESHOLD } from '../../lib/cron/fade-rate-v2';
 import { ChainId, SUPPORTED_CHAINS } from '../../lib/util/chains';
 
 export const NAMESPACE = 'Uniswap';
@@ -45,6 +46,12 @@ export type LambdaWidget = {
         label: string;
         showUnits: boolean;
       };
+    };
+    annotations?: {
+      horizontal: {
+        label?: string;
+        value: number;
+      }[];
     };
   };
 };
@@ -290,7 +297,7 @@ const FailingRFQLogsWidget = (region: string, logGroup: string): LambdaWidget =>
     width: 24,
     height: 6,
     properties: {
-      query: `SOURCE '${logGroup}' | fields @timestamp, msg\n| filter quoter = 'WebhookQuoter' and msg like \"Error fetching quote\"\n| sort @timestamp desc\n| limit 20`,
+      query: `SOURCE '${logGroup}' | fields @timestamp, msg\n| filter quoter = 'WebhookQuoter' and msg like "Error fetching quote"\n| sort @timestamp desc\n| limit 20`,
       region,
       stacked: false,
       view: 'table',
@@ -360,29 +367,97 @@ const RFQFailRatesWidget = (region: string, rfqProviders: string[]): LambdaWidge
     };
   });
 
-const CircuitBreakerV2Widget = (region: string): LambdaWidget => {
-  return {
-    height: 11,
-    width: 11,
+const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
+  // How often the breaker fires: new blocks / extensions per run, fillers currently benched,
+  // and how many fillers were evaluated (sample-health denominator).
+  {
+    height: 8,
+    width: 12,
     type: 'metric',
     properties: {
       metrics: [
         [
           'Uniswap',
-          Metric.CIRCUIT_BREAKER_V2_BLOCKED,
+          Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS,
           'Service',
           CircuitBreakerMetricDimension.Service,
-          { stat: 'Average', label: 'avg' },
+          { stat: 'Sum', label: 'new blocks' },
+        ],
+        ['.', Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, '.', '.', { stat: 'Sum', label: 'extended blocks' }],
+        ['.', Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS, '.', '.', { stat: 'Maximum', label: 'active blocks' }],
+        ['.', Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, '.', '.', { stat: 'Maximum', label: 'fillers evaluated' }],
+      ],
+      view: 'timeSeries',
+      stacked: false,
+      region,
+      period: 600,
+      title: 'Circuit Breaker Activity | 10 minutes',
+    },
+  },
+  // Per-filler smoothed fade rates against the block threshold: healthy fillers should sit
+  // near the 5% prior; anyone trending toward the 12% line is about to be benched. The
+  // during-block rate is charted alongside because a benched filler's post-block fade rate
+  // sits at the prior — the during-block rate is what shows them above the threshold.
+  {
+    height: 8,
+    width: 12,
+    type: 'metric',
+    properties: {
+      metrics: [
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_FADE_RATE}_', 'Average', 600)`,
+            id: 'fadeRates',
+            region,
+          },
+        ],
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE}_', 'Average', 600)`,
+            id: 'duringBlockRates',
+            region,
+          },
         ],
       ],
       view: 'timeSeries',
       stacked: false,
       region,
       period: 600,
-      title: 'Blocked Filler On Average | 10 minutes',
+      title: 'Filler Fade Rates (smoothed) vs Block Threshold',
+      yAxis: {
+        left: {
+          label: 'fade rate',
+          showUnits: false,
+        },
+      },
+      annotations: {
+        horizontal: [{ label: 'block threshold', value: FADE_RATE_BLOCK_THRESHOLD }],
+      },
     },
-  };
-};
+  },
+  // Escalation state per filler: repeat offenders climb, recovered fillers decay back to 0.
+  {
+    height: 8,
+    width: 12,
+    type: 'metric',
+    properties: {
+      metrics: [
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS}_', 'Maximum', 600)`,
+            id: 'consecutiveBlocks',
+            region,
+          },
+        ],
+      ],
+      view: 'timeSeries',
+      stacked: false,
+      region,
+      period: 600,
+      title: 'Filler Consecutive Blocks (escalation)',
+    },
+  },
+];
 
 export interface DashboardProps extends cdk.NestedStackProps {
   quoteLambda: aws_lambda_nodejs.NodejsFunction;
@@ -412,7 +487,7 @@ export class ParamDashboardStack extends cdk.NestedStack {
           RFQFailRatesWidget(region, RFQ_PROVIDERS),
           LambdaErrorRatesWidget(region, scope),
           FailingRFQLogsWidget(region, props.quoteLambda.logGroup.logGroupArn),
-          CircuitBreakerV2Widget(region),
+          CircuitBreakerWidgets(region),
         ].flat(),
       }),
     });

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -29,6 +29,16 @@ module.exports = {
         { AttributeName: 'hash', AttributeType: 'S' },
       ],
       ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
+    },
+    {
+      TableName: 'FillerCBTimestampsV2',
+      KeySchema: [
+        { AttributeName: 'hash', KeyType: 'HASH' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'hash', AttributeType: 'S' },
+      ],
+      ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
     }
   ],
   port: 8000,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -17,6 +17,11 @@ export const DYNAMO_TABLE_NAME = {
   SYNTHETIC_SWITCH_TABLE: 'SyntheticSwitchTable',
   FILLER_ADDRESS: 'FillerAddress',
   FILLER_CB_TIMESTAMPS: 'FillerCBTimestamps',
+  // V2 circuit-breaker state table. Introduced as a separate table (not a rename of the
+  // above) so the rate-based breaker can be rolled back cleanly: the old code keeps writing
+  // FillerCBTimestamps, the new code writes only here, and neither contaminates the other.
+  // State is derived (recomputed each cron run from Redshift), so this starts empty.
+  FILLER_CB_TIMESTAMPS_V2: 'FillerCBTimestampsV2',
 };
 
 export const DYNAMO_TABLE_KEY = {
@@ -29,7 +34,8 @@ export const DYNAMO_TABLE_KEY = {
   LOWER: 'lower',
   ENABLED: 'enabled',
   BLOCK_UNTIL_TIMESTAMP: 'blockUntilTimestamp',
-  LAST_POST_TIMESTAMP: 'lastPostTimestamp',
+  LAST_EXAMINED_TIMESTAMP: 'lastExaminedTimestamp',
+  FADE_WINDOW_START: 'fadeWindowStart',
   FADED: 'faded',
   CONSECUTIVE_BLOCKS: 'consecutiveBlocks',
 };
@@ -67,4 +73,4 @@ export const RPC_HEADERS: { [key: string]: string } = {
   // via the RPC_HEADER_SECRET env var (sourced from Secrets Manager); omitted
   // when unset (e.g. local dev / unit tests).
   ...(process.env.RPC_HEADER_SECRET ? { 'x-internal-service-secret': process.env.RPC_HEADER_SECRET } : {}),
-}
+};

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -17,10 +17,9 @@ export const DYNAMO_TABLE_NAME = {
   SYNTHETIC_SWITCH_TABLE: 'SyntheticSwitchTable',
   FILLER_ADDRESS: 'FillerAddress',
   FILLER_CB_TIMESTAMPS: 'FillerCBTimestamps',
-  // V2 circuit-breaker state table. Introduced as a separate table (not a rename of the
-  // above) so the rate-based breaker can be rolled back cleanly: the old code keeps writing
-  // FillerCBTimestamps, the new code writes only here, and neither contaminates the other.
-  // State is derived (recomputed each cron run from Redshift), so this starts empty.
+  // V2 circuit-breaker state table, separate from FILLER_CB_TIMESTAMPS so the rate-based
+  // breaker's state is isolated for independent rollout/rollback. State is derived
+  // (recomputed each cron run from Redshift), so it starts empty.
   FILLER_CB_TIMESTAMPS_V2: 'FillerCBTimestampsV2',
 };
 

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -121,6 +121,14 @@ async function main(metrics: MetricsLogger) {
   }
 }
 
+// parseInt on a missing/malformed Dynamo attribute yields NaN. A NaN timestamp must not
+// be treated as a real value: e.g. `deadline > NaN` is always false, which would silently
+// zero out the fade-rate window and make a filler permanently unblockable. Coerce any
+// non-finite stored timestamp back to the "unset" sentinel.
+function finiteOr(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) ? (value as number) : fallback;
+}
+
 function newConsecutiveBlocks(consecutiveBlocks?: number): number {
   if (!consecutiveBlocks) {
     return 1;
@@ -213,7 +221,7 @@ export function calculateNewTimestamps(
       updatedTimestamps.push({
         hash,
         lastPostTimestamp: newPostTimestamp,
-        blockUntilTimestamp: fillerTimestamp?.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+        blockUntilTimestamp: finiteOr(fillerTimestamp?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP),
         consecutiveBlocks: decayedBlocks,
       });
     }
@@ -274,13 +282,14 @@ export function getFillersFadeStats(
       tallies[fillerHash] = { windowFades: 0, windowTotal: 0, newFades: 0 };
     }
     // Rate window: orders completed after the filler's last block ended (clean slate).
-    const windowStart = fillerTimestamp?.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP;
+    const windowStart = finiteOr(fillerTimestamp?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
     if (row.deadline > windowStart) {
       tallies[fillerHash].windowTotal += 1;
       tallies[fillerHash].windowFades += row.faded;
     }
     // New fades since the last cron run (deadline-based; catches in-flight orders).
-    if (!fillerTimestamp || row.deadline > fillerTimestamp.lastPostTimestamp) {
+    const lastPostTimestamp = finiteOr(fillerTimestamp?.lastPostTimestamp, 0);
+    if (!fillerTimestamp || row.deadline > lastPostTimestamp) {
       tallies[fillerHash].newFades += row.faded;
     }
   });

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -34,11 +34,11 @@ export const BASE_BLOCK_SECS = 60 * 15; // 15 minutes
 
 // Laplace (additive) smoothing applied to each filler's fade rate so a few fades on a
 // small sample don't trip the breaker. Equivalent to seeding every filler with ALPHA
-// pretend-fades and BETA pretend-clean-fills. Prior mean = ALPHA/(ALPHA+BETA) ≈ 4.8%.
+// pretend-fades and BETA pretend-clean-fills. Prior mean = ALPHA/(ALPHA+BETA) = 1/20 = 5%.
 export const LAPLACE_ALPHA = 1;
-export const LAPLACE_BETA = 20;
+export const LAPLACE_BETA = 19;
 // Block a filler once their smoothed fade rate exceeds this. MUST be greater than the
-// prior mean (~4.8%), otherwise the prior alone would block every filler.
+// prior mean (5%), otherwise the prior alone would block every filler.
 // At this threshold a filler needs e.g. ~3 fades in 10 orders, ~4 in 20, ~8 in 50.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -21,11 +21,26 @@ import { DynamoFillerAddressRepository } from '../repositories/filler-address-re
 import { TimestampRepository } from '../repositories/timestamp-repository';
 import { STAGE } from '../util/stage';
 
-export type FillerFades = Record<string, number>;
+export type FillerFadeStats = {
+  // Laplace-smoothed fade rate over the filler's post-block window (see getFillersFadeStats).
+  fadeRate: number;
+  // Orders that faded since the last cron run; used to stack penalties while already blocked.
+  newFades: number;
+};
+export type FillerFadeStatsMap = Record<string, FillerFadeStats>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
 
 export const BASE_BLOCK_SECS = 60 * 15; // 15 minutes
-export const NUM_FADES_MULTIPLIER = 1.2;
+
+// Laplace (additive) smoothing applied to each filler's fade rate so a few fades on a
+// small sample don't trip the breaker. Equivalent to seeding every filler with ALPHA
+// pretend-fades and BETA pretend-clean-fills. Prior mean = ALPHA/(ALPHA+BETA) ≈ 4.8%.
+export const LAPLACE_ALPHA = 1;
+export const LAPLACE_BETA = 20;
+// Block a filler once their smoothed fade rate exceeds this. MUST be greater than the
+// prior mean (~4.8%), otherwise the prior alone would block every filler.
+// At this threshold a filler needs e.g. ~3 fades in 10 orders, ~4 in 20, ~8 in 50.
+export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 
 /** Sentinel when the filler has no active block (always < now for real unix seconds). Avoids equaling lastPostTimestamp, which could briefly read as blocked under clock skew. */
 export const UNBLOCKED_BLOCK_UNTIL_TIMESTAMP = 0;
@@ -80,18 +95,18 @@ async function main(metrics: MetricsLogger) {
     const addressToFillerMap = await fillerAddressRepo.getAddressToFillerMap(fillerEndpoints);
     const fillerTimestamps = await timestampDB.getFillerTimestampsMap(fillerEndpoints);
 
-    // get fillers new fades from last checked timestamp:
-    //  | hash     |    faded  |   postTimestamp  |
-    //  |---- foo -|---- 3 ----|---- 12345678 ----|
-    //  |---- bar -|---- 1 ----|---- 12222222 ----|
-    const fillersNewFades = getFillersNewFades(result, addressToFillerMap, fillerTimestamps, log);
+    // compute each filler's Laplace-smoothed fade rate (and new fades since last run):
+    //  | hash     |  fadeRate  |  newFades  |
+    //  |---- foo -|---- 0.18 --|---- 3 -----|
+    //  |---- bar -|---- 0.05 --|---- 0 -----|
+    const fillerFadeStats = getFillersFadeStats(result, addressToFillerMap, fillerTimestamps, log);
 
     //  | hash        |lastPostTimestamp|blockUntilTimestamp|
     //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
     //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
     const updatedTimestamps = calculateNewTimestamps(
       fillerTimestamps,
-      fillersNewFades,
+      fillerFadeStats,
       Math.floor(Date.now() / 1000),
       log,
       metrics
@@ -118,38 +133,38 @@ function newConsecutiveBlocks(consecutiveBlocks?: number): number {
 
 /* compute blockUntil timestamp for each filler
   If currently blocked:
-    - With new fades: EXTEND the block from current blockUntil and increment consecutiveBlocks
+    - With new fades (in-flight orders that faded while blocked): EXTEND the block from
+      current blockUntil and increment consecutiveBlocks
     - Without new fades: keep existing block (don't decay while blocked)
   If not blocked:
-    - With new fades: calculate new block, increment consecutiveBlocks
-    - Without new fades: decay consecutiveBlocks by 1
+    - Fade rate over threshold: block, increment consecutiveBlocks
+    - Fade rate under threshold: decay consecutiveBlocks by 1, and KEEP the (now past)
+      blockUntilTimestamp so it remains the clean-slate floor for the rate window
 */
 export function calculateNewTimestamps(
   fillerTimestamps: FillerTimestamps,
-  fillersNewFades: FillerFades,
+  fillerFadeStats: FillerFadeStatsMap,
   newPostTimestamp: number,
   log?: Logger,
   metrics?: MetricsLogger
 ): ToUpdateTimestampRow[] {
   const updatedTimestamps: ToUpdateTimestampRow[] = [];
-  Object.entries(fillersNewFades).forEach((row) => {
-    const hash = row[0];
-    const fades = row[1];
+  Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
+    const { fadeRate, newFades } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
 
-    if (isCurrentlyBlocked && fades) {
-      // Stack penalties while blocked
-      // Extend the block from current blockUntil, not from now
+    if (isCurrentlyBlocked && newFades > 0) {
+      // Faded again on in-flight orders while blocked: stack the penalty.
+      // Extend the block from current blockUntil, not from now.
       const extendedBlockUntil = calculateBlockUntilTimestamp(
         fillerTimestamp.blockUntilTimestamp, // Extend from when current block ends
-        fillerTimestamp.consecutiveBlocks,
-        fades
+        fillerTimestamp.consecutiveBlocks
       );
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
 
       log?.info(
-        { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, fades },
+        { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, newFades },
         'Extending block for filler who faded while blocked'
       );
       metrics?.putMetric(
@@ -172,13 +187,11 @@ export function calculateNewTimestamps(
         blockUntilTimestamp: fillerTimestamp.blockUntilTimestamp,
         consecutiveBlocks: fillerTimestamp.consecutiveBlocks,
       });
-    } else if (fades) {
-      const blockUntilTimestamp = calculateBlockUntilTimestamp(
-        newPostTimestamp,
-        fillerTimestamp?.consecutiveBlocks,
-        fades
-      );
+    } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD) {
+      const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
+
+      log?.info({ hash, fadeRate, blockUntilTimestamp }, 'Blocking filler for exceeding fade rate threshold');
       metrics?.putMetric(
         metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash),
         consecutiveBlocks,
@@ -192,13 +205,15 @@ export function calculateNewTimestamps(
         consecutiveBlocks: consecutiveBlocks,
       });
     } else {
-      // no new fades, decay consecutive blocks gradually instead of resetting
-      // This prevents gaming by alternating fade/clean cycles
+      // Under threshold: decay consecutiveBlocks gradually instead of resetting (prevents
+      // gaming via alternating fade/clean cycles). Preserve the existing (now past)
+      // blockUntilTimestamp: it's the clean-slate floor so a returning filler is scored
+      // only on orders completed after their last block ended.
       const decayedBlocks = Math.max(0, (fillerTimestamp?.consecutiveBlocks || 0) - 1);
       updatedTimestamps.push({
         hash,
         lastPostTimestamp: newPostTimestamp,
-        blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+        blockUntilTimestamp: fillerTimestamp?.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         consecutiveBlocks: decayedBlocks,
       });
     }
@@ -207,77 +222,92 @@ export function calculateNewTimestamps(
   return updatedTimestamps;
 }
 
-/* find the number of new fades, for each filler entity, from 
-   the last time this cron is run
+/* Laplace-smoothed fade rate: pretend we've already seen LAPLACE_ALPHA fades and
+   LAPLACE_BETA clean fills, so small samples are pulled toward the prior mean instead
+   of swinging to 0% or 100%. */
+export function laplaceSmoothedFadeRate(fades: number, total: number): number {
+  return (fades + LAPLACE_ALPHA) / (total + LAPLACE_ALPHA + LAPLACE_BETA);
+}
+
+/* Compute, per filler, the Laplace-smoothed fade rate and the number of fades since
+   the last cron run.
    @param rows: info about individual orders: filler address, faded or not, deadline (completion time)
    @param fillerTimestamps: last checked timestamp and block until timestamp for each filler
    @param addressToFillerMap: map of address to filler hash
-   
-   NOTE: We use `deadline` (order completion time) instead of `postTimestamp` to determine
-   "new" orders. This ensures orders that were posted before the last cron run but completed
-   after are still counted, preventing the "in-flight orders" exploit.
+
+   The fade rate is computed over the filler's "post-block window" — orders whose deadline
+   is after their last blockUntilTimestamp. This is the clean-slate mechanism: a filler who
+   served a block is scored only on orders completed after the block ended, not on the
+   pre-block fades that are still inside the query's rolling window. While a filler is
+   currently blocked the floor is in the future, so windowTotal is ~0 and the rate sits at
+   the prior — only newFades (used by calculateNewTimestamps) can extend an active block.
+
+   NOTE: We use `deadline` (order completion time) instead of `postTimestamp` for newFades.
+   This ensures orders posted before the last cron run but completed after are still counted,
+   preventing the "in-flight orders" exploit.
 */
-export function getFillersNewFades(
+export function getFillersFadeStats(
   rows: V2FadesRowType[],
   addressToFillerMap: Map<string, string>,
   fillerTimestamps: FillerTimestamps,
   log?: Logger
-): FillerFades {
+): FillerFadeStatsMap {
   log?.info(
     {
       rows: rows,
       fillerTimestamps: [...fillerTimestamps.entries()],
       addressToFillerMap: [...addressToFillerMap.entries()],
     },
-    'getFillersNewFades'
+    'getFillersFadeStats'
   );
-  const newFadesMap: FillerFades = {}; // filler hash -> # of new fades
+  // filler hash -> tallies used to derive the stats below
+  const tallies: Record<string, { windowFades: number; windowTotal: number; newFades: number }> = {};
   rows.forEach((row) => {
     const fillerAddr = ethers.utils.getAddress(row.fillerAddress);
     const fillerHash = addressToFillerMap.get(fillerAddr);
     if (!fillerHash) {
       log?.info({ fillerAddr }, 'filler address not found dynamo mapping');
-    } else if (
-      // Use deadline (completion time) instead of postTimestamp to catch orders
-      // that were posted before lastPostTimestamp but completed after
-      (fillerTimestamps.has(fillerHash) && row.deadline > fillerTimestamps.get(fillerHash)!.lastPostTimestamp) ||
-      !fillerTimestamps.has(fillerHash)
-    ) {
-      if (!newFadesMap[fillerHash]) {
-        newFadesMap[fillerHash] = row.faded;
-      } else {
-        newFadesMap[fillerHash] += row.faded;
-      }
+      return;
+    }
+    const fillerTimestamp = fillerTimestamps.get(fillerHash);
+    if (!tallies[fillerHash]) {
+      tallies[fillerHash] = { windowFades: 0, windowTotal: 0, newFades: 0 };
+    }
+    // Rate window: orders completed after the filler's last block ended (clean slate).
+    const windowStart = fillerTimestamp?.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP;
+    if (row.deadline > windowStart) {
+      tallies[fillerHash].windowTotal += 1;
+      tallies[fillerHash].windowFades += row.faded;
+    }
+    // New fades since the last cron run (deadline-based; catches in-flight orders).
+    if (!fillerTimestamp || row.deadline > fillerTimestamp.lastPostTimestamp) {
+      tallies[fillerHash].newFades += row.faded;
     }
   });
-  log?.info({ newFadesMap }, '# of new fades by filler');
-  return newFadesMap;
+
+  const stats: FillerFadeStatsMap = {};
+  Object.entries(tallies).forEach(([hash, t]) => {
+    stats[hash] = {
+      fadeRate: laplaceSmoothedFadeRate(t.windowFades, t.windowTotal),
+      newFades: t.newFades,
+    };
+  });
+  log?.info({ stats }, 'fade stats by filler');
+  return stats;
 }
 
 /*
-  calculate the block until timestamp with exponential backoff
-  if a filler faded multiple times in between the last post timestamp and now,
-    we apply a 1.2 multiplier for each fade
-    
-    examples:
-    - 1 fade, 0 consecutive blocks: 15 minutes
-    - 1 fade, 1 consecutive blocks:  (1.2 ^ 0) * 15 * 2^1 = 30 minutes
-    - 1 fade, 2 consecutive blocks:  (1.2 ^ 0) * 15 * 2^2 = 60 minutes
-    - 1 fade, 3 consecutive blocks:  (1.2 ^ 0) * 15 * 2^3 = 120 minutes
-    - 2 fades, 0 consecutive blocks: (1.2 ^ 1) * 15 * 2^0 = 18 minutes
-    - 2 fades 1 consecutive blocks:  (1.2 ^ 1) * 15 * 2^1 = 36 minutes
-    - 2 fades 2 consecutive blocks:  (1.2 ^ 1) * 15 * 2^2 = 72 minute
-    - 3 fades 0 consecutive blocks:  (1.2 ^ 2) * 15 * 2^0 = 21 minutes
-    - 3 fades 1 consecutive blocks:  (1.2 ^ 2) * 15 * 2^1 = 43 minutes
-    - 3 fades 2 consecutive blocks:  (1.2 ^ 2) * 15 * 2^2 = 86 minutes
+  calculate the block until timestamp with exponential backoff on consecutive blocks.
+  Block length depends only on how many times the filler has been blocked in a row, not
+  on the absolute fade count, so high-volume fillers aren't penalized for volume.
+
+    examples (BASE_BLOCK_SECS = 15 min):
+    - 0 consecutive blocks: 15 * 2^0 = 15 minutes
+    - 1 consecutive block:  15 * 2^1 = 30 minutes
+    - 2 consecutive blocks: 15 * 2^2 = 60 minutes
+    - 3 consecutive blocks: 15 * 2^3 = 120 minutes
 */
-export function calculateBlockUntilTimestamp(
-  newPostTimestamp: number,
-  consecutiveBlocks: number | undefined,
-  fades: number
-): number {
+export function calculateBlockUntilTimestamp(fromTimestamp: number, consecutiveBlocks: number | undefined): number {
   const blocks = consecutiveBlocks || 0;
-  return Math.floor(
-    newPostTimestamp + BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, fades - 1) * Math.pow(2, blocks)
-  );
+  return Math.floor(fromTimestamp + BASE_BLOCK_SECS * Math.pow(2, blocks));
 }

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -78,7 +78,7 @@ const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
   },
 });
 const fillerAddressRepo = DynamoFillerAddressRepository.create(documentClient);
-const timestampDB = TimestampRepository.create(documentClient);
+const timestampDB = TimestampRepository.create();
 
 export const handler: ScheduledHandler = metricScope((metrics) => async (_event: EventBridgeEvent<string, void>) => {
   await main(metrics);
@@ -116,7 +116,7 @@ async function main(metrics: MetricsLogger) {
     //  |---- bar -|---- 0.05 --|------ 0.20 -------|
     const fillerFadeStats = getFillersFadeStats(result, addressToFillerMap, fillerTimestamps, log);
 
-    //  | hash        |lastPostTimestamp|blockUntilTimestamp|
+    //  | hash        |lastExaminedTimestamp|blockUntilTimestamp|fadeWindowStart|
     //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
     //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
     const updatedTimestamps = calculateNewTimestamps(
@@ -134,14 +134,6 @@ async function main(metrics: MetricsLogger) {
       log.info('no timestamp to update');
     }
   }
-}
-
-// TimestampRepository coerces NaN at the parse boundary, so stored rows should already be
-// finite. Kept as defense-in-depth for timestamps arriving from other sources: a NaN here
-// would poison comparisons (`deadline > NaN` is always false), silently zeroing the
-// fade-rate window and making a filler permanently unblockable.
-function finiteOr(value: number | undefined, fallback: number): number {
-  return Number.isFinite(value) ? (value as number) : fallback;
 }
 
 function newConsecutiveBlocks(consecutiveBlocks?: number): number {
@@ -163,9 +155,14 @@ function newConsecutiveBlocks(consecutiveBlocks?: number): number {
     - Post-block fade rate over threshold — or the during-block cohort over threshold
       (late in-flight fades from a block that expired between cron runs): block,
       increment consecutiveBlocks
-    - Otherwise: decay consecutiveBlocks by 1 — but only if the filler completed new
-      orders since the last run (idling must not work off escalation) — and KEEP the
-      (now past) blockUntilTimestamp so it remains the clean-slate floor for the rate window
+    - Otherwise: reset blockUntilTimestamp to unblocked and decay consecutiveBlocks by 1 —
+      but only if the filler completed new orders since the last run (idling must not work
+      off escalation). fadeWindowStart is left untouched so the clean-slate floor persists.
+
+  blockUntilTimestamp is the block expiry (used for the is-blocked check). fadeWindowStart is
+  the clean-slate floor for the fade-rate window; a block/extension sets both to the block end,
+  so while blocked the floor is in the future (window empty) and after expiry it is the past
+  block end (a returning filler is scored only on orders completed after their block ended).
 */
 export function calculateNewTimestamps(
   fillerTimestamps: FillerTimestamps,
@@ -203,16 +200,18 @@ export function calculateNewTimestamps(
 
       updatedTimestamps.push({
         hash,
-        lastPostTimestamp: newPostTimestamp,
+        lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: extendedBlockUntil,
+        fadeWindowStart: extendedBlockUntil, // clean slate resumes when the extended block ends
         consecutiveBlocks,
       });
     } else if (isCurrentlyBlocked) {
-      // Blocked but no new fades - keep existing block, don't decay
+      // Blocked but no new fades - keep existing block and floor, don't decay
       updatedTimestamps.push({
         hash,
-        lastPostTimestamp: newPostTimestamp,
+        lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: fillerTimestamp.blockUntilTimestamp,
+        fadeWindowStart: fillerTimestamp.fadeWindowStart,
         consecutiveBlocks: fillerTimestamp.consecutiveBlocks,
       });
     } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD || duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
@@ -240,24 +239,28 @@ export function calculateNewTimestamps(
 
       updatedTimestamps.push({
         hash,
-        lastPostTimestamp: newPostTimestamp,
+        lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp,
+        fadeWindowStart: blockUntilTimestamp, // clean slate resumes when the block ends
         consecutiveBlocks: consecutiveBlocks,
       });
     } else {
-      // Under threshold: decay consecutiveBlocks gradually instead of resetting (prevents
-      // gaming via alternating fade/clean cycles). Decay only when the filler completed new
-      // orders since the last run — without this gate, stale rows lingering in the 24h view
-      // would decay escalation every 10-minute run while the filler simply idles (raised in
-      // review). Working off escalation requires demonstrated clean activity.
-      // Preserve the existing (now past) blockUntilTimestamp: it's the clean-slate floor so
-      // a returning filler is scored only on orders completed after their last block ended.
+      // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked, and decay
+      // consecutiveBlocks gradually instead of resetting (prevents gaming via alternating
+      // fade/clean cycles). Decay only when the filler completed new orders since the last
+      // run — without this gate, stale rows lingering in the 24h view would decay escalation
+      // every 10-minute run while the filler simply idles (raised in review). Working off
+      // escalation requires demonstrated clean activity.
+      // fadeWindowStart is preserved (not written from blockUntilTimestamp): it independently
+      // holds the last block end as the clean-slate floor so a returning filler is scored
+      // only on orders completed after their block ended.
       const currentBlocks = fillerTimestamp?.consecutiveBlocks || 0;
       const decayedBlocks = newCompletions > 0 ? Math.max(0, currentBlocks - 1) : currentBlocks;
       updatedTimestamps.push({
         hash,
-        lastPostTimestamp: newPostTimestamp,
-        blockUntilTimestamp: finiteOr(fillerTimestamp?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP),
+        lastExaminedTimestamp: newPostTimestamp,
+        blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+        fadeWindowStart: fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         consecutiveBlocks: decayedBlocks,
       });
     }
@@ -278,7 +281,7 @@ export function laplaceSmoothedFadeRate(fades: number, total: number): number {
    @param fillerTimestamps: last checked timestamp and block until timestamp for each filler
    @param addressToFillerMap: map of address to filler hash
 
-   - fadeRate: orders whose deadline is after the filler's last blockUntilTimestamp
+   - fadeRate: orders whose deadline is after the filler's fadeWindowStart (last block end)
      ("post-block window"). This is the clean-slate mechanism: a filler who served a block
      is scored only on orders completed after the block ended, not on the pre-block fades
      that are still inside the query's rolling window. While a filler is currently blocked
@@ -324,16 +327,16 @@ export function getFillersFadeStats(
     if (!tallies[fillerHash]) {
       tallies[fillerHash] = { windowFades: 0, windowTotal: 0, blockFades: 0, blockTotal: 0, newCompletions: 0 };
     }
-    const windowStart = finiteOr(fillerTimestamp?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
-    const lastPostTimestamp = finiteOr(fillerTimestamp?.lastPostTimestamp, 0);
-    if (row.deadline > lastPostTimestamp) {
+    const windowStart = fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP;
+    const lastExaminedTimestamp = fillerTimestamp?.lastExaminedTimestamp ?? 0;
+    if (row.deadline > lastExaminedTimestamp) {
       tallies[fillerHash].newCompletions += 1;
     }
     if (row.deadline > windowStart) {
       // Rate window: orders completed after the filler's last block ended (clean slate).
       tallies[fillerHash].windowTotal += 1;
       tallies[fillerHash].windowFades += row.faded;
-    } else if (row.deadline > lastPostTimestamp) {
+    } else if (row.deadline > lastExaminedTimestamp) {
       // During-block cohort: completed since the last cron run but on/before the block end,
       // i.e. in flight during the block. Never overlaps the rate window (deadline <= floor),
       // so during-block orders stay excluded from the post-block clean slate.

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -117,15 +117,16 @@ async function main(metrics: MetricsLogger) {
     //  | hash        |lastExaminedTimestamp|blockUntilTimestamp|fadeWindowStart|
     //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
     //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
-    const updatedTimestamps = calculateNewTimestamps(
-      fillerTimestamps,
-      fillerFadeStats,
-      Math.floor(Date.now() / 1000),
-      log,
-      metrics
-    );
+    const now = Math.floor(Date.now() / 1000);
+    const updatedTimestamps = calculateNewTimestamps(fillerTimestamps, fillerFadeStats, now, log, metrics);
     log.info({ updatedTimestamps }, 'filler for which to update timestamp');
     metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_BLOCKED, updatedTimestamps.length, Unit.Count);
+    metrics.putMetric(
+      Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS,
+      countActiveBlocks(fillerTimestamps, updatedTimestamps, now),
+      Unit.Count
+    );
+    metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, Object.keys(fillerFadeStats).length, Unit.Count);
     if (updatedTimestamps.length > 0) {
       await timestampDB.updateTimestampsBatch(updatedTimestamps);
     } else {
@@ -170,10 +171,26 @@ export function calculateNewTimestamps(
   metrics?: MetricsLogger
 ): ToUpdateTimestampRow[] {
   const updatedTimestamps: ToUpdateTimestampRow[] = [];
+  let newBlocks = 0;
+  let extendedBlocks = 0;
   Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
     const { fadeRate, duringBlockRate, newCompletions } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
+    const previousBlocks = fillerTimestamp?.consecutiveBlocks || 0;
+
+    // Per-filler rate so the distribution can be charted against FADE_RATE_BLOCK_THRESHOLD. While
+    // blocked, fadeRate sits at the prior (post-block window is empty), so also emit the
+    // during-block rate — the signal that actually drives extend/re-block — to chart benched
+    // fillers against the same threshold.
+    metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, hash), fadeRate, Unit.None);
+    if (isCurrentlyBlocked) {
+      metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, hash), duringBlockRate, Unit.None);
+    }
+
+    // Resulting escalation level for this filler, emitted once below so the dashboard can chart
+    // climbs, plateaus, and decay back to 0 (not just the block/extend steps).
+    let consecutiveBlocks: number;
 
     if (isCurrentlyBlocked && duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
       // In-flight orders faded at over the threshold rate while blocked: stack the penalty,
@@ -183,16 +200,12 @@ export function calculateNewTimestamps(
         fillerTimestamp.blockUntilTimestamp, // Extend from when current block ends
         fillerTimestamp.consecutiveBlocks
       );
-      const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
+      consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
 
+      extendedBlocks++;
       log?.info(
         { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, duringBlockRate },
         'Extending block for filler who faded while blocked'
-      );
-      metrics?.putMetric(
-        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash),
-        consecutiveBlocks,
-        Unit.Count
       );
 
       updatedTimestamps.push({
@@ -204,12 +217,13 @@ export function calculateNewTimestamps(
       });
     } else if (isCurrentlyBlocked) {
       // Blocked but no new fades - keep existing block and floor, don't decay
+      consecutiveBlocks = fillerTimestamp.consecutiveBlocks;
       updatedTimestamps.push({
         hash,
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: fillerTimestamp.blockUntilTimestamp,
         fadeWindowStart: fillerTimestamp.fadeWindowStart,
-        consecutiveBlocks: fillerTimestamp.consecutiveBlocks,
+        consecutiveBlocks,
       });
     } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD || duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
       // duringBlockRate covers in-flight fades that landed near the end of a block that
@@ -218,16 +232,12 @@ export function calculateNewTimestamps(
       // threshold on a run with no new completions ("blocked while idle") as clean orders age
       // out; that is accepted behavior.
       const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
-      const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
+      consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
 
+      newBlocks++;
       log?.info(
         { hash, fadeRate, duringBlockRate, blockUntilTimestamp },
         'Blocking filler for exceeding fade rate threshold'
-      );
-      metrics?.putMetric(
-        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash),
-        consecutiveBlocks,
-        Unit.Count
       );
 
       updatedTimestamps.push({
@@ -235,7 +245,7 @@ export function calculateNewTimestamps(
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp,
         fadeWindowStart: blockUntilTimestamp, // clean slate resumes when the block ends
-        consecutiveBlocks: consecutiveBlocks,
+        consecutiveBlocks,
       });
     } else {
       // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked and decay
@@ -244,19 +254,45 @@ export function calculateNewTimestamps(
       // escalation requires demonstrated clean activity rather than idling. fadeWindowStart
       // is left as-is: it holds the last block end as the clean-slate floor, so a returning
       // filler is scored only on orders completed after their block ended.
-      const currentBlocks = fillerTimestamp?.consecutiveBlocks || 0;
-      const decayedBlocks = newCompletions > 0 ? Math.max(0, currentBlocks - 1) : currentBlocks;
+      consecutiveBlocks = newCompletions > 0 ? Math.max(0, previousBlocks - 1) : previousBlocks;
       updatedTimestamps.push({
         hash,
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         fadeWindowStart: fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-        consecutiveBlocks: decayedBlocks,
+        consecutiveBlocks,
       });
     }
+
+    // Emit the escalation level whenever the filler is or was escalated, so the chart steps
+    // down through decay and plots the 0 when a filler fully recovers. Skip never-blocked
+    // fillers (0 -> 0) to avoid a flat-zero series per filler.
+    if (consecutiveBlocks > 0 || previousBlocks > 0) {
+      metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash), consecutiveBlocks, Unit.Count);
+    }
   });
-  log?.info({ updatedTimestamps }, 'updated timestamps');
+  metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, newBlocks, Unit.Count);
+  metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, extendedBlocks, Unit.Count);
+  log?.info({ updatedTimestamps, newBlocks, extendedBlocks }, 'updated timestamps');
   return updatedTimestamps;
+}
+
+/* Number of fillers benched (blockUntilTimestamp in the future) after applying this run's
+   updates on top of stored state. Includes benched fillers with no completions this run —
+   they produce no stats row, but their stored block is still active. */
+export function countActiveBlocks(
+  fillerTimestamps: FillerTimestamps,
+  updatedTimestamps: ToUpdateTimestampRow[],
+  now: number
+): number {
+  const effectiveBlockUntil = new Map<string, number>();
+  fillerTimestamps.forEach((row, hash) =>
+    effectiveBlockUntil.set(hash, row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP)
+  );
+  updatedTimestamps.forEach((row) =>
+    effectiveBlockUntil.set(row.hash, row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP)
+  );
+  return [...effectiveBlockUntil.values()].filter((blockUntil) => blockUntil > now).length;
 }
 
 /* Laplace-smoothed fade rate: pretend we've already seen LAPLACE_ALPHA fades and

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -52,7 +52,17 @@ export const LAPLACE_BETA = 19;
 // (14 fades in latest 100 => 15/120 = 12.5%), while a sustained ~10% filler stays clear.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 
-/** Sentinel when the filler has no active block (always < now for real unix seconds). Avoids equaling lastPostTimestamp, which could briefly read as blocked under clock skew. */
+/**
+ * Sentinel for a filler that has NEVER been blocked (or whose stored state is unset/corrupt).
+ * Always < now for real unix seconds; also avoids equaling lastPostTimestamp, which could
+ * briefly read as blocked under clock skew.
+ *
+ * NOTE: this is deliberately NOT written for fillers coming off a block. The decay branch
+ * preserves their expired blockUntilTimestamp because it doubles as the clean-slate floor of
+ * the fade-rate window (only orders completed after it are scored). Overwriting it with this
+ * sentinel would erase that floor and re-score the filler's entire 24h history — including
+ * the pre-block fades that got them blocked in the first place.
+ */
 export const UNBLOCKED_BLOCK_UNTIL_TIMESTAMP = 0;
 
 const log = Logger.createLogger({

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -27,8 +27,12 @@ export type FillerFadeStats = {
   // orders, whichever is smaller — so high-volume fillers are judged on recent orders (fast
   // acute response) and low-volume fillers on up to a full day (catches chronic fading).
   fadeRate: number;
-  // Orders that faded since the last cron run; used to stack penalties while already blocked.
-  newFades: number;
+  // Laplace-smoothed fade rate over orders that completed since the last cron run with a
+  // deadline on/before the filler's block end — i.e. orders in flight during a block.
+  // Used to extend an active block (or re-block right after expiry). Rate-based so clean
+  // in-flight fills offset stray fades: extending a block is volume-neutral, just like
+  // tripping one.
+  duringBlockRate: number;
 };
 export type FillerFadeStatsMap = Record<string, FillerFadeStats>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
@@ -101,10 +105,10 @@ async function main(metrics: MetricsLogger) {
     const addressToFillerMap = await fillerAddressRepo.getAddressToFillerMap(fillerEndpoints);
     const fillerTimestamps = await timestampDB.getFillerTimestampsMap(fillerEndpoints);
 
-    // compute each filler's Laplace-smoothed fade rate (and new fades since last run):
-    //  | hash     |  fadeRate  |  newFades  |
-    //  |---- foo -|---- 0.18 --|---- 3 -----|
-    //  |---- bar -|---- 0.05 --|---- 0 -----|
+    // compute each filler's Laplace-smoothed fade rates (post-block window + during-block cohort):
+    //  | hash     |  fadeRate  |  duringBlockRate  |
+    //  |---- foo -|---- 0.18 --|------ 0.05 -------|
+    //  |---- bar -|---- 0.05 --|------ 0.20 -------|
     const fillerFadeStats = getFillersFadeStats(result, addressToFillerMap, fillerTimestamps, log);
 
     //  | hash        |lastPostTimestamp|blockUntilTimestamp|
@@ -147,12 +151,14 @@ function newConsecutiveBlocks(consecutiveBlocks?: number): number {
 
 /* compute blockUntil timestamp for each filler
   If currently blocked:
-    - With new fades (in-flight orders that faded while blocked): EXTEND the block from
-      current blockUntil and increment consecutiveBlocks
-    - Without new fades: keep existing block (don't decay while blocked)
+    - In-flight orders faded at over the threshold rate while blocked: EXTEND the block
+      from current blockUntil and increment consecutiveBlocks
+    - Otherwise: keep existing block (don't decay while blocked)
   If not blocked:
-    - Fade rate over threshold: block, increment consecutiveBlocks
-    - Fade rate under threshold: decay consecutiveBlocks by 1, and KEEP the (now past)
+    - Post-block fade rate over threshold — or the during-block cohort over threshold
+      (late in-flight fades from a block that expired between cron runs): block,
+      increment consecutiveBlocks
+    - Otherwise: decay consecutiveBlocks by 1, and KEEP the (now past)
       blockUntilTimestamp so it remains the clean-slate floor for the rate window
 */
 export function calculateNewTimestamps(
@@ -164,13 +170,15 @@ export function calculateNewTimestamps(
 ): ToUpdateTimestampRow[] {
   const updatedTimestamps: ToUpdateTimestampRow[] = [];
   Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
-    const { fadeRate, newFades } = stats;
+    const { fadeRate, duringBlockRate } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
 
-    if (isCurrentlyBlocked && newFades > 0) {
-      // Faded again on in-flight orders while blocked: stack the penalty.
-      // Extend the block from current blockUntil, not from now.
+    if (isCurrentlyBlocked && duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
+      // In-flight orders faded at over the threshold rate while blocked: stack the penalty.
+      // Extend the block from current blockUntil, not from now. Rate-based (not count-based)
+      // so a high-volume filler's stray in-flight fade, offset by clean in-flight fills,
+      // does not extend the block.
       const extendedBlockUntil = calculateBlockUntilTimestamp(
         fillerTimestamp.blockUntilTimestamp, // Extend from when current block ends
         fillerTimestamp.consecutiveBlocks
@@ -178,7 +186,7 @@ export function calculateNewTimestamps(
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
 
       log?.info(
-        { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, newFades },
+        { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, duringBlockRate },
         'Extending block for filler who faded while blocked'
       );
       metrics?.putMetric(
@@ -201,11 +209,23 @@ export function calculateNewTimestamps(
         blockUntilTimestamp: fillerTimestamp.blockUntilTimestamp,
         consecutiveBlocks: fillerTimestamp.consecutiveBlocks,
       });
-    } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD) {
+    } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD || duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
+      // duringBlockRate here covers in-flight fades that landed near the end of a block that
+      // expired between cron runs — they sit below the clean-slate floor, so without this
+      // check they would never be scored by either path.
+      //
+      // NOTE(review): because the rate window is a rolling 24h, clean orders can age out
+      // while fades remain, so fadeRate can cross the threshold on a run where the filler
+      // completed nothing new ("blocked while idle"). We accept this rather than gating on
+      // new completions: the gate would just move the surprise to right after a completed
+      // (possibly cleanly filled) order, which is stranger UX for the filler.
       const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
 
-      log?.info({ hash, fadeRate, blockUntilTimestamp }, 'Blocking filler for exceeding fade rate threshold');
+      log?.info(
+        { hash, fadeRate, duringBlockRate, blockUntilTimestamp },
+        'Blocking filler for exceeding fade rate threshold'
+      );
       metrics?.putMetric(
         metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash),
         consecutiveBlocks,
@@ -243,20 +263,24 @@ export function laplaceSmoothedFadeRate(fades: number, total: number): number {
   return (fades + LAPLACE_ALPHA) / (total + LAPLACE_ALPHA + LAPLACE_BETA);
 }
 
-/* Compute, per filler, the Laplace-smoothed fade rate and the number of fades since
-   the last cron run.
+/* Compute, per filler, Laplace-smoothed fade rates over two disjoint cohorts.
    @param rows: info about individual orders: filler address, faded or not, deadline (completion time)
    @param fillerTimestamps: last checked timestamp and block until timestamp for each filler
    @param addressToFillerMap: map of address to filler hash
 
-   The fade rate is computed over the filler's "post-block window" — orders whose deadline
-   is after their last blockUntilTimestamp. This is the clean-slate mechanism: a filler who
-   served a block is scored only on orders completed after the block ended, not on the
-   pre-block fades that are still inside the query's rolling window. While a filler is
-   currently blocked the floor is in the future, so windowTotal is ~0 and the rate sits at
-   the prior — only newFades (used by calculateNewTimestamps) can extend an active block.
+   - fadeRate: orders whose deadline is after the filler's last blockUntilTimestamp
+     ("post-block window"). This is the clean-slate mechanism: a filler who served a block
+     is scored only on orders completed after the block ended, not on the pre-block fades
+     that are still inside the query's rolling window. While a filler is currently blocked
+     the floor is in the future, so this window is ~empty and the rate sits at the prior.
+   - duringBlockRate: orders completed since the last cron run with deadline on/before the
+     block end — i.e. orders that were in flight during a block. calculateNewTimestamps uses
+     this to extend an active block, or to re-block right after expiry so late in-flight
+     fades can't slip between two cron runs. Scored per cron-run slice: a blocked filler
+     trickling isolated fades (each slice under threshold) won't extend the block, but those
+     orders never enter the post-block window either — they still serve the full bench.
 
-   NOTE: We use `deadline` (order completion time) instead of `postTimestamp` for newFades.
+   NOTE: cohort membership uses `deadline` (order completion time) instead of `postTimestamp`.
    This ensures orders posted before the last cron run but completed after are still counted,
    preventing the "in-flight orders" exploit.
 */
@@ -275,7 +299,8 @@ export function getFillersFadeStats(
     'getFillersFadeStats'
   );
   // filler hash -> tallies used to derive the stats below
-  const tallies: Record<string, { windowFades: number; windowTotal: number; newFades: number }> = {};
+  const tallies: Record<string, { windowFades: number; windowTotal: number; blockFades: number; blockTotal: number }> =
+    {};
   rows.forEach((row) => {
     const fillerAddr = ethers.utils.getAddress(row.fillerAddress);
     const fillerHash = addressToFillerMap.get(fillerAddr);
@@ -285,18 +310,20 @@ export function getFillersFadeStats(
     }
     const fillerTimestamp = fillerTimestamps.get(fillerHash);
     if (!tallies[fillerHash]) {
-      tallies[fillerHash] = { windowFades: 0, windowTotal: 0, newFades: 0 };
+      tallies[fillerHash] = { windowFades: 0, windowTotal: 0, blockFades: 0, blockTotal: 0 };
     }
-    // Rate window: orders completed after the filler's last block ended (clean slate).
     const windowStart = finiteOr(fillerTimestamp?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
+    const lastPostTimestamp = finiteOr(fillerTimestamp?.lastPostTimestamp, 0);
     if (row.deadline > windowStart) {
+      // Rate window: orders completed after the filler's last block ended (clean slate).
       tallies[fillerHash].windowTotal += 1;
       tallies[fillerHash].windowFades += row.faded;
-    }
-    // New fades since the last cron run (deadline-based; catches in-flight orders).
-    const lastPostTimestamp = finiteOr(fillerTimestamp?.lastPostTimestamp, 0);
-    if (!fillerTimestamp || row.deadline > lastPostTimestamp) {
-      tallies[fillerHash].newFades += row.faded;
+    } else if (row.deadline > lastPostTimestamp) {
+      // During-block cohort: completed since the last cron run but on/before the block end,
+      // i.e. in flight during the block. Never overlaps the rate window (deadline <= floor),
+      // so during-block orders stay excluded from the post-block clean slate.
+      tallies[fillerHash].blockTotal += 1;
+      tallies[fillerHash].blockFades += row.faded;
     }
   });
 
@@ -304,10 +331,10 @@ export function getFillersFadeStats(
   Object.entries(tallies).forEach(([hash, t]) => {
     stats[hash] = {
       fadeRate: laplaceSmoothedFadeRate(t.windowFades, t.windowTotal),
-      newFades: t.newFades,
+      duringBlockRate: laplaceSmoothedFadeRate(t.blockFades, t.blockTotal),
     };
   });
-  log?.info({ stats }, 'fade stats by filler');
+  log?.info({ tallies, stats }, 'fade stats by filler');
   return stats;
 }
 

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -18,8 +18,12 @@ import {
   V2FadesRowType,
 } from '../repositories';
 import { DynamoFillerAddressRepository } from '../repositories/filler-address-repository';
-import { TimestampRepository } from '../repositories/timestamp-repository';
+import { TimestampRepository, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP } from '../repositories/timestamp-repository';
 import { STAGE } from '../util/stage';
+
+// Re-exported for existing importers; the sentinel lives with the repository that owns the
+// stored value's parse/write semantics.
+export { UNBLOCKED_BLOCK_UNTIL_TIMESTAMP };
 
 export type FillerFadeStats = {
   // Laplace-smoothed fade rate over the filler's post-block window (see getFillersFadeStats).
@@ -51,19 +55,6 @@ export const LAPLACE_BETA = 19;
 // (2 fades => 3/22 ≈ 13.6%) and a high-volume filler chronically fading ~14%+ of orders
 // (14 fades in latest 100 => 15/120 = 12.5%), while a sustained ~10% filler stays clear.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
-
-/**
- * Sentinel for a filler that has NEVER been blocked (or whose stored state is unset/corrupt).
- * Always < now for real unix seconds; also avoids equaling lastPostTimestamp, which could
- * briefly read as blocked under clock skew.
- *
- * NOTE: this is deliberately NOT written for fillers coming off a block. The decay branch
- * preserves their expired blockUntilTimestamp because it doubles as the clean-slate floor of
- * the fade-rate window (only orders completed after it are scored). Overwriting it with this
- * sentinel would erase that floor and re-score the filler's entire 24h history — including
- * the pre-block fades that got them blocked in the first place.
- */
-export const UNBLOCKED_BLOCK_UNTIL_TIMESTAMP = 0;
 
 const log = Logger.createLogger({
   name: 'FadeRate',
@@ -141,10 +132,10 @@ async function main(metrics: MetricsLogger) {
   }
 }
 
-// parseInt on a missing/malformed Dynamo attribute yields NaN. A NaN timestamp must not
-// be treated as a real value: e.g. `deadline > NaN` is always false, which would silently
-// zero out the fade-rate window and make a filler permanently unblockable. Coerce any
-// non-finite stored timestamp back to the "unset" sentinel.
+// TimestampRepository coerces NaN at the parse boundary, so stored rows should already be
+// finite. Kept as defense-in-depth for timestamps arriving from other sources: a NaN here
+// would poison comparisons (`deadline > NaN` is always false), silently zeroing the
+// fade-rate window and making a filler permanently unblockable.
 function finiteOr(value: number | undefined, fallback: number): number {
   return Number.isFinite(value) ? (value as number) : fallback;
 }

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -37,6 +37,10 @@ export type FillerFadeStats = {
   // in-flight fills offset stray fades: extending a block is volume-neutral, just like
   // tripping one.
   duringBlockRate: number;
+  // Orders completed since the last cron run (any cohort). Gates consecutiveBlocks decay:
+  // working off escalation requires demonstrated activity, not just going idle while stale
+  // rows linger in the 24h view.
+  newCompletions: number;
 };
 export type FillerFadeStatsMap = Record<string, FillerFadeStats>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
@@ -159,8 +163,9 @@ function newConsecutiveBlocks(consecutiveBlocks?: number): number {
     - Post-block fade rate over threshold — or the during-block cohort over threshold
       (late in-flight fades from a block that expired between cron runs): block,
       increment consecutiveBlocks
-    - Otherwise: decay consecutiveBlocks by 1, and KEEP the (now past)
-      blockUntilTimestamp so it remains the clean-slate floor for the rate window
+    - Otherwise: decay consecutiveBlocks by 1 — but only if the filler completed new
+      orders since the last run (idling must not work off escalation) — and KEEP the
+      (now past) blockUntilTimestamp so it remains the clean-slate floor for the rate window
 */
 export function calculateNewTimestamps(
   fillerTimestamps: FillerTimestamps,
@@ -171,7 +176,7 @@ export function calculateNewTimestamps(
 ): ToUpdateTimestampRow[] {
   const updatedTimestamps: ToUpdateTimestampRow[] = [];
   Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
-    const { fadeRate, duringBlockRate } = stats;
+    const { fadeRate, duringBlockRate, newCompletions } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
 
@@ -241,10 +246,14 @@ export function calculateNewTimestamps(
       });
     } else {
       // Under threshold: decay consecutiveBlocks gradually instead of resetting (prevents
-      // gaming via alternating fade/clean cycles). Preserve the existing (now past)
-      // blockUntilTimestamp: it's the clean-slate floor so a returning filler is scored
-      // only on orders completed after their last block ended.
-      const decayedBlocks = Math.max(0, (fillerTimestamp?.consecutiveBlocks || 0) - 1);
+      // gaming via alternating fade/clean cycles). Decay only when the filler completed new
+      // orders since the last run — without this gate, stale rows lingering in the 24h view
+      // would decay escalation every 10-minute run while the filler simply idles (raised in
+      // review). Working off escalation requires demonstrated clean activity.
+      // Preserve the existing (now past) blockUntilTimestamp: it's the clean-slate floor so
+      // a returning filler is scored only on orders completed after their last block ended.
+      const currentBlocks = fillerTimestamp?.consecutiveBlocks || 0;
+      const decayedBlocks = newCompletions > 0 ? Math.max(0, currentBlocks - 1) : currentBlocks;
       updatedTimestamps.push({
         hash,
         lastPostTimestamp: newPostTimestamp,
@@ -300,8 +309,10 @@ export function getFillersFadeStats(
     'getFillersFadeStats'
   );
   // filler hash -> tallies used to derive the stats below
-  const tallies: Record<string, { windowFades: number; windowTotal: number; blockFades: number; blockTotal: number }> =
-    {};
+  const tallies: Record<
+    string,
+    { windowFades: number; windowTotal: number; blockFades: number; blockTotal: number; newCompletions: number }
+  > = {};
   rows.forEach((row) => {
     const fillerAddr = ethers.utils.getAddress(row.fillerAddress);
     const fillerHash = addressToFillerMap.get(fillerAddr);
@@ -311,10 +322,13 @@ export function getFillersFadeStats(
     }
     const fillerTimestamp = fillerTimestamps.get(fillerHash);
     if (!tallies[fillerHash]) {
-      tallies[fillerHash] = { windowFades: 0, windowTotal: 0, blockFades: 0, blockTotal: 0 };
+      tallies[fillerHash] = { windowFades: 0, windowTotal: 0, blockFades: 0, blockTotal: 0, newCompletions: 0 };
     }
     const windowStart = finiteOr(fillerTimestamp?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
     const lastPostTimestamp = finiteOr(fillerTimestamp?.lastPostTimestamp, 0);
+    if (row.deadline > lastPostTimestamp) {
+      tallies[fillerHash].newCompletions += 1;
+    }
     if (row.deadline > windowStart) {
       // Rate window: orders completed after the filler's last block ended (clean slate).
       tallies[fillerHash].windowTotal += 1;
@@ -333,6 +347,7 @@ export function getFillersFadeStats(
     stats[hash] = {
       fadeRate: laplaceSmoothedFadeRate(t.windowFades, t.windowTotal),
       duringBlockRate: laplaceSmoothedFadeRate(t.blockFades, t.blockTotal),
+      newCompletions: t.newCompletions,
     };
   });
   log?.info({ tallies, stats }, 'fade stats by filler');

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -52,12 +52,10 @@ export const BASE_BLOCK_SECS = 60 * 15; // 15 minutes
 // pretend-fades and BETA pretend-clean-fills. Prior mean = ALPHA/(ALPHA+BETA) = 1/20 = 5%.
 export const LAPLACE_ALPHA = 1;
 export const LAPLACE_BETA = 19;
-// Block a filler once their smoothed fade rate exceeds this. MUST be greater than the
-// prior mean (5%), otherwise the prior alone would block every filler.
-// At this threshold a filler needs e.g. ~2 fades in 2 orders, ~3 in 10, ~8 in 50, ~14 in 100.
-// With the 24h/latest-100 window this catches both a low-volume filler fading every order
-// (2 fades => 3/22 ≈ 13.6%) and a high-volume filler chronically fading ~14%+ of orders
-// (14 fades in latest 100 => 15/120 = 12.5%), while a sustained ~10% filler stays clear.
+// Block a filler once their smoothed fade rate exceeds this. Must be greater than the prior
+// mean (5%), else the prior alone would block every filler. At 12% a filler trips at roughly
+// a sustained ~14%+ raw fade rate (e.g. ~3 fades in 10, ~14 in 100), or ~2 fades at very low
+// volume.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 
 const log = Logger.createLogger({
@@ -178,10 +176,9 @@ export function calculateNewTimestamps(
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
 
     if (isCurrentlyBlocked && duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
-      // In-flight orders faded at over the threshold rate while blocked: stack the penalty.
-      // Extend the block from current blockUntil, not from now. Rate-based (not count-based)
-      // so a high-volume filler's stray in-flight fade, offset by clean in-flight fills,
-      // does not extend the block.
+      // In-flight orders faded at over the threshold rate while blocked: stack the penalty,
+      // extending from the current block end. Rate-based, so a high-volume filler's stray
+      // in-flight fade offset by clean in-flight fills does not extend the block.
       const extendedBlockUntil = calculateBlockUntilTimestamp(
         fillerTimestamp.blockUntilTimestamp, // Extend from when current block ends
         fillerTimestamp.consecutiveBlocks
@@ -215,15 +212,11 @@ export function calculateNewTimestamps(
         consecutiveBlocks: fillerTimestamp.consecutiveBlocks,
       });
     } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD || duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
-      // duringBlockRate here covers in-flight fades that landed near the end of a block that
-      // expired between cron runs — they sit below the clean-slate floor, so without this
-      // check they would never be scored by either path.
-      //
-      // NOTE(review): because the rate window is a rolling 24h, clean orders can age out
-      // while fades remain, so fadeRate can cross the threshold on a run where the filler
-      // completed nothing new ("blocked while idle"). We accept this rather than gating on
-      // new completions: the gate would just move the surprise to right after a completed
-      // (possibly cleanly filled) order, which is stranger UX for the filler.
+      // duringBlockRate covers in-flight fades that landed near the end of a block that
+      // expired between cron runs: they sit below the clean-slate floor, so this is the only
+      // path that scores them. Over the rolling 24h window a filler can also cross the
+      // threshold on a run with no new completions ("blocked while idle") as clean orders age
+      // out; that is accepted behavior.
       const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
 
@@ -245,15 +238,12 @@ export function calculateNewTimestamps(
         consecutiveBlocks: consecutiveBlocks,
       });
     } else {
-      // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked, and decay
-      // consecutiveBlocks gradually instead of resetting (prevents gaming via alternating
-      // fade/clean cycles). Decay only when the filler completed new orders since the last
-      // run — without this gate, stale rows lingering in the 24h view would decay escalation
-      // every 10-minute run while the filler simply idles (raised in review). Working off
-      // escalation requires demonstrated clean activity.
-      // fadeWindowStart is preserved (not written from blockUntilTimestamp): it independently
-      // holds the last block end as the clean-slate floor so a returning filler is scored
-      // only on orders completed after their block ended.
+      // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked and decay
+      // consecutiveBlocks by 1 (gradual decay resists gaming via alternating fade/clean
+      // cycles). Decay only when the filler completed new orders this run, so working off
+      // escalation requires demonstrated clean activity rather than idling. fadeWindowStart
+      // is left as-is: it holds the last block end as the clean-slate floor, so a returning
+      // filler is scored only on orders completed after their block ended.
       const currentBlocks = fillerTimestamp?.consecutiveBlocks || 0;
       const decayedBlocks = newCompletions > 0 ? Math.max(0, currentBlocks - 1) : currentBlocks;
       updatedTimestamps.push({

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -23,6 +23,9 @@ import { STAGE } from '../util/stage';
 
 export type FillerFadeStats = {
   // Laplace-smoothed fade rate over the filler's post-block window (see getFillersFadeStats).
+  // The underlying query bounds the window to 24 hours OR the latest ORDERS_PER_FILLER_LIMIT
+  // orders, whichever is smaller — so high-volume fillers are judged on recent orders (fast
+  // acute response) and low-volume fillers on up to a full day (catches chronic fading).
   fadeRate: number;
   // Orders that faded since the last cron run; used to stack penalties while already blocked.
   newFades: number;
@@ -39,7 +42,10 @@ export const LAPLACE_ALPHA = 1;
 export const LAPLACE_BETA = 19;
 // Block a filler once their smoothed fade rate exceeds this. MUST be greater than the
 // prior mean (5%), otherwise the prior alone would block every filler.
-// At this threshold a filler needs e.g. ~3 fades in 10 orders, ~4 in 20, ~8 in 50.
+// At this threshold a filler needs e.g. ~2 fades in 2 orders, ~3 in 10, ~8 in 50, ~14 in 100.
+// With the 24h/latest-100 window this catches both a low-volume filler fading every order
+// (2 fades => 3/22 ≈ 13.6%) and a high-volume filler chronically fading ~14%+ of orders
+// (14 fades in latest 100 => 15/120 = 12.5%), while a sustained ~10% filler stays clear.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 
 /** Sentinel when the filler has no active block (always < now for real unix seconds). Avoids equaling lastPostTimestamp, which could briefly read as blocked under clock skew. */

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -27,7 +27,7 @@ export const HardQuoteMetricDimension = {
 
 export class AWSMetricsLogger implements IMetric {
   constructor(private awsMetricLogger: AWSEmbeddedMetricsLogger) {}
-  
+
   public setProperty(key: string, value: unknown): void {
     this.awsMetricLogger.setProperty(key, value);
   }
@@ -88,6 +88,21 @@ export enum Metric {
   CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS = 'CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS',
   CIRCUIT_BREAKER_V2_BLOCKED = 'CIRCUIT_BREAKER_V2_BLOCKED',
   CIRCUIT_BREAKER_TRIGGERED = 'CIRCUIT_BREAKER_TRIGGERED',
+  // Per-filler Laplace-smoothed fade rate over the post-block window (compare to FADE_RATE_BLOCK_THRESHOLD)
+  CIRCUIT_BREAKER_V2_FADE_RATE = 'CIRCUIT_BREAKER_V2_FADE_RATE',
+  // Per-filler Laplace-smoothed fade rate over the in-flight-during-block cohort, emitted while
+  // a filler is benched. This is the rate that drives extend/re-block decisions, so it (not the
+  // post-block FADE_RATE, which sits at the prior while blocked) is what shows a benched filler
+  // above the threshold. Compare to FADE_RATE_BLOCK_THRESHOLD.
+  CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE = 'CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE',
+  // Fillers newly blocked in a cron run (unblocked -> blocked)
+  CIRCUIT_BREAKER_V2_NEW_BLOCKS = 'CIRCUIT_BREAKER_V2_NEW_BLOCKS',
+  // Active blocks extended in a cron run (in-flight cohort faded over threshold while blocked)
+  CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS = 'CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS',
+  // Fillers currently benched (blockUntilTimestamp in the future) after a cron run
+  CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS = 'CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS',
+  // Fillers with fade stats evaluated in a cron run (sample-health denominator)
+  CIRCUIT_BREAKER_V2_FILLERS_EVALUATED = 'CIRCUIT_BREAKER_V2_FILLERS_EVALUATED',
 }
 
 type MetricNeedingContext =
@@ -104,7 +119,9 @@ type MetricNeedingContext =
   | Metric.SYNTH_PAIR_DISABLED
   | Metric.SYNTH_ORDERS_POSITIVE_OUTCOME
   | Metric.SYNTH_ORDERS_NEGATIVE_OUTCOME
-  | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS;
+  | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS
+  | Metric.CIRCUIT_BREAKER_V2_FADE_RATE
+  | Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE;
 
 export function metricContext(metric: MetricNeedingContext, context: string): string {
   return `${metric}_${context}`;

--- a/lib/handlers/quote/schema.ts
+++ b/lib/handlers/quote/schema.ts
@@ -77,7 +77,10 @@ export const RfqResponseJoi = Joi.object({
   amountIn: FieldValidator.amount.required(),
   tokenOut: Joi.string().required(),
   amountOut: FieldValidator.amount.required(),
-  filler: FieldValidator.address.optional(),
+  // Required: the filler's settlement address. It's the circuit breaker's attribution key,
+  // so a response without it (which would post with no exclusive filler and escape the fade
+  // view) is rejected as a validation error.
+  filler: FieldValidator.address.required(),
   quoteId: FieldValidator.uuid,
 });
 
@@ -89,5 +92,5 @@ export type RfqResponse = {
   tokenOut: string;
   amountOut: string;
   quoteId: string;
-  filler?: string;
+  filler: string;
 };

--- a/lib/providers/circuit-breaker/dynamo.ts
+++ b/lib/providers/circuit-breaker/dynamo.ts
@@ -1,5 +1,3 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import Logger from 'bunyan';
 
 import { CircuitBreakerConfigurationProvider, EndpointStatuses } from '.';
@@ -21,15 +19,8 @@ export class DynamoCircuitBreakerConfigurationProvider implements CircuitBreaker
     this.log = _log.child({ quoter: 'CircuitBreakerConfigurationProvider' });
     this.webhookProvider = _webhookProvider;
     this.lastUpdatedTimestamp = Date.now();
-    const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
-      marshallOptions: {
-        convertEmptyValues: true,
-      },
-      unmarshallOptions: {
-        wrapNumbers: true,
-      },
-    });
-    this.timestampDB = TimestampRepository.create(documentClient);
+    // TimestampRepository builds its own wrapNumbers:false client (state is small integers).
+    this.timestampDB = TimestampRepository.create();
   }
 
   private async getFillerEndpoints(): Promise<string[]> {

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -30,23 +30,27 @@ export enum TimestampThreshold {
 
 export type TimestampRepoRow = {
   hash: string;
-  lastPostTimestamp: number;
+  // Timestamp of the last cron run that examined this filler; boundary for "new since last run".
+  lastExaminedTimestamp: number;
+  // Block expiry; 0 (UNBLOCKED_BLOCK_UNTIL_TIMESTAMP) when the filler is not blocked.
   blockUntilTimestamp: number;
+  // Clean-slate floor for the fade-rate window: only orders completed after this are scored.
+  // Set to the block end whenever a block is applied/extended; 0 if the filler was never blocked.
+  fadeWindowStart: number;
   consecutiveBlocks: number;
 };
 
-export type DynamoTimestampRepoRow = Exclude<TimestampRepoRow, 'lastPostTimestamp' | 'blockUntilTimestamp'> & {
-  lastPostTimestamp: string;
-  blockUntilTimestamp: string;
-  consecutiveBlocks: string;
-};
+// Rows round-trip as native numbers now (number-typed attributes read via a wrapNumbers:false
+// client), so the raw shape matches TimestampRepoRow — no string parsing.
+export type DynamoTimestampRepoRow = TimestampRepoRow;
 
-export type ToUpdateTimestampRow = Omit<TimestampRepoRow, 'blockUntilTimestamp'> & {
+export type ToUpdateTimestampRow = Omit<TimestampRepoRow, 'blockUntilTimestamp' | 'fadeWindowStart'> & {
   blockUntilTimestamp?: number;
+  fadeWindowStart?: number;
 };
 
 /*
-  fillerHash -> { lastPostTimestamp, blockUntilTimestamp }
+  fillerHash -> { lastExaminedTimestamp, blockUntilTimestamp, fadeWindowStart, consecutiveBlocks }
 */
 export type FillerTimestampMap = Map<string, Omit<TimestampRepoRow, 'hash'>>;
 

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -4,8 +4,14 @@ import Logger from 'bunyan';
 import { OrderType, PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
 import { BaseRedshiftRepository, SharedConfigs } from './base';
 
-// Number of recent orders to evaluate per filler for fade rate calculation
-export const ORDERS_PER_FILLER_LIMIT = 50;
+// Cap on the most-recent orders per filler evaluated for the fade rate. Together with the
+// 24-hour view window this makes the lookback adaptive: a high-volume filler is judged on
+// its latest ORDERS_PER_FILLER_LIMIT orders (fast reaction to an acute fade spike),
+// while a low-volume filler is judged on up to 24 hours of orders (catches chronic fading
+// that a short window would never accumulate enough samples to see).
+// At 100 with the 12% smoothed threshold, a sustained raw fade rate of ~14%+ trips the
+// breaker regardless of volume; a fresh 100%-fader trips after ~2 orders.
+export const ORDERS_PER_FILLER_LIMIT = 100;
 
 export type FadesRowType = {
   fillerAddress: string;
@@ -91,7 +97,7 @@ export class V2FadesRepository extends BaseRedshiftRepository {
     await this.executeStatement(V2_CREATE_VIEW_SQL, V2FadesRepository.log, { waitTimeMs: 2_000 });
   }
 
-  //get latest 20 orders for each filler address, and whether they are faded or not
+  // get each filler address's recent orders (24h window, capped at ORDERS_PER_FILLER_LIMIT) and whether they faded
   async getFades(): Promise<V2FadesRowType[]> {
     const stmtId = await this.executeStatement(V2_FADE_RATE_SQL, V2FadesRepository.log, { waitTimeMs: 2_000 });
     const response = await this.client.send(new GetStatementResultCommand({ Id: stmtId }));
@@ -197,7 +203,7 @@ AND latestOrdersV2.quoteId IS NOT NULL
 AND rfqFiller != '0x0000000000000000000000000000000000000000'
 AND chainId NOT IN (5,8001,420,421613) -- exclude mainnet goerli, polygon goerli, optimism goerli and arbitrum goerli testnets 
 AND
-    deadline >= extract(epoch from (GETDATE() - INTERVAL '1 HOUR')) -- 1-hour rolling window based on order completion time
+    deadline >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS')) -- 24-hour rolling window based on order completion time; catches chronic low-volume fading
 )
 ORDER BY rfqFiller, deadline DESC
 LIMIT 5000 

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -4,20 +4,14 @@ import Logger from 'bunyan';
 import { OrderType, PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
 import { BaseRedshiftRepository, SharedConfigs } from './base';
 
-// Cap on the most-recent orders per filler evaluated for the fade rate. Together with the
-// 24-hour view window this makes the lookback adaptive: a high-volume filler is judged on
-// its latest ORDERS_PER_FILLER_LIMIT orders (fast reaction to an acute fade spike),
-// while a low-volume filler is judged on up to 24 hours of orders (catches chronic fading
-// that a short window would never accumulate enough samples to see).
-// At 100 with the 12% smoothed threshold, a sustained raw fade rate of ~14%+ trips the
-// breaker regardless of volume; a fresh 100%-fader trips after ~2 orders.
+// Most-recent orders per filler evaluated for the fade rate. With the 24h view window the
+// lookback is adaptive: a high-volume filler is judged on its latest N orders (fast reaction),
+// a low-volume filler on up to 24h of orders (catches chronic fading).
 export const ORDERS_PER_FILLER_LIMIT = 100;
 
-// Row cap on the fade view/query. The view emits up to ORDERS_PER_FILLER_LIMIT rows per
-// filler address, so total rows ~= (distinct filler addresses in 24h) * 100. At 20000 that
-// is ~200 addresses of headroom (vs ~50 at the old 5000, which the 1h->24h widening blew
-// past). If this is ever hit, rows are silently truncated and some fillers escape scoring —
-// the CIRCUIT_BREAKER_V2_FILLERS_EVALUATED metric alarm is the tripwire for that.
+// Row cap on the fade view/query. The view emits up to ORDERS_PER_FILLER_LIMIT rows per filler
+// address, so total rows ~= (distinct filler addresses in 24h) * ORDERS_PER_FILLER_LIMIT.
+// Above the cap, rows are truncated and some fillers escape scoring.
 export const FADE_QUERY_ROW_LIMIT = 20000;
 
 export type FadesRowType = {

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -183,10 +183,11 @@ CREATE OR REPLACE VIEW latestRfqsV2
 AS (
 WITH latestOrdersV2 AS (
   SELECT * FROM (
-    SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders WHERE ordertype IN ('${OrderType.Dutch_V2}', '${OrderType.Dutch_V3}')
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY filler ORDER BY createdat DESC) AS row_num FROM postedorders
+    WHERE ordertype IN ('${OrderType.Dutch_V2}', '${OrderType.Dutch_V3}')
+    AND deadline < EXTRACT(EPOCH FROM GETDATE()) -- completed orders only, BEFORE numbering: in-flight orders must not consume latest-N slots
   )
   WHERE row_num <= ${ORDERS_PER_FILLER_LIMIT}
-  AND deadline < EXTRACT(EPOCH FROM GETDATE()) -- exclude orders that can still be filled
   LIMIT 5000
 )
 SELECT

--- a/lib/repositories/fades-repository.ts
+++ b/lib/repositories/fades-repository.ts
@@ -13,6 +13,13 @@ import { BaseRedshiftRepository, SharedConfigs } from './base';
 // breaker regardless of volume; a fresh 100%-fader trips after ~2 orders.
 export const ORDERS_PER_FILLER_LIMIT = 100;
 
+// Row cap on the fade view/query. The view emits up to ORDERS_PER_FILLER_LIMIT rows per
+// filler address, so total rows ~= (distinct filler addresses in 24h) * 100. At 20000 that
+// is ~200 addresses of headroom (vs ~50 at the old 5000, which the 1h->24h widening blew
+// past). If this is ever hit, rows are silently truncated and some fillers escape scoring —
+// the CIRCUIT_BREAKER_V2_FILLERS_EVALUATED metric alarm is the tripwire for that.
+export const FADE_QUERY_ROW_LIMIT = 20000;
+
 export type FadesRowType = {
   fillerAddress: string;
   totalQuotes: number;
@@ -188,7 +195,7 @@ WITH latestOrdersV2 AS (
     AND deadline < EXTRACT(EPOCH FROM GETDATE()) -- completed orders only, BEFORE numbering: in-flight orders must not consume latest-N slots
   )
   WHERE row_num <= ${ORDERS_PER_FILLER_LIMIT}
-  LIMIT 5000
+  LIMIT ${FADE_QUERY_ROW_LIMIT}
 )
 SELECT
     latestOrdersV2.chainid as chainId, latestOrdersV2.ordertype as orderType, latestOrdersV2.filler as rfqFiller, latestOrdersV2.startTime as decayStartTime, latestOrdersV2.quoteid, archivedorders.filler as actualFiller, latestOrdersV2.createdat as postTimestamp, latestOrdersV2.deadline as deadline, archivedorders.txhash as txHash, archivedOrders.fillTimestamp as fillTimestamp, archivedorders.fillTimeBlocks as fillTimeBlocks, archivedOrders.tokenIn as tokenIn, archivedOrders.tokenOut as tokenOut,
@@ -207,7 +214,7 @@ AND
     deadline >= extract(epoch from (GETDATE() - INTERVAL '24 HOURS')) -- 24-hour rolling window based on order completion time; catches chronic low-volume fading
 )
 ORDER BY rfqFiller, deadline DESC
-LIMIT 5000 
+LIMIT ${FADE_QUERY_ROW_LIMIT} 
 `;
 
 const V2_FADE_RATE_SQL = `
@@ -231,5 +238,5 @@ FROM latestRfqsV2
 WHERE LOWER(tokenIn) NOT IN (${PERMISSIONED_TOKENS.map((token) => `'${token.address.toLowerCase()}'`).join(',')})
 AND LOWER(tokenOut) NOT IN (${PERMISSIONED_TOKENS.map((token) => `'${token.address.toLowerCase()}'`).join(',')})
 ORDER BY rfqFiller, deadline DESC
-LIMIT 5000
+LIMIT ${FADE_QUERY_ROW_LIMIT}
 `;

--- a/lib/repositories/filler-address-repository.ts
+++ b/lib/repositories/filler-address-repository.ts
@@ -10,6 +10,13 @@ export type DynamoFillerToAddressRow = {
   addresses: string[];
 };
 
+// Max distinct on-chain addresses a single filler (webhook endpoint) may register. Bounds
+// Sybil breadth: without a cap a filler could register unbounded addresses to spread fades or
+// inflate the circuit-breaker's row set. Rejected registrations are a safe no-op (the order
+// still quotes/fills; the address just isn't attributed), so this can't break quoting.
+// NOTE: tune against the real per-endpoint address distribution before tightening.
+export const MAX_FILLER_ADDRESSES = 3;
+
 export interface FillerAddressRepository {
   getFillerAddresses(filler: string): Promise<string[] | undefined>;
   getFillerByAddress(address: string): Promise<string | undefined>;
@@ -79,20 +86,43 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
 
   async addNewAddressToFiller(address: string, filler?: string): Promise<void> {
     const addrToAdd = getAddress(address);
-    await this._addressToFillerEntity.put({ pk: addrToAdd, filler: filler });
-    if (filler) {
-      const fillerAddresses = await this.getFillerAddresses(filler);
-      if (!fillerAddresses || fillerAddresses.length === 0) {
-        await this._fillerToAddressEntity.put({ pk: filler, addresses: [addrToAdd] });
-      } else {
-        await this._fillerToAddressEntity.update({ pk: filler, addresses: { $add: [addrToAdd] } });
-      }
+    const existingOwner = await this.getFillerByAddress(addrToAdd);
+    const owner = filler ?? existingOwner;
+    if (!owner) {
+      throw new Error(`Filler not found for address ${addrToAdd}`);
+    }
+
+    // First-writer-wins: an address belongs to whichever filler registered it first. A claim
+    // from a different filler is ignored (prevents attribution poisoning / griefing). A genuine
+    // address migration between endpoints needs a manual override.
+    if (existingOwner && existingOwner !== owner) {
+      DynamoFillerAddressRepository.log.info(
+        { address: addrToAdd, existingOwner, attemptedOwner: owner },
+        'address already owned by another filler; ignoring claim'
+      );
+      return;
+    }
+
+    // Already registered to this owner — idempotent no-op.
+    if (existingOwner === owner) {
+      return;
+    }
+
+    // New address for this owner — enforce the per-filler cap.
+    const fillerAddresses = (await this.getFillerAddresses(owner)) ?? [];
+    if (fillerAddresses.length >= MAX_FILLER_ADDRESSES) {
+      DynamoFillerAddressRepository.log.info(
+        { filler: owner, address: addrToAdd, count: fillerAddresses.length, max: MAX_FILLER_ADDRESSES },
+        'filler address cap reached; ignoring new address'
+      );
+      return;
+    }
+
+    await this._addressToFillerEntity.put({ pk: addrToAdd, filler: owner });
+    if (fillerAddresses.length === 0) {
+      await this._fillerToAddressEntity.put({ pk: owner, addresses: [addrToAdd] });
     } else {
-      const existingFiller = await this.getFillerByAddress(addrToAdd);
-      if (!existingFiller) {
-        throw new Error(`Filler not found for address ${addrToAdd}`);
-      }
-      await this._fillerToAddressEntity.update({ pk: existingFiller, addresses: { $add: [addrToAdd] } });
+      await this._fillerToAddressEntity.update({ pk: owner, addresses: { $add: [addrToAdd] } });
     }
   }
 
@@ -148,20 +178,27 @@ export class MockFillerAddressRepository implements FillerAddressRepository {
   }
 
   async addNewAddressToFiller(address: string, filler?: string): Promise<void> {
-    if (filler) {
-      const fillerAddresses = this._fillerToAddress.get(filler) || new Set<string>();
-      fillerAddresses.add(address);
-      this._fillerToAddress.set(filler, fillerAddresses);
-      this._addressToFiller.set(address, filler);
-    } else {
-      const existingFiller = this._addressToFiller.get(address);
-      if (!existingFiller) {
-        throw new Error(`Filler not found for address ${address}`);
-      }
-      const fillerAddresses = this._fillerToAddress.get(existingFiller) || new Set<string>();
-      fillerAddresses.add(address);
-      this._fillerToAddress.set(existingFiller, fillerAddresses);
+    const existingOwner = this._addressToFiller.get(address);
+    const owner = filler ?? existingOwner;
+    if (!owner) {
+      throw new Error(`Filler not found for address ${address}`);
     }
+    // First-writer-wins: ignore a claim on an address owned by another filler.
+    if (existingOwner && existingOwner !== owner) {
+      return;
+    }
+    // Already registered to this owner — idempotent no-op.
+    if (existingOwner === owner) {
+      return;
+    }
+    // New address for this owner — enforce the per-filler cap.
+    const fillerAddresses = this._fillerToAddress.get(owner) || new Set<string>();
+    if (fillerAddresses.size >= MAX_FILLER_ADDRESSES) {
+      return;
+    }
+    fillerAddresses.add(address);
+    this._fillerToAddress.set(owner, fillerAddresses);
+    this._addressToFiller.set(address, owner);
   }
 
   async getFillerAddressesBatch(fillers: string[]): Promise<Map<string, Set<string>>> {

--- a/lib/repositories/filler-address-repository.ts
+++ b/lib/repositories/filler-address-repository.ts
@@ -10,11 +10,9 @@ export type DynamoFillerToAddressRow = {
   addresses: string[];
 };
 
-// Max distinct on-chain addresses a single filler (webhook endpoint) may register. Bounds
-// Sybil breadth: without a cap a filler could register unbounded addresses to spread fades or
-// inflate the circuit-breaker's row set. Rejected registrations are a safe no-op (the order
-// still quotes/fills; the address just isn't attributed), so this can't break quoting.
-// NOTE: tune against the real per-endpoint address distribution before tightening.
+// Max distinct on-chain addresses a single filler (webhook endpoint) may register, bounding
+// Sybil breadth. Registrations beyond the cap are a safe no-op — the order still quotes and
+// fills, the address just isn't attributed — so this can't break quoting.
 export const MAX_FILLER_ADDRESSES = 3;
 
 export interface FillerAddressRepository {

--- a/lib/repositories/timestamp-repository.ts
+++ b/lib/repositories/timestamp-repository.ts
@@ -1,3 +1,4 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import Logger from 'bunyan';
 import { Entity, Table } from 'dynamodb-toolbox';
@@ -10,32 +11,27 @@ export type BatchGetResponse = {
 };
 
 /**
- * Sentinel for a filler that has NEVER been blocked (or whose stored state is unset/corrupt).
- * Always < now for real unix seconds; also avoids equaling lastPostTimestamp, which could
- * briefly read as blocked under clock skew.
- *
- * NOTE: this is deliberately NOT written for fillers coming off a block. The fade-rate cron's
- * decay branch preserves their expired blockUntilTimestamp because it doubles as the
- * clean-slate floor of the fade-rate window (only orders completed after it are scored).
- * Overwriting it with this sentinel would erase that floor and re-score the filler's entire
- * 24h history — including the pre-block fades that got them blocked in the first place.
+ * Sentinel for a filler that is not blocked (also the value for a never-blocked filler or a
+ * missing attribute). Always < now for real unix seconds; also avoids equaling
+ * lastExaminedTimestamp, which could briefly read as blocked under clock skew.
  */
 export const UNBLOCKED_BLOCK_UNTIL_TIMESTAMP = 0;
 
-// Rows are written with optional attributes (e.g. blockUntilTimestamp: undefined), and
-// parseInt on a missing/malformed attribute yields NaN. NaN poisons downstream comparisons
-// (`x > NaN` is always false), which reads as fail-open for the circuit breaker. Coerce at
-// the parse boundary so consumers always see finite numbers.
-function parseFiniteInt(value: string | undefined, fallback: number): number {
-  const parsed = parseInt(value as string);
-  return Number.isFinite(parsed) ? parsed : fallback;
+// The circuit-breaker state is small integers (unix seconds, small counts), so it is stored
+// as native DynamoDB numbers and read with a wrapNumbers:false client — no string parsing,
+// and a missing attribute reads as undefined (guarded with ?? below) rather than NaN.
+function circuitBreakerDocumentClient(): DynamoDBDocumentClient {
+  return DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+    marshallOptions: { convertEmptyValues: true },
+    unmarshallOptions: { wrapNumbers: false },
+  });
 }
 
 export class TimestampRepository implements BaseTimestampRepository {
   static log: Logger;
   static PARTITION_KEY = 'hash';
 
-  static create(documentClient: DynamoDBDocumentClient): BaseTimestampRepository {
+  static create(documentClient: DynamoDBDocumentClient = circuitBreakerDocumentClient()): BaseTimestampRepository {
     this.log = Logger.createLogger({
       name: 'DynamoTimestampRepository',
       serializers: Logger.stdSerializers,
@@ -44,7 +40,7 @@ export class TimestampRepository implements BaseTimestampRepository {
     delete this.log.fields.hostname;
 
     const table = new Table({
-      name: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS,
+      name: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS_V2,
       partitionKey: TimestampRepository.PARTITION_KEY,
       DocumentClient: documentClient,
     });
@@ -53,9 +49,10 @@ export class TimestampRepository implements BaseTimestampRepository {
       name: 'FillerTimestampEntity',
       attributes: {
         [TimestampRepository.PARTITION_KEY]: { partitionKey: true, type: 'string' },
-        [`${DYNAMO_TABLE_KEY.LAST_POST_TIMESTAMP}`]: { type: 'string' },
-        [`${DYNAMO_TABLE_KEY.BLOCK_UNTIL_TIMESTAMP}`]: { type: 'string' },
-        [`${DYNAMO_TABLE_KEY.CONSECUTIVE_BLOCKS}`]: { type: 'string' },
+        [`${DYNAMO_TABLE_KEY.LAST_EXAMINED_TIMESTAMP}`]: { type: 'number' },
+        [`${DYNAMO_TABLE_KEY.BLOCK_UNTIL_TIMESTAMP}`]: { type: 'number' },
+        [`${DYNAMO_TABLE_KEY.FADE_WINDOW_START}`]: { type: 'number' },
+        [`${DYNAMO_TABLE_KEY.CONSECUTIVE_BLOCKS}`]: { type: 'number' },
       },
       table: table,
       autoExecute: true,
@@ -75,8 +72,9 @@ export class TimestampRepository implements BaseTimestampRepository {
       updatedTimestamps.map((row) => {
         return this.entity.putBatch({
           [TimestampRepository.PARTITION_KEY]: row.hash,
-          [`${DYNAMO_TABLE_KEY.LAST_POST_TIMESTAMP}`]: row.lastPostTimestamp,
+          [`${DYNAMO_TABLE_KEY.LAST_EXAMINED_TIMESTAMP}`]: row.lastExaminedTimestamp,
           [`${DYNAMO_TABLE_KEY.BLOCK_UNTIL_TIMESTAMP}`]: row.blockUntilTimestamp,
+          [`${DYNAMO_TABLE_KEY.FADE_WINDOW_START}`]: row.fadeWindowStart,
           [`${DYNAMO_TABLE_KEY.CONSECUTIVE_BLOCKS}`]: row.consecutiveBlocks,
         });
       }),
@@ -95,9 +93,10 @@ export class TimestampRepository implements BaseTimestampRepository {
     );
     return {
       hash: Item?.hash,
-      lastPostTimestamp: parseFiniteInt(Item?.lastPostTimestamp, 0),
-      blockUntilTimestamp: parseFiniteInt(Item?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP),
-      consecutiveBlocks: parseFiniteInt(Item?.consecutiveBlocks, 0),
+      lastExaminedTimestamp: Item?.lastExaminedTimestamp ?? 0,
+      blockUntilTimestamp: Item?.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+      fadeWindowStart: Item?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+      consecutiveBlocks: Item?.consecutiveBlocks ?? 0,
     };
   }
 
@@ -113,12 +112,13 @@ export class TimestampRepository implements BaseTimestampRepository {
         parse: true,
       }
     );
-    return items[DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS].map((row: DynamoTimestampRepoRow) => {
+    return items[DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS_V2].map((row: DynamoTimestampRepoRow) => {
       return {
         hash: row.hash,
-        lastPostTimestamp: parseFiniteInt(row.lastPostTimestamp, 0),
-        blockUntilTimestamp: parseFiniteInt(row.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP),
-        consecutiveBlocks: parseFiniteInt(row.consecutiveBlocks, 0),
+        lastExaminedTimestamp: row.lastExaminedTimestamp ?? 0,
+        blockUntilTimestamp: row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+        fadeWindowStart: row.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+        consecutiveBlocks: row.consecutiveBlocks ?? 0,
       };
     });
   }
@@ -128,8 +128,9 @@ export class TimestampRepository implements BaseTimestampRepository {
     const res = new Map<string, Omit<TimestampRepoRow, 'hash'>>();
     rows.forEach((row) => {
       res.set(row.hash, {
-        lastPostTimestamp: row.lastPostTimestamp,
+        lastExaminedTimestamp: row.lastExaminedTimestamp,
         blockUntilTimestamp: row.blockUntilTimestamp,
+        fadeWindowStart: row.fadeWindowStart,
         consecutiveBlocks: row.consecutiveBlocks,
       });
     });

--- a/lib/repositories/timestamp-repository.ts
+++ b/lib/repositories/timestamp-repository.ts
@@ -9,6 +9,28 @@ export type BatchGetResponse = {
   tableName: string;
 };
 
+/**
+ * Sentinel for a filler that has NEVER been blocked (or whose stored state is unset/corrupt).
+ * Always < now for real unix seconds; also avoids equaling lastPostTimestamp, which could
+ * briefly read as blocked under clock skew.
+ *
+ * NOTE: this is deliberately NOT written for fillers coming off a block. The fade-rate cron's
+ * decay branch preserves their expired blockUntilTimestamp because it doubles as the
+ * clean-slate floor of the fade-rate window (only orders completed after it are scored).
+ * Overwriting it with this sentinel would erase that floor and re-score the filler's entire
+ * 24h history — including the pre-block fades that got them blocked in the first place.
+ */
+export const UNBLOCKED_BLOCK_UNTIL_TIMESTAMP = 0;
+
+// Rows are written with optional attributes (e.g. blockUntilTimestamp: undefined), and
+// parseInt on a missing/malformed attribute yields NaN. NaN poisons downstream comparisons
+// (`x > NaN` is always false), which reads as fail-open for the circuit breaker. Coerce at
+// the parse boundary so consumers always see finite numbers.
+function parseFiniteInt(value: string | undefined, fallback: number): number {
+  const parsed = parseInt(value as string);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 export class TimestampRepository implements BaseTimestampRepository {
   static log: Logger;
   static PARTITION_KEY = 'hash';
@@ -73,9 +95,9 @@ export class TimestampRepository implements BaseTimestampRepository {
     );
     return {
       hash: Item?.hash,
-      lastPostTimestamp: parseInt(Item?.lastPostTimestamp),
-      blockUntilTimestamp: parseInt(Item?.blockUntilTimestamp),
-      consecutiveBlocks: parseInt(Item?.consecutiveBlocks),
+      lastPostTimestamp: parseFiniteInt(Item?.lastPostTimestamp, 0),
+      blockUntilTimestamp: parseFiniteInt(Item?.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP),
+      consecutiveBlocks: parseFiniteInt(Item?.consecutiveBlocks, 0),
     };
   }
 
@@ -94,9 +116,9 @@ export class TimestampRepository implements BaseTimestampRepository {
     return items[DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS].map((row: DynamoTimestampRepoRow) => {
       return {
         hash: row.hash,
-        lastPostTimestamp: parseInt(row.lastPostTimestamp),
-        blockUntilTimestamp: parseInt(row.blockUntilTimestamp),
-        consecutiveBlocks: parseInt(row.consecutiveBlocks),
+        lastPostTimestamp: parseFiniteInt(row.lastPostTimestamp, 0),
+        blockUntilTimestamp: parseFiniteInt(row.blockUntilTimestamp, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP),
+        consecutiveBlocks: parseFiniteInt(row.consecutiveBlocks, 0),
       };
     });
   }

--- a/lib/util/rfqValidator.ts
+++ b/lib/util/rfqValidator.ts
@@ -1,8 +1,8 @@
-import Logger from "bunyan";
-import { ethers, BigNumber } from "ethers";
-import { QuoteRequestData } from "../entities";
-import { RfqResponse } from "../handlers/quote";
-import { PermissionedTokenValidator } from "@uniswap/uniswapx-sdk";
+import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk';
+import Logger from 'bunyan';
+import { BigNumber, ethers } from 'ethers';
+import { QuoteRequestData } from '../entities';
+import { PostQuoteResponse } from '../handlers/quote';
 
 export class RFQValidator {
   static ProviderRequiredError = class extends Error {
@@ -45,13 +45,7 @@ export class RFQValidator {
       return new RFQValidator.ProviderRequiredError(tokenAddress, chainId).message;
     }
 
-    const isValid = await PermissionedTokenValidator.preTransferCheck(
-      provider,
-      tokenAddress,
-      from,
-      to,
-      amount
-    );
+    const isValid = await PermissionedTokenValidator.preTransferCheck(provider, tokenAddress, from, to, amount);
 
     if (!isValid) {
       return new RFQValidator.PreTransferCheckError(tokenAddress, from, to, amount).message;
@@ -74,13 +68,12 @@ export class RFQValidator {
    */
   public static async validatePermissionedTokens(
     request: QuoteRequestData,
-    data: RfqResponse,
+    data: PostQuoteResponse,
     amountIn: BigNumber,
     amountOut: BigNumber,
     provider?: ethers.providers.StaticJsonRpcProvider,
     log?: Logger
   ): Promise<string | undefined> {
-    
     if (!data.filler) {
       return undefined;
     }
@@ -102,7 +95,7 @@ export class RFQValidator {
           request.swapper,
           amountOut.toString(),
           provider
-        )
+        ),
       ]);
 
       if (tokenInError) return tokenInError;

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -2,437 +2,231 @@ import Logger from 'bunyan';
 
 import {
   BASE_BLOCK_SECS,
+  calculateBlockUntilTimestamp,
   calculateNewTimestamps,
-  FillerFades,
+  FADE_RATE_BLOCK_THRESHOLD,
+  FillerFadeStatsMap,
   FillerTimestamps,
-  getFillersNewFades,
-  NUM_FADES_MULTIPLIER,
+  getFillersFadeStats,
+  laplaceSmoothedFadeRate,
+  LAPLACE_ALPHA,
+  LAPLACE_BETA,
   UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
 } from '../../lib/cron/fade-rate-v2';
 import { ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
 
 const now = Math.floor(Date.now() / 1000);
 
-// Note: deadline = postTimestamp + 20 (simulating 20-second order lifetime)
-// Orders are counted as "new" if deadline > lastPostTimestamp (not postTimestamp!)
-const FADES_ROWS: V2FadesRowType[] = [
-  // filler1 - lastPostTimestamp: now - 150, all orders have deadline > now - 150, so all counted
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000001',
-    faded: 1,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000001',
-    faded: 0,
-    postTimestamp: now - 90,
-    deadline: now - 70,
-  },
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000001',
-    faded: 1,
-    postTimestamp: now - 80,
-    deadline: now - 60,
-  },
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000002',
-    faded: 1,
-    postTimestamp: now - 80,
-    deadline: now - 60,
-  },
-  // filler2 - lastPostTimestamp: now - 75
-  // Order at now - 100 has deadline now - 80 which is NOT > now - 75, so NOT counted
-  // Order at now - 70 has deadline now - 50 which IS > now - 75, so counted
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000003',
-    faded: 1,
-    postTimestamp: now - 70,
-    deadline: now - 50,
-  },
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000003',
-    faded: 1,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  // filler3 - lastPostTimestamp: now - 101, deadline now - 80 > now - 101, so counted
-  // filler3 is BLOCKED (blockUntilTimestamp: now + 1000) and has a fade!
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000004',
-    faded: 1,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  // filler4 - lastPostTimestamp: now - 150, deadline now - 80 > now - 150, so counted
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000005',
-    faded: 0,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  // filler5 - lastPostTimestamp: now - 150, deadline now - 80 > now - 150, so counted
-  // filler5 is BLOCKED (blockUntilTimestamp: now + 100) but has NO fade
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000006',
-    faded: 0,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  // filler6 - not in FILLER_TIMESTAMPS, so all counted
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000007',
-    faded: 1,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  // filler7 - lastPostTimestamp: now - 150, deadline now - 80 > now - 150, so counted
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000008',
-    faded: 1,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-  // filler8 - lastPostTimestamp: now - 150, deadline now - 80 > now - 150, so counted
-  {
-    fillerAddress: '0x0000000000000000000000000000000000000009',
-    faded: 0,
-    postTimestamp: now - 100,
-    deadline: now - 80,
-  },
-];
-
-const ADDRESS_TO_FILLER = new Map<string, string>([
-  ['0x0000000000000000000000000000000000000001', 'filler1'],
-  ['0x0000000000000000000000000000000000000002', 'filler1'],
-  ['0x0000000000000000000000000000000000000003', 'filler2'],
-  ['0x0000000000000000000000000000000000000004', 'filler3'],
-  ['0x0000000000000000000000000000000000000005', 'filler4'],
-  ['0x0000000000000000000000000000000000000006', 'filler5'],
-  ['0x0000000000000000000000000000000000000007', 'filler6'],
-  ['0x0000000000000000000000000000000000000008', 'filler7'],
-  ['0x0000000000000000000000000000000000000009', 'filler8'],
-]);
-
-const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
-  ['filler1', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
-  ['filler2', { lastPostTimestamp: now - 75, blockUntilTimestamp: now - 50, consecutiveBlocks: 0 }],
-  ['filler3', { lastPostTimestamp: now - 101, blockUntilTimestamp: now + 1000, consecutiveBlocks: 0 }],
-  ['filler4', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN, consecutiveBlocks: 0 }],
-  ['filler5', { lastPostTimestamp: now - 150, blockUntilTimestamp: now + 100, consecutiveBlocks: 0 }],
-  ['filler7', { lastPostTimestamp: now - 150, blockUntilTimestamp: now - 50, consecutiveBlocks: 2 }],
-  ['filler8', { lastPostTimestamp: now - 150, blockUntilTimestamp: now - 50, consecutiveBlocks: 2 }],
-]);
-
 // silent logger in tests
 const logger = Logger.createLogger({ name: 'test' });
 logger.level(Logger.FATAL);
 
-describe('FadeRateCron test', () => {
-  let newFades: FillerFades;
-  beforeAll(() => {
-    newFades = getFillersNewFades(FADES_ROWS, ADDRESS_TO_FILLER, FILLER_TIMESTAMPS, logger);
+// helper to build a faded/non-faded order row
+const order = (fillerAddress: string, faded: 0 | 1, deadline: number): V2FadesRowType => ({
+  fillerAddress,
+  faded,
+  postTimestamp: deadline - 20,
+  deadline,
+});
+
+describe('FadeRateV2 cron', () => {
+  describe('laplaceSmoothedFadeRate', () => {
+    it('returns the prior mean for an empty sample', () => {
+      // (0 + 1) / (0 + 1 + 20) = 1/21 ≈ 0.0476
+      expect(laplaceSmoothedFadeRate(0, 0)).toBeCloseTo(LAPLACE_ALPHA / (LAPLACE_ALPHA + LAPLACE_BETA), 6);
+      expect(laplaceSmoothedFadeRate(0, 0)).toBeCloseTo(0.0476, 4);
+    });
+
+    it('pulls small samples toward the prior', () => {
+      // raw 50% (1/2) -> (1+1)/(2+21) ≈ 0.087, well under the 12% threshold
+      expect(laplaceSmoothedFadeRate(1, 2)).toBeCloseTo(2 / 23, 6);
+      expect(laplaceSmoothedFadeRate(1, 2)).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
+    });
+
+    it('converges to the empirical rate with volume', () => {
+      // sustained 50% on 50 samples -> clearly over threshold
+      expect(laplaceSmoothedFadeRate(25, 50)).toBeCloseTo(26 / 71, 6);
+      expect(laplaceSmoothedFadeRate(25, 50)).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
+      // high volume, low rate stays safe
+      expect(laplaceSmoothedFadeRate(3, 500)).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
+    });
   });
 
-  describe('getFillersNewFades', () => {
-    it('takes into account multiple filler addresses of the same filler', () => {
-      expect(newFades).toEqual({
-        filler1: 3, // count all fades in FADES_ROWS
-        filler2: 1, // only count postTimestamp == now - 70
-        filler3: 1,
-        filler4: 0,
-        filler5: 0,
-        filler6: 1,
-        filler7: 1,
-        filler8: 0,
-      });
+  describe('getFillersFadeStats', () => {
+    const ADDRESS_TO_FILLER = new Map<string, string>([
+      ['0x0000000000000000000000000000000000000001', 'fillerA'],
+      ['0x0000000000000000000000000000000000000002', 'fillerB'],
+      ['0x0000000000000000000000000000000000000003', 'fillerC'],
+      ['0x0000000000000000000000000000000000000004', 'fillerC'],
+    ]);
+
+    it('computes the smoothed rate and new fades for a filler with no prior timestamp', () => {
+      const rows: V2FadesRowType[] = [
+        ...Array(3)
+          .fill(0)
+          .map(() => order('0x0000000000000000000000000000000000000001', 1, now - 50)),
+        ...Array(7)
+          .fill(0)
+          .map(() => order('0x0000000000000000000000000000000000000001', 0, now - 50)),
+      ];
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
+      // window = all 10 orders (no prior block), rate = (3+1)/(10+21) = 4/31
+      expect(stats['fillerA'].fadeRate).toBeCloseTo(4 / 31, 6);
+      // no timestamp => every fade counts as new
+      expect(stats['fillerA'].newFades).toEqual(3);
+    });
+
+    it('excludes pre-block orders from the rate window and new fades', () => {
+      const fillerTimestamps: FillerTimestamps = new Map([
+        ['fillerB', { lastPostTimestamp: now - 150, blockUntilTimestamp: now - 200, consecutiveBlocks: 1 }],
+      ]);
+      const rows: V2FadesRowType[] = [
+        // pre-block fades (deadline now-300, before block end now-200): excluded from window;
+        // also before lastPostTimestamp (now-150) so excluded from newFades
+        order('0x0000000000000000000000000000000000000002', 1, now - 300),
+        order('0x0000000000000000000000000000000000000002', 1, now - 300),
+        // post-block orders (deadline now-100): 1 faded + 4 clean
+        order('0x0000000000000000000000000000000000000002', 1, now - 100),
+        ...Array(4)
+          .fill(0)
+          .map(() => order('0x0000000000000000000000000000000000000002', 0, now - 100)),
+      ];
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
+      // window = 5 post-block orders, 1 faded => (1+1)/(5+21) = 2/26
+      expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 26, 6);
+      // only the post-block fade is newer than lastPostTimestamp
+      expect(stats['fillerB'].newFades).toEqual(1);
+    });
+
+    it('aggregates multiple addresses belonging to the same filler', () => {
+      const rows: V2FadesRowType[] = [
+        order('0x0000000000000000000000000000000000000003', 1, now - 40),
+        order('0x0000000000000000000000000000000000000004', 1, now - 40),
+        order('0x0000000000000000000000000000000000000004', 0, now - 40),
+        order('0x0000000000000000000000000000000000000004', 0, now - 40),
+      ];
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
+      // combined: 2 faded / 4 total => (2+1)/(4+21) = 3/25 = 0.12
+      expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 25, 6);
+      expect(stats['fillerC'].newFades).toEqual(2);
+    });
+  });
+
+  describe('calculateBlockUntilTimestamp', () => {
+    it('escalates only on consecutive blocks (no per-fade multiplier)', () => {
+      expect(calculateBlockUntilTimestamp(now, 0)).toEqual(now + BASE_BLOCK_SECS);
+      expect(calculateBlockUntilTimestamp(now, 1)).toEqual(now + BASE_BLOCK_SECS * 2);
+      expect(calculateBlockUntilTimestamp(now, 2)).toEqual(now + BASE_BLOCK_SECS * 4);
+      expect(calculateBlockUntilTimestamp(now, undefined)).toEqual(now + BASE_BLOCK_SECS);
     });
   });
 
   describe('calculateNewTimestamps', () => {
-    let newTimestamps: ToUpdateTimestampRow[];
-
-    beforeAll(() => {
-      newTimestamps = calculateNewTimestamps(FILLER_TIMESTAMPS, newFades, now, logger);
+    it('blocks a filler whose fade rate exceeds the threshold', () => {
+      const timestamps: FillerTimestamps = new Map();
+      const stats: FillerFadeStatsMap = { newBad: { fadeRate: 0.2, newFades: 3 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row).toEqual({
+        hash: 'newBad',
+        lastPostTimestamp: now,
+        blockUntilTimestamp: now + BASE_BLOCK_SECS, // 2^0
+        consecutiveBlocks: 1,
+      });
     });
 
-    it('calculates blockUntilTimestamp for each filler', () => {
-      expect(newTimestamps).toEqual(
-        expect.arrayContaining([
-          {
-            hash: 'filler1',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: now + Math.floor(BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, 2)),
-            consecutiveBlocks: 1,
-          },
-          {
-            hash: 'filler2',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: now + Math.floor(BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, 0)),
-            consecutiveBlocks: 1,
-          },
-          // filler3 is blocked AND has a fade → EXTEND block from current blockUntil
-          // Block extended from (now + 1000) by BASE_BLOCK_SECS * 1.2^0 * 2^0 = 15 min
-          {
-            hash: 'filler3',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: now + 1000 + Math.floor(BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, 0)),
-            consecutiveBlocks: 1, // incremented from 0
-          },
-          // filler5 is blocked but has NO fade → keeps existing block
-          {
-            hash: 'filler5',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: now + 100,
-            consecutiveBlocks: 0,
-          },
-          // test exponential backoff
-          {
-            hash: 'filler7',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: now + Math.floor(BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, 0) * Math.pow(2, 2)),
-            consecutiveBlocks: 3,
-          },
-          // consecutiveBlocks DECAY instead of reset
-          // filler8 had consecutiveBlocks: 2, no fades → decays to 1
-          {
-            hash: 'filler8',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-            consecutiveBlocks: 1, // decayed from 2, not reset to 0
-          },
-        ])
-      );
+    it('does not block a filler under the threshold', () => {
+      const timestamps: FillerTimestamps = new Map();
+      const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, newFades: 0 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
+      expect(row.consecutiveBlocks).toEqual(0);
     });
 
-    it('notices new fillers not already in fillerTimestamps', () => {
-      // filler6 one fade, no existing consecutiveBlocks
-      expect(newTimestamps).toEqual(
-        expect.arrayContaining([
-          {
-            hash: 'filler6',
-            lastPostTimestamp: now,
-            blockUntilTimestamp: now + Math.floor(BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, 0)),
-            consecutiveBlocks: 1,
-          },
-        ])
-      );
+    it('uses consecutiveBlocks for backoff when re-blocking', () => {
+      // previously blocked twice, block now expired (past), breaches again
+      const timestamps: FillerTimestamps = new Map([
+        ['repeat', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 10, consecutiveBlocks: 2 }],
+      ]);
+      const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, newFades: 1 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
+      expect(row.consecutiveBlocks).toEqual(3);
     });
 
-    it('keep old blockUntilTimestamp if no new fades', () => {
-      expect(newTimestamps).not.toContain([['filler4', expect.anything(), expect.anything()]]);
+    it('preserves the past blockUntilTimestamp as the clean-slate floor while decaying', () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['recovering', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 500, consecutiveBlocks: 2 }],
+      ]);
+      const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, newFades: 0 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      // block end is kept (not reset to 0) so the rate window stays scoped to post-block orders
+      expect(row.blockUntilTimestamp).toEqual(now - 500);
+      expect(row.consecutiveBlocks).toEqual(1); // decayed 2 -> 1
     });
 
-    it('decays consecutiveBlocks instead of resetting to 0', () => {
-      // filler8 had consecutiveBlocks: 2 and no new fades
-      // decay to 1
-      const filler8 = newTimestamps.find((t) => t.hash === 'filler8');
-      expect(filler8?.consecutiveBlocks).toBe(1); // decayed, not reset
+    it('extends the block when a blocked filler fades again on in-flight orders', () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['blockedFader', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
+      ]);
+      // rate is near the prior (blocked => empty window), but new in-flight fades arrived
+      const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, newFades: 2 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
+      expect(row.consecutiveBlocks).toEqual(2);
     });
 
-    it('extends block when filler fades while blocked', () => {
-      // filler3 was blocked until now + 1000, and had 1 fade
-      // extend to now + 1000 + penalty
-      const filler3 = newTimestamps.find((t) => t.hash === 'filler3');
-      expect(filler3?.blockUntilTimestamp).toBeGreaterThan(now + 1000);
-      expect(filler3?.consecutiveBlocks).toBe(1); // incremented from 0
+    it('keeps an active block (no extend, no decay) when a blocked filler has no new fades', () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['blockedClean', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 300, consecutiveBlocks: 1 }],
+      ]);
+      // even a high rate must not extend while blocked without new fades
+      const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, newFades: 0 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(now + 300);
+      expect(row.consecutiveBlocks).toEqual(1);
     });
 
-    it('keeps block but does not decay when blocked with no fades', () => {
-      // filler5 was blocked until now + 100, and had 0 fades
-      // Should keep existing block without decaying consecutiveBlocks
-      const filler5 = newTimestamps.find((t) => t.hash === 'filler5');
-      expect(filler5?.blockUntilTimestamp).toBe(now + 100);
-      expect(filler5?.consecutiveBlocks).toBe(0); // unchanged, not decayed
-    });
-  });
-
-  describe('Alternating fade/clean cycle gaming', () => {
-    it('requires multiple clean cycles to fully reset consecutiveBlocks', () => {
-      // Simulate: Filler built up consecutiveBlocks: 3, now has a clean cycle
+    it('requires multiple clean cycles to fully decay consecutiveBlocks (anti-gaming)', () => {
       const timestamps: FillerTimestamps = new Map([
         ['gamer', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 3 }],
       ]);
+      const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, newFades: 0 } };
 
-      // Cycle 1: Clean (no fades)
-      let result = calculateNewTimestamps(timestamps, { gamer: 0 }, now, logger);
-      expect(result[0].consecutiveBlocks).toBe(2); // 3 → 2
+      let row = calculateNewTimestamps(timestamps, clean, now, logger)[0];
+      expect(row.consecutiveBlocks).toEqual(2);
 
-      // Cycle 2: Clean again
       timestamps.set('gamer', {
-        lastPostTimestamp: result[0].lastPostTimestamp,
-        blockUntilTimestamp: result[0].blockUntilTimestamp ?? now + 300,
-        consecutiveBlocks: result[0].consecutiveBlocks,
+        lastPostTimestamp: row.lastPostTimestamp,
+        blockUntilTimestamp: row.blockUntilTimestamp ?? now - 50,
+        consecutiveBlocks: row.consecutiveBlocks,
       });
-      result = calculateNewTimestamps(timestamps, { gamer: 0 }, now + 300, logger);
-      expect(result[0].consecutiveBlocks).toBe(1); // 2 → 1
+      row = calculateNewTimestamps(timestamps, clean, now + 300, logger)[0];
+      expect(row.consecutiveBlocks).toEqual(1);
 
-      // Cycle 3: Clean again
       timestamps.set('gamer', {
-        lastPostTimestamp: result[0].lastPostTimestamp,
-        blockUntilTimestamp: result[0].blockUntilTimestamp ?? now + 600,
-        consecutiveBlocks: result[0].consecutiveBlocks,
+        lastPostTimestamp: row.lastPostTimestamp,
+        blockUntilTimestamp: row.blockUntilTimestamp ?? now - 50,
+        consecutiveBlocks: row.consecutiveBlocks,
       });
-      result = calculateNewTimestamps(timestamps, { gamer: 0 }, now + 600, logger);
-      expect(result[0].consecutiveBlocks).toBe(0); // 1 → 0
-
-      // Takes 3 clean cycles, not 1!
+      row = calculateNewTimestamps(timestamps, clean, now + 600, logger)[0];
+      expect(row.consecutiveBlocks).toEqual(0);
     });
 
-    it('escalates penalty when filler fades after only partial decay', () => {
-      // Simulate: Filler has consecutiveBlocks: 2, does 1 clean cycle, then fades again
-      const timestamps: FillerTimestamps = new Map([
-        ['gamer', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 2 }],
-      ]);
-
-      // Cycle 1: Clean - decays from 2 to 1
-      let result = calculateNewTimestamps(timestamps, { gamer: 0 }, now, logger);
-      expect(result[0].consecutiveBlocks).toBe(1);
-
-      // Cycle 2: Fades again! consecutiveBlocks goes from 1 to 2
-      timestamps.set('gamer', {
-        lastPostTimestamp: now,
-        blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP, // block expired
-        consecutiveBlocks: 1,
-      });
-      result = calculateNewTimestamps(timestamps, { gamer: 1 }, now + 300, logger);
-      expect(result[0].consecutiveBlocks).toBe(2); // back up!
-
-      // Penalty should be: BASE_BLOCK_SECS * 1.2^0 * 2^1 = 30 minutes
-      const expectedBlock = now + 300 + Math.floor(BASE_BLOCK_SECS * Math.pow(2, 1));
-      expect(result[0].blockUntilTimestamp).toBe(expectedBlock);
-    });
-
-    it('OLD EXPLOIT: would have allowed indefinite 15-min penalties', () => {
-      // This test documents what the OLD behavior would have allowed:
-      // Filler fades, gets blocked 15 min, waits, does 1 clean cycle, fades again
-      // Result: Always gets minimum 15-min penalty, never escalates
-
-      // With NEW behavior, even alternating pattern eventually accumulates
-      const timestamps: FillerTimestamps = new Map([
-        ['attacker', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 0 }],
-      ]);
-
-      // Pattern: fade, clean, fade, clean, fade...
-      // Cycle 1: Fade
-      let result = calculateNewTimestamps(timestamps, { attacker: 1 }, now, logger);
-      expect(result[0].consecutiveBlocks).toBe(1);
-      const block1 = result[0].blockUntilTimestamp! - now; // ~15 min
-
-      // Cycle 2: Clean (after block expires)
-      timestamps.set('attacker', {
-        lastPostTimestamp: now,
-        blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-        consecutiveBlocks: 1,
-      });
-      result = calculateNewTimestamps(timestamps, { attacker: 0 }, now + 1000, logger);
-      expect(result[0].consecutiveBlocks).toBe(0); // decayed to 0
-
-      // Cycle 3: Fade again
-      timestamps.set('attacker', {
-        lastPostTimestamp: now + 1000,
-        blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-        consecutiveBlocks: 0,
-      });
-      result = calculateNewTimestamps(timestamps, { attacker: 1 }, now + 2000, logger);
-      expect(result[0].consecutiveBlocks).toBe(1);
-      const block3 = result[0].blockUntilTimestamp! - (now + 2000);
-
-      // Both penalties are the same (15 min) - this is still possible with alternating
-      // But at least they can't game it with a SINGLE clean cycle after building up blocks
-      expect(block1).toBe(block3);
-    });
-  });
-
-  /**
-   * EXPLOIT #2 PREVENTION TESTS
-   *
-   * Attack vector: Orders assigned before a block can fade during the block period,
-   * but those fades weren't being counted due to postTimestamp comparison.
-   * Also: Fading while blocked didn't extend the block or increment consecutiveBlocks.
-   *
-   * Old behavior: Fades during block were ignored
-   * New behavior: Block is extended and consecutiveBlocks incremented
-   */
-  describe('Exploit #2 Prevention: Fading while blocked', () => {
-    it('extends block when filler fades during existing block', () => {
+    it('processes a mix of fillers in one pass', () => {
       const timestamps: FillerTimestamps = new Map([
         ['blocked', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
       ]);
-
-      // Filler is blocked until now + 500, but has 2 fades from pre-block orders
-      const result = calculateNewTimestamps(timestamps, { blocked: 2 }, now, logger);
-      const blocked = result[0];
-
-      // Block should be EXTENDED from now + 500, not kept as-is
-      expect(blocked.blockUntilTimestamp).toBeGreaterThan(now + 500);
-
-      // consecutiveBlocks should increment
-      expect(blocked.consecutiveBlocks).toBe(2);
-
-      // Verify the extension amount: BASE_BLOCK_SECS * 1.2^(2-1) * 2^1
-      const expectedExtension = Math.floor(BASE_BLOCK_SECS * Math.pow(NUM_FADES_MULTIPLIER, 1) * Math.pow(2, 1));
-      expect(blocked.blockUntilTimestamp).toBe(now + 500 + expectedExtension);
-    });
-
-    it('counts orders by deadline, not postTimestamp (in-flight order fix)', () => {
-      // Scenario: Order posted at T=-100, deadline at T=-50
-      // lastPostTimestamp was T=-60 (set by previous cron run)
-      //
-      // OLD: postTimestamp (-100) > lastPostTimestamp (-60)? NO → not counted
-      // NEW: deadline (-50) > lastPostTimestamp (-60)? YES → counted
-
-      const timestamps: FillerTimestamps = new Map([
-        ['filler', { lastPostTimestamp: now - 60, blockUntilTimestamp: now - 100, consecutiveBlocks: 0 }],
-      ]);
-      const addressMap = new Map([['0x0000000000000000000000000000000000000001', 'filler']]);
-
-      // Order posted before lastPostTimestamp, but deadline after
-      const rows: V2FadesRowType[] = [
-        {
-          fillerAddress: '0x0000000000000000000000000000000000000001',
-          faded: 1,
-          postTimestamp: now - 100, // Before lastPostTimestamp
-          deadline: now - 50, // After lastPostTimestamp
-        },
-      ];
-
-      const fades = getFillersNewFades(rows, addressMap, timestamps, logger);
-
-      // With deadline-based check, this fade IS counted
-      expect(fades['filler']).toBe(1);
-    });
-
-    it('OLD EXPLOIT: fading while blocked had no consequences', () => {
-      // Document what OLD behavior would have done
-      const timestamps: FillerTimestamps = new Map([
-        ['badActor', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 1000, consecutiveBlocks: 2 }],
-      ]);
-
-      // With OLD behavior, this would have kept blockUntilTimestamp at now + 1000
-      // and consecutiveBlocks at 2 (no change)
-
-      // With NEW behavior:
-      const result = calculateNewTimestamps(timestamps, { badActor: 3 }, now, logger);
-
-      // Block is extended significantly
-      expect(result[0].blockUntilTimestamp).toBeGreaterThan(now + 1000);
-
-      // consecutiveBlocks increased
-      expect(result[0].consecutiveBlocks).toBe(3);
-    });
-
-    it('does not decay consecutiveBlocks while actively blocked', () => {
-      // If blocked with no new fades, should keep consecutiveBlocks (not decay)
-      const timestamps: FillerTimestamps = new Map([
-        ['blocked', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 3 }],
-      ]);
-
-      const result = calculateNewTimestamps(timestamps, { blocked: 0 }, now, logger);
-
-      // No decay while blocked - they're serving their time
-      expect(result[0].consecutiveBlocks).toBe(3);
-      expect(result[0].blockUntilTimestamp).toBe(now + 500);
+      const stats: FillerFadeStatsMap = {
+        breach: { fadeRate: 0.25, newFades: 2 },
+        clean: { fadeRate: 0.03, newFades: 0 },
+        blocked: { fadeRate: 0.05, newFades: 0 },
+      };
+      const rows: ToUpdateTimestampRow[] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(rows).toHaveLength(3);
+      const byHash = Object.fromEntries(rows.map((r) => [r.hash, r]));
+      expect(byHash['breach'].blockUntilTimestamp).toBeGreaterThan(now);
+      expect(byHash['clean'].blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
+      expect(byHash['blocked'].blockUntilTimestamp).toEqual(now + 500); // unchanged
     });
   });
 });

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -32,20 +32,20 @@ const order = (fillerAddress: string, faded: 0 | 1, deadline: number): V2FadesRo
 describe('FadeRateV2 cron', () => {
   describe('laplaceSmoothedFadeRate', () => {
     it('returns the prior mean for an empty sample', () => {
-      // (0 + 1) / (0 + 1 + 20) = 1/21 ≈ 0.0476
+      // (0 + 1) / (0 + 1 + 19) = 1/20 = 0.05
       expect(laplaceSmoothedFadeRate(0, 0)).toBeCloseTo(LAPLACE_ALPHA / (LAPLACE_ALPHA + LAPLACE_BETA), 6);
-      expect(laplaceSmoothedFadeRate(0, 0)).toBeCloseTo(0.0476, 4);
+      expect(laplaceSmoothedFadeRate(0, 0)).toBeCloseTo(0.05, 4);
     });
 
     it('pulls small samples toward the prior', () => {
-      // raw 50% (1/2) -> (1+1)/(2+21) ≈ 0.087, well under the 12% threshold
-      expect(laplaceSmoothedFadeRate(1, 2)).toBeCloseTo(2 / 23, 6);
+      // raw 50% (1/2) -> (1+1)/(2+20) ≈ 0.091, well under the 12% threshold
+      expect(laplaceSmoothedFadeRate(1, 2)).toBeCloseTo(2 / 22, 6);
       expect(laplaceSmoothedFadeRate(1, 2)).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
     });
 
     it('converges to the empirical rate with volume', () => {
       // sustained 50% on 50 samples -> clearly over threshold
-      expect(laplaceSmoothedFadeRate(25, 50)).toBeCloseTo(26 / 71, 6);
+      expect(laplaceSmoothedFadeRate(25, 50)).toBeCloseTo(26 / 70, 6);
       expect(laplaceSmoothedFadeRate(25, 50)).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
       // high volume, low rate stays safe
       expect(laplaceSmoothedFadeRate(3, 500)).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
@@ -70,8 +70,8 @@ describe('FadeRateV2 cron', () => {
           .map(() => order('0x0000000000000000000000000000000000000001', 0, now - 50)),
       ];
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
-      // window = all 10 orders (no prior block), rate = (3+1)/(10+21) = 4/31
-      expect(stats['fillerA'].fadeRate).toBeCloseTo(4 / 31, 6);
+      // window = all 10 orders (no prior block), rate = (3+1)/(10+20) = 4/30
+      expect(stats['fillerA'].fadeRate).toBeCloseTo(4 / 30, 6);
       // no timestamp => every fade counts as new
       expect(stats['fillerA'].newFades).toEqual(3);
     });
@@ -92,8 +92,8 @@ describe('FadeRateV2 cron', () => {
           .map(() => order('0x0000000000000000000000000000000000000002', 0, now - 100)),
       ];
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
-      // window = 5 post-block orders, 1 faded => (1+1)/(5+21) = 2/26
-      expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 26, 6);
+      // window = 5 post-block orders, 1 faded => (1+1)/(5+20) = 2/25
+      expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 25, 6);
       // only the post-block fade is newer than lastPostTimestamp
       expect(stats['fillerB'].newFades).toEqual(1);
     });
@@ -106,8 +106,8 @@ describe('FadeRateV2 cron', () => {
         order('0x0000000000000000000000000000000000000004', 0, now - 40),
       ];
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
-      // combined: 2 faded / 4 total => (2+1)/(4+21) = 3/25 = 0.12
-      expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 25, 6);
+      // combined: 2 faded / 4 total => (2+1)/(4+20) = 3/24 = 0.125
+      expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 24, 6);
       expect(stats['fillerC'].newFades).toEqual(2);
     });
 
@@ -127,8 +127,8 @@ describe('FadeRateV2 cron', () => {
           .map(() => order('0x0000000000000000000000000000000000000001', 0, now - 50)),
       ];
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
-      // all 10 orders counted: (4+1)/(10+21) = 5/31 ≈ 0.161 > threshold
-      expect(stats['fillerA'].fadeRate).toBeCloseTo(5 / 31, 6);
+      // all 10 orders counted: (4+1)/(10+20) = 5/30 ≈ 0.167 > threshold
+      expect(stats['fillerA'].fadeRate).toBeCloseTo(5 / 30, 6);
       expect(stats['fillerA'].fadeRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
       expect(stats['fillerA'].newFades).toEqual(4);
     });

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -110,6 +110,28 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 25, 6);
       expect(stats['fillerC'].newFades).toEqual(2);
     });
+
+    it('treats a non-finite (NaN) stored timestamp as unset, not silently zeroing the window', () => {
+      // A corrupted/missing Dynamo attribute parses to NaN. `deadline > NaN` is always
+      // false, so without the guard windowTotal would stay 0 and the filler could never
+      // be blocked. With the guard, NaN behaves like "unset" (floor 0) => all orders count.
+      const fillerTimestamps: FillerTimestamps = new Map([
+        ['fillerA', { lastPostTimestamp: NaN, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
+      ]);
+      const rows: V2FadesRowType[] = [
+        ...Array(4)
+          .fill(0)
+          .map(() => order('0x0000000000000000000000000000000000000001', 1, now - 50)),
+        ...Array(6)
+          .fill(0)
+          .map(() => order('0x0000000000000000000000000000000000000001', 0, now - 50)),
+      ];
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
+      // all 10 orders counted: (4+1)/(10+21) = 5/31 ≈ 0.161 > threshold
+      expect(stats['fillerA'].fadeRate).toBeCloseTo(5 / 31, 6);
+      expect(stats['fillerA'].fadeRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
+      expect(stats['fillerA'].newFades).toEqual(4);
+    });
   });
 
   describe('calculateBlockUntilTimestamp', () => {
@@ -132,6 +154,18 @@ describe('FadeRateV2 cron', () => {
         blockUntilTimestamp: now + BASE_BLOCK_SECS, // 2^0
         consecutiveBlocks: 1,
       });
+    });
+
+    it('does not re-persist a non-finite (NaN) blockUntilTimestamp in the decay branch', () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['corrupt', { lastPostTimestamp: NaN, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
+      ]);
+      const stats: FillerFadeStatsMap = { corrupt: { fadeRate: 0.04, newFades: 0 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      // NaN floor is normalized back to the unblocked sentinel, not written back as NaN
+      expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
+      expect(Number.isNaN(row.blockUntilTimestamp)).toBe(false);
+      expect(row.consecutiveBlocks).toEqual(0);
     });
 
     it('does not block a filler under the threshold', () => {

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -93,6 +93,8 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerA'].fadeRate).toBeCloseTo(4 / 30, 6);
       // never blocked => empty during-block cohort => prior mean
       expect(stats['fillerA'].duringBlockRate).toBeCloseTo(0.05, 6);
+      // no prior timestamp => every completion is new
+      expect(stats['fillerA'].newCompletions).toEqual(10);
     });
 
     it('excludes pre-block orders from the rate window', () => {
@@ -115,6 +117,8 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 25, 6);
       // stale pre-block fades don't resurrect as a during-block cohort
       expect(stats['fillerB'].duringBlockRate).toBeCloseTo(0.05, 6);
+      // only the 5 post-lastPost orders are new completions
+      expect(stats['fillerB'].newCompletions).toEqual(5);
     });
 
     it('scores in-flight orders that completed during a block, even after it expired', () => {
@@ -139,6 +143,7 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerB'].duringBlockRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
       // window = 1 clean post-block order
       expect(stats['fillerB'].fadeRate).toBeCloseTo(1 / 21, 6);
+      expect(stats['fillerB'].newCompletions).toEqual(4);
     });
 
     it('aggregates multiple addresses belonging to the same filler', () => {
@@ -190,7 +195,7 @@ describe('FadeRateV2 cron', () => {
   describe('calculateNewTimestamps', () => {
     it('blocks a filler whose fade rate exceeds the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = { newBad: { fadeRate: 0.2, duringBlockRate: 0.05 } };
+      const stats: FillerFadeStatsMap = { newBad: { fadeRate: 0.2, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row).toEqual({
         hash: 'newBad',
@@ -204,7 +209,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['corrupt', { lastPostTimestamp: NaN, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
       ]);
-      const stats: FillerFadeStatsMap = { corrupt: { fadeRate: 0.04, duringBlockRate: 0.05 } };
+      const stats: FillerFadeStatsMap = { corrupt: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       // NaN floor is normalized back to the unblocked sentinel, not written back as NaN
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
@@ -214,7 +219,7 @@ describe('FadeRateV2 cron', () => {
 
     it('does not block a filler under the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, duringBlockRate: 0.05 } };
+      const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
       expect(row.consecutiveBlocks).toEqual(0);
@@ -225,7 +230,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['repeat', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 10, consecutiveBlocks: 2 }],
       ]);
-      const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, duringBlockRate: 0.05 } };
+      const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
       expect(row.consecutiveBlocks).toEqual(3);
@@ -235,11 +240,24 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['recovering', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 500, consecutiveBlocks: 2 }],
       ]);
-      const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, duringBlockRate: 0.05 } };
+      const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       // block end is kept (not reset to 0) so the rate window stays scoped to post-block orders
       expect(row.blockUntilTimestamp).toEqual(now - 500);
       expect(row.consecutiveBlocks).toEqual(1); // decayed 2 -> 1
+    });
+
+    it('freezes consecutiveBlocks while idle: no new completions means no decay', () => {
+      // A filler's stale rows can sit in the 24h view long after their block expired. Without
+      // the newCompletions gate, escalation would decay every 10-minute cron run while they
+      // simply idle — resetting 3 -> 0 in ~30 minutes with zero demonstrated clean fills.
+      const timestamps: FillerTimestamps = new Map([
+        ['idler', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 3 }],
+      ]);
+      const stats: FillerFadeStatsMap = { idler: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 0 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.consecutiveBlocks).toEqual(3); // frozen, not decayed
+      expect(row.blockUntilTimestamp).toEqual(now - 50); // clean-slate floor preserved
     });
 
     it('extends the block when in-flight orders fade at over the threshold rate while blocked', () => {
@@ -248,7 +266,7 @@ describe('FadeRateV2 cron', () => {
       ]);
       // post-block rate sits at the prior (blocked => empty window), but the in-flight
       // cohort faded at over the threshold rate
-      const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2 } };
+      const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
       expect(row.consecutiveBlocks).toEqual(2);
@@ -262,7 +280,7 @@ describe('FadeRateV2 cron', () => {
       // Under the old count-based rule (newFades > 0) this high-volume filler's block
       // would have been extended by a single statistical fade.
       const stats: FillerFadeStatsMap = {
-        blockedBusy: { fadeRate: 0.05, duringBlockRate: laplaceSmoothedFadeRate(1, 20) },
+        blockedBusy: { fadeRate: 0.05, duringBlockRate: laplaceSmoothedFadeRate(1, 20), newCompletions: 1 },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500); // kept, not extended
@@ -275,7 +293,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['lateFader', { lastPostTimestamp: now - 400, blockUntilTimestamp: now - 10, consecutiveBlocks: 1 }],
       ]);
-      const stats: FillerFadeStatsMap = { lateFader: { fadeRate: 0.05, duringBlockRate: 0.14 } };
+      const stats: FillerFadeStatsMap = { lateFader: { fadeRate: 0.05, duringBlockRate: 0.14, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2); // 2^1 backoff
       expect(row.consecutiveBlocks).toEqual(2);
@@ -286,7 +304,7 @@ describe('FadeRateV2 cron', () => {
         ['blockedClean', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 300, consecutiveBlocks: 1 }],
       ]);
       // even a high (stale) window rate must not extend an active block by itself
-      const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05 } };
+      const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 300);
       expect(row.consecutiveBlocks).toEqual(1);
@@ -296,7 +314,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['gamer', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 3 }],
       ]);
-      const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, duringBlockRate: 0.05 } };
+      const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1 } };
 
       let row = calculateNewTimestamps(timestamps, clean, now, logger)[0];
       expect(row.consecutiveBlocks).toEqual(2);
@@ -323,9 +341,9 @@ describe('FadeRateV2 cron', () => {
         ['blocked', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: { fadeRate: 0.25, duringBlockRate: 0.05 },
-        clean: { fadeRate: 0.03, duringBlockRate: 0.05 },
-        blocked: { fadeRate: 0.05, duringBlockRate: 0.05 },
+        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1 },
+        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1 },
+        blocked: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 },
       };
       const rows: ToUpdateTimestampRow[] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(rows).toHaveLength(3);

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -79,7 +79,7 @@ describe('FadeRateV2 cron', () => {
       ['0x0000000000000000000000000000000000000004', 'fillerC'],
     ]);
 
-    it('computes the smoothed rate and new fades for a filler with no prior timestamp', () => {
+    it('computes the smoothed rates for a filler with no prior timestamp', () => {
       const rows: V2FadesRowType[] = [
         ...Array(3)
           .fill(0)
@@ -91,17 +91,17 @@ describe('FadeRateV2 cron', () => {
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
       // window = all 10 orders (no prior block), rate = (3+1)/(10+20) = 4/30
       expect(stats['fillerA'].fadeRate).toBeCloseTo(4 / 30, 6);
-      // no timestamp => every fade counts as new
-      expect(stats['fillerA'].newFades).toEqual(3);
+      // never blocked => empty during-block cohort => prior mean
+      expect(stats['fillerA'].duringBlockRate).toBeCloseTo(0.05, 6);
     });
 
-    it('excludes pre-block orders from the rate window and new fades', () => {
+    it('excludes pre-block orders from the rate window', () => {
       const fillerTimestamps: FillerTimestamps = new Map([
         ['fillerB', { lastPostTimestamp: now - 150, blockUntilTimestamp: now - 200, consecutiveBlocks: 1 }],
       ]);
       const rows: V2FadesRowType[] = [
         // pre-block fades (deadline now-300, before block end now-200): excluded from window;
-        // also before lastPostTimestamp (now-150) so excluded from newFades
+        // also before lastPostTimestamp (now-150) so not part of the during-block cohort
         order('0x0000000000000000000000000000000000000002', 1, now - 300),
         order('0x0000000000000000000000000000000000000002', 1, now - 300),
         // post-block orders (deadline now-100): 1 faded + 4 clean
@@ -113,8 +113,32 @@ describe('FadeRateV2 cron', () => {
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
       // window = 5 post-block orders, 1 faded => (1+1)/(5+20) = 2/25
       expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 25, 6);
-      // only the post-block fade is newer than lastPostTimestamp
-      expect(stats['fillerB'].newFades).toEqual(1);
+      // stale pre-block fades don't resurrect as a during-block cohort
+      expect(stats['fillerB'].duringBlockRate).toBeCloseTo(0.05, 6);
+    });
+
+    it('scores in-flight orders that completed during a block, even after it expired', () => {
+      // Block ran until now-100 and has expired; the last cron run was at now-400 (while
+      // blocked). Orders completed in between (deadline in (now-400, now-100]) were in
+      // flight during the block: below the clean-slate floor, so they never enter the
+      // post-block window — the during-block cohort is the only path that scores them.
+      const fillerTimestamps: FillerTimestamps = new Map([
+        ['fillerB', { lastPostTimestamp: now - 400, blockUntilTimestamp: now - 100, consecutiveBlocks: 1 }],
+      ]);
+      const rows: V2FadesRowType[] = [
+        // during-block cohort: 2 faded + 1 clean
+        order('0x0000000000000000000000000000000000000002', 1, now - 200),
+        order('0x0000000000000000000000000000000000000002', 1, now - 200),
+        order('0x0000000000000000000000000000000000000002', 0, now - 200),
+        // post-block window: 1 clean
+        order('0x0000000000000000000000000000000000000002', 0, now - 50),
+      ];
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
+      // cohort = (2+1)/(3+20) = 3/23 ≈ 13.0% > threshold => calculateNewTimestamps re-blocks
+      expect(stats['fillerB'].duringBlockRate).toBeCloseTo(3 / 23, 6);
+      expect(stats['fillerB'].duringBlockRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
+      // window = 1 clean post-block order
+      expect(stats['fillerB'].fadeRate).toBeCloseTo(1 / 21, 6);
     });
 
     it('aggregates multiple addresses belonging to the same filler', () => {
@@ -127,7 +151,7 @@ describe('FadeRateV2 cron', () => {
       const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
       // combined: 2 faded / 4 total => (2+1)/(4+20) = 3/24 = 0.125
       expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 24, 6);
-      expect(stats['fillerC'].newFades).toEqual(2);
+      expect(stats['fillerC'].duringBlockRate).toBeCloseTo(0.05, 6);
     });
 
     it('treats a non-finite (NaN) stored timestamp as unset, not silently zeroing the window', () => {
@@ -149,7 +173,8 @@ describe('FadeRateV2 cron', () => {
       // all 10 orders counted: (4+1)/(10+20) = 5/30 ≈ 0.167 > threshold
       expect(stats['fillerA'].fadeRate).toBeCloseTo(5 / 30, 6);
       expect(stats['fillerA'].fadeRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
-      expect(stats['fillerA'].newFades).toEqual(4);
+      // NaN floor coerces to the unset sentinel, so no during-block cohort exists
+      expect(stats['fillerA'].duringBlockRate).toBeCloseTo(0.05, 6);
     });
   });
 
@@ -165,7 +190,7 @@ describe('FadeRateV2 cron', () => {
   describe('calculateNewTimestamps', () => {
     it('blocks a filler whose fade rate exceeds the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = { newBad: { fadeRate: 0.2, newFades: 3 } };
+      const stats: FillerFadeStatsMap = { newBad: { fadeRate: 0.2, duringBlockRate: 0.05 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row).toEqual({
         hash: 'newBad',
@@ -179,7 +204,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['corrupt', { lastPostTimestamp: NaN, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
       ]);
-      const stats: FillerFadeStatsMap = { corrupt: { fadeRate: 0.04, newFades: 0 } };
+      const stats: FillerFadeStatsMap = { corrupt: { fadeRate: 0.04, duringBlockRate: 0.05 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       // NaN floor is normalized back to the unblocked sentinel, not written back as NaN
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
@@ -189,7 +214,7 @@ describe('FadeRateV2 cron', () => {
 
     it('does not block a filler under the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, newFades: 0 } };
+      const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, duringBlockRate: 0.05 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
       expect(row.consecutiveBlocks).toEqual(0);
@@ -200,7 +225,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['repeat', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 10, consecutiveBlocks: 2 }],
       ]);
-      const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, newFades: 1 } };
+      const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, duringBlockRate: 0.05 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
       expect(row.consecutiveBlocks).toEqual(3);
@@ -210,30 +235,58 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['recovering', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 500, consecutiveBlocks: 2 }],
       ]);
-      const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, newFades: 0 } };
+      const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, duringBlockRate: 0.05 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       // block end is kept (not reset to 0) so the rate window stays scoped to post-block orders
       expect(row.blockUntilTimestamp).toEqual(now - 500);
       expect(row.consecutiveBlocks).toEqual(1); // decayed 2 -> 1
     });
 
-    it('extends the block when a blocked filler fades again on in-flight orders', () => {
+    it('extends the block when in-flight orders fade at over the threshold rate while blocked', () => {
       const timestamps: FillerTimestamps = new Map([
         ['blockedFader', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
       ]);
-      // rate is near the prior (blocked => empty window), but new in-flight fades arrived
-      const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, newFades: 2 } };
+      // post-block rate sits at the prior (blocked => empty window), but the in-flight
+      // cohort faded at over the threshold rate
+      const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
       expect(row.consecutiveBlocks).toEqual(2);
     });
 
-    it('keeps an active block (no extend, no decay) when a blocked filler has no new fades', () => {
+    it("does not extend when a blocked filler's stray in-flight fade is offset by clean fills", () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['blockedBusy', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
+      ]);
+      // 1 fade among 19 clean in-flight fills: (1+1)/(20+20) = 5% <= threshold.
+      // Under the old count-based rule (newFades > 0) this high-volume filler's block
+      // would have been extended by a single statistical fade.
+      const stats: FillerFadeStatsMap = {
+        blockedBusy: { fadeRate: 0.05, duringBlockRate: laplaceSmoothedFadeRate(1, 20) },
+      };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(now + 500); // kept, not extended
+      expect(row.consecutiveBlocks).toEqual(1);
+    });
+
+    it('re-blocks after expiry when in-flight orders faded during the block (slip-through fix)', () => {
+      // The block expired between cron runs; the fades landed while it was active, so they
+      // sit below the clean-slate floor (fadeRate at prior) — duringBlockRate catches them.
+      const timestamps: FillerTimestamps = new Map([
+        ['lateFader', { lastPostTimestamp: now - 400, blockUntilTimestamp: now - 10, consecutiveBlocks: 1 }],
+      ]);
+      const stats: FillerFadeStatsMap = { lateFader: { fadeRate: 0.05, duringBlockRate: 0.14 } };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2); // 2^1 backoff
+      expect(row.consecutiveBlocks).toEqual(2);
+    });
+
+    it('keeps an active block (no extend, no decay) when the in-flight cohort is clean', () => {
       const timestamps: FillerTimestamps = new Map([
         ['blockedClean', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 300, consecutiveBlocks: 1 }],
       ]);
-      // even a high rate must not extend while blocked without new fades
-      const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, newFades: 0 } };
+      // even a high (stale) window rate must not extend an active block by itself
+      const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 300);
       expect(row.consecutiveBlocks).toEqual(1);
@@ -243,7 +296,7 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         ['gamer', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 3 }],
       ]);
-      const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, newFades: 0 } };
+      const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, duringBlockRate: 0.05 } };
 
       let row = calculateNewTimestamps(timestamps, clean, now, logger)[0];
       expect(row.consecutiveBlocks).toEqual(2);
@@ -270,9 +323,9 @@ describe('FadeRateV2 cron', () => {
         ['blocked', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: { fadeRate: 0.25, newFades: 2 },
-        clean: { fadeRate: 0.03, newFades: 0 },
-        blocked: { fadeRate: 0.05, newFades: 0 },
+        breach: { fadeRate: 0.25, duringBlockRate: 0.05 },
+        clean: { fadeRate: 0.03, duringBlockRate: 0.05 },
+        blocked: { fadeRate: 0.05, duringBlockRate: 0.05 },
       };
       const rows: ToUpdateTimestampRow[] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(rows).toHaveLength(3);

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -50,6 +50,25 @@ describe('FadeRateV2 cron', () => {
       // high volume, low rate stays safe
       expect(laplaceSmoothedFadeRate(3, 500)).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
     });
+
+    it('catches the evasion scenarios under the 24h / latest-100 window', () => {
+      // These pin the window parameters (24h view window, ORDERS_PER_FILLER_LIMIT=100)
+      // to the scenarios they were chosen for — see PR #454 review discussion.
+
+      // Low-volume filler fading every order (e.g. 1 order/hr): the 24h window
+      // accumulates their orders, so 2 fades already trips the threshold.
+      expect(laplaceSmoothedFadeRate(2, 2)).toBeCloseTo(3 / 22, 6);
+      expect(laplaceSmoothedFadeRate(2, 2)).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
+
+      // High-volume chronic ~14% fader (e.g. 7 fades per 50 orders/hr): the latest-100
+      // cap holds ~14 fades -> 15/120 = 12.5% > 12%. (With the old 1h/latest-50 window
+      // this filler sat at 8/70 = 11.4% and was never blocked.)
+      expect(laplaceSmoothedFadeRate(14, 100)).toBeCloseTo(15 / 120, 6);
+      expect(laplaceSmoothedFadeRate(14, 100)).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
+
+      // A legitimate sustained ~10% filler at the same volume stays clear.
+      expect(laplaceSmoothedFadeRate(10, 100)).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
+    });
   });
 
   describe('getFillersFadeStats', () => {

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -99,11 +99,20 @@ describe('FadeRateV2 cron', () => {
 
     it('excludes pre-block orders from the rate window', () => {
       const fillerTimestamps: FillerTimestamps = new Map([
-        ['fillerB', { lastPostTimestamp: now - 150, blockUntilTimestamp: now - 200, consecutiveBlocks: 1 }],
+        // fadeWindowStart (the clean-slate floor) is the last block end at now-200
+        [
+          'fillerB',
+          {
+            lastExaminedTimestamp: now - 150,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 200,
+            consecutiveBlocks: 1,
+          },
+        ],
       ]);
       const rows: V2FadesRowType[] = [
         // pre-block fades (deadline now-300, before block end now-200): excluded from window;
-        // also before lastPostTimestamp (now-150) so not part of the during-block cohort
+        // also before lastExaminedTimestamp (now-150) so not part of the during-block cohort
         order('0x0000000000000000000000000000000000000002', 1, now - 300),
         order('0x0000000000000000000000000000000000000002', 1, now - 300),
         // post-block orders (deadline now-100): 1 faded + 4 clean
@@ -127,7 +136,16 @@ describe('FadeRateV2 cron', () => {
       // flight during the block: below the clean-slate floor, so they never enter the
       // post-block window — the during-block cohort is the only path that scores them.
       const fillerTimestamps: FillerTimestamps = new Map([
-        ['fillerB', { lastPostTimestamp: now - 400, blockUntilTimestamp: now - 100, consecutiveBlocks: 1 }],
+        // block ended at now-100 => fadeWindowStart is now-100; last cron run at now-400
+        [
+          'fillerB',
+          {
+            lastExaminedTimestamp: now - 400,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 100,
+            consecutiveBlocks: 1,
+          },
+        ],
       ]);
       const rows: V2FadesRowType[] = [
         // during-block cohort: 2 faded + 1 clean
@@ -158,29 +176,6 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 24, 6);
       expect(stats['fillerC'].duringBlockRate).toBeCloseTo(0.05, 6);
     });
-
-    it('treats a non-finite (NaN) stored timestamp as unset, not silently zeroing the window', () => {
-      // A corrupted/missing Dynamo attribute parses to NaN. `deadline > NaN` is always
-      // false, so without the guard windowTotal would stay 0 and the filler could never
-      // be blocked. With the guard, NaN behaves like "unset" (floor 0) => all orders count.
-      const fillerTimestamps: FillerTimestamps = new Map([
-        ['fillerA', { lastPostTimestamp: NaN, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
-      ]);
-      const rows: V2FadesRowType[] = [
-        ...Array(4)
-          .fill(0)
-          .map(() => order('0x0000000000000000000000000000000000000001', 1, now - 50)),
-        ...Array(6)
-          .fill(0)
-          .map(() => order('0x0000000000000000000000000000000000000001', 0, now - 50)),
-      ];
-      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
-      // all 10 orders counted: (4+1)/(10+20) = 5/30 ≈ 0.167 > threshold
-      expect(stats['fillerA'].fadeRate).toBeCloseTo(5 / 30, 6);
-      expect(stats['fillerA'].fadeRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
-      // NaN floor coerces to the unset sentinel, so no during-block cohort exists
-      expect(stats['fillerA'].duringBlockRate).toBeCloseTo(0.05, 6);
-    });
   });
 
   describe('calculateBlockUntilTimestamp', () => {
@@ -199,22 +194,11 @@ describe('FadeRateV2 cron', () => {
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row).toEqual({
         hash: 'newBad',
-        lastPostTimestamp: now,
+        lastExaminedTimestamp: now,
         blockUntilTimestamp: now + BASE_BLOCK_SECS, // 2^0
+        fadeWindowStart: now + BASE_BLOCK_SECS, // floor = block end
         consecutiveBlocks: 1,
       });
-    });
-
-    it('does not re-persist a non-finite (NaN) blockUntilTimestamp in the decay branch', () => {
-      const timestamps: FillerTimestamps = new Map([
-        ['corrupt', { lastPostTimestamp: NaN, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
-      ]);
-      const stats: FillerFadeStatsMap = { corrupt: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1 } };
-      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
-      // NaN floor is normalized back to the unblocked sentinel, not written back as NaN
-      expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
-      expect(Number.isNaN(row.blockUntilTimestamp)).toBe(false);
-      expect(row.consecutiveBlocks).toEqual(0);
     });
 
     it('does not block a filler under the threshold', () => {
@@ -222,28 +206,41 @@ describe('FadeRateV2 cron', () => {
       const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
+      expect(row.fadeWindowStart).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // never blocked
       expect(row.consecutiveBlocks).toEqual(0);
     });
 
     it('uses consecutiveBlocks for backoff when re-blocking', () => {
       // previously blocked twice, block now expired (past), breaches again
       const timestamps: FillerTimestamps = new Map([
-        ['repeat', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 10, consecutiveBlocks: 2 }],
+        [
+          'repeat',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 10, consecutiveBlocks: 2 },
+        ],
       ]);
       const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
+      expect(row.fadeWindowStart).toEqual(now + BASE_BLOCK_SECS * 4);
       expect(row.consecutiveBlocks).toEqual(3);
     });
 
-    it('preserves the past blockUntilTimestamp as the clean-slate floor while decaying', () => {
+    it('resets blockUntilTimestamp but preserves fadeWindowStart while decaying', () => {
       const timestamps: FillerTimestamps = new Map([
-        ['recovering', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 500, consecutiveBlocks: 2 }],
+        [
+          'recovering',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 500,
+            consecutiveBlocks: 2,
+          },
+        ],
       ]);
       const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
-      // block end is kept (not reset to 0) so the rate window stays scoped to post-block orders
-      expect(row.blockUntilTimestamp).toEqual(now - 500);
+      expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // not blocked
+      expect(row.fadeWindowStart).toEqual(now - 500); // clean-slate floor preserved independently
       expect(row.consecutiveBlocks).toEqual(1); // decayed 2 -> 1
     });
 
@@ -252,29 +249,49 @@ describe('FadeRateV2 cron', () => {
       // the newCompletions gate, escalation would decay every 10-minute cron run while they
       // simply idle — resetting 3 -> 0 in ~30 minutes with zero demonstrated clean fills.
       const timestamps: FillerTimestamps = new Map([
-        ['idler', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 3 }],
+        [
+          'idler',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 3 },
+        ],
       ]);
       const stats: FillerFadeStatsMap = { idler: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 0 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.consecutiveBlocks).toEqual(3); // frozen, not decayed
-      expect(row.blockUntilTimestamp).toEqual(now - 50); // clean-slate floor preserved
+      expect(row.fadeWindowStart).toEqual(now - 50); // clean-slate floor preserved
     });
 
     it('extends the block when in-flight orders fade at over the threshold rate while blocked', () => {
       const timestamps: FillerTimestamps = new Map([
-        ['blockedFader', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
+        [
+          'blockedFader',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
       ]);
       // post-block rate sits at the prior (blocked => empty window), but the in-flight
       // cohort faded at over the threshold rate
       const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
+      expect(row.fadeWindowStart).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // floor tracks the extended end
       expect(row.consecutiveBlocks).toEqual(2);
     });
 
     it("does not extend when a blocked filler's stray in-flight fade is offset by clean fills", () => {
       const timestamps: FillerTimestamps = new Map([
-        ['blockedBusy', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
+        [
+          'blockedBusy',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
       ]);
       // 1 fade among 19 clean in-flight fills: (1+1)/(20+20) = 5% <= threshold.
       // Under the old count-based rule (newFades > 0) this high-volume filler's block
@@ -291,7 +308,10 @@ describe('FadeRateV2 cron', () => {
       // The block expired between cron runs; the fades landed while it was active, so they
       // sit below the clean-slate floor (fadeRate at prior) — duringBlockRate catches them.
       const timestamps: FillerTimestamps = new Map([
-        ['lateFader', { lastPostTimestamp: now - 400, blockUntilTimestamp: now - 10, consecutiveBlocks: 1 }],
+        [
+          'lateFader',
+          { lastExaminedTimestamp: now - 400, blockUntilTimestamp: 0, fadeWindowStart: now - 10, consecutiveBlocks: 1 },
+        ],
       ]);
       const stats: FillerFadeStatsMap = { lateFader: { fadeRate: 0.05, duringBlockRate: 0.14, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
@@ -301,18 +321,30 @@ describe('FadeRateV2 cron', () => {
 
     it('keeps an active block (no extend, no decay) when the in-flight cohort is clean', () => {
       const timestamps: FillerTimestamps = new Map([
-        ['blockedClean', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 300, consecutiveBlocks: 1 }],
+        [
+          'blockedClean',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 300,
+            fadeWindowStart: now + 300,
+            consecutiveBlocks: 1,
+          },
+        ],
       ]);
       // even a high (stale) window rate must not extend an active block by itself
       const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05, newCompletions: 1 } };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 300);
+      expect(row.fadeWindowStart).toEqual(now + 300);
       expect(row.consecutiveBlocks).toEqual(1);
     });
 
     it('requires multiple clean cycles to fully decay consecutiveBlocks (anti-gaming)', () => {
       const timestamps: FillerTimestamps = new Map([
-        ['gamer', { lastPostTimestamp: now - 100, blockUntilTimestamp: now - 50, consecutiveBlocks: 3 }],
+        [
+          'gamer',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 3 },
+        ],
       ]);
       const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1 } };
 
@@ -320,16 +352,18 @@ describe('FadeRateV2 cron', () => {
       expect(row.consecutiveBlocks).toEqual(2);
 
       timestamps.set('gamer', {
-        lastPostTimestamp: row.lastPostTimestamp,
-        blockUntilTimestamp: row.blockUntilTimestamp ?? now - 50,
+        lastExaminedTimestamp: row.lastExaminedTimestamp,
+        blockUntilTimestamp: row.blockUntilTimestamp ?? 0,
+        fadeWindowStart: row.fadeWindowStart ?? 0,
         consecutiveBlocks: row.consecutiveBlocks,
       });
       row = calculateNewTimestamps(timestamps, clean, now + 300, logger)[0];
       expect(row.consecutiveBlocks).toEqual(1);
 
       timestamps.set('gamer', {
-        lastPostTimestamp: row.lastPostTimestamp,
-        blockUntilTimestamp: row.blockUntilTimestamp ?? now - 50,
+        lastExaminedTimestamp: row.lastExaminedTimestamp,
+        blockUntilTimestamp: row.blockUntilTimestamp ?? 0,
+        fadeWindowStart: row.fadeWindowStart ?? 0,
         consecutiveBlocks: row.consecutiveBlocks,
       });
       row = calculateNewTimestamps(timestamps, clean, now + 600, logger)[0];
@@ -338,7 +372,15 @@ describe('FadeRateV2 cron', () => {
 
     it('processes a mix of fillers in one pass', () => {
       const timestamps: FillerTimestamps = new Map([
-        ['blocked', { lastPostTimestamp: now - 100, blockUntilTimestamp: now + 500, consecutiveBlocks: 1 }],
+        [
+          'blocked',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
       ]);
       const stats: FillerFadeStatsMap = {
         breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1 },

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -4,6 +4,7 @@ import {
   BASE_BLOCK_SECS,
   calculateBlockUntilTimestamp,
   calculateNewTimestamps,
+  countActiveBlocks,
   FADE_RATE_BLOCK_THRESHOLD,
   FillerFadeStatsMap,
   FillerTimestamps,
@@ -13,6 +14,7 @@ import {
   LAPLACE_BETA,
   UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
 } from '../../lib/cron/fade-rate-v2';
+import { Metric, metricContext } from '../../lib/entities';
 import { ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
 
 const now = Math.floor(Date.now() / 1000);
@@ -393,6 +395,146 @@ describe('FadeRateV2 cron', () => {
       expect(byHash['breach'].blockUntilTimestamp).toBeGreaterThan(now);
       expect(byHash['clean'].blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
       expect(byHash['blocked'].blockUntilTimestamp).toEqual(now + 500); // unchanged
+    });
+
+    it('emits per-filler fade rates and new/extended block counters', () => {
+      const metrics = { putMetric: jest.fn() } as any;
+      const timestamps: FillerTimestamps = new Map([
+        [
+          'extendMe',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
+      ]);
+      const stats: FillerFadeStatsMap = {
+        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1 }, // trips a new block
+        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1 }, // decays
+        extendMe: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1 }, // extends an active block
+      };
+      calculateNewTimestamps(timestamps, stats, now, logger, metrics);
+
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, 'breach'),
+        0.25,
+        expect.anything()
+      );
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, 'clean'),
+        0.03,
+        expect.anything()
+      );
+      expect(metrics.putMetric).toHaveBeenCalledWith(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, 1, expect.anything());
+      expect(metrics.putMetric).toHaveBeenCalledWith(Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, 1, expect.anything());
+
+      // during-block rate is charted only for the currently-blocked filler (its post-block
+      // fadeRate sits at the prior while benched)
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, 'extendMe'),
+        0.2,
+        expect.anything()
+      );
+      expect(metrics.putMetric).not.toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, 'breach'),
+        expect.anything(),
+        expect.anything()
+      );
+
+      // escalation level emitted for blocked/blocking fillers; never-blocked 'clean' (0 -> 0)
+      // emits nothing
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'breach'),
+        1,
+        expect.anything()
+      );
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'extendMe'),
+        2,
+        expect.anything()
+      );
+      expect(metrics.putMetric).not.toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'clean'),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('emits the decayed escalation level so recovery is visible (steps down to 0)', () => {
+      const metrics = { putMetric: jest.fn() } as any;
+      const timestamps: FillerTimestamps = new Map([
+        [
+          'recovering',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 1 },
+        ],
+      ]);
+      const stats: FillerFadeStatsMap = {
+        recovering: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 5 }, // clean run, decays 1 -> 0
+      };
+      calculateNewTimestamps(timestamps, stats, now, logger, metrics);
+
+      // the step down to 0 is emitted (previousBlocks was 1), not silently dropped
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'recovering'),
+        0,
+        expect.anything()
+      );
+    });
+  });
+
+  describe('countActiveBlocks', () => {
+    it('counts benched fillers across stored and updated state, updates taking precedence', () => {
+      const timestamps: FillerTimestamps = new Map([
+        // benched with no completions this run: no update row, still active
+        [
+          'benchedIdle',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
+        // recovered: past block, no update
+        [
+          'recovered',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+        ],
+        // stored state says unblocked, but this run blocks them
+        [
+          'justBlocked',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+        ],
+      ]);
+      const updated: ToUpdateTimestampRow[] = [
+        {
+          hash: 'justBlocked',
+          lastExaminedTimestamp: now,
+          blockUntilTimestamp: now + 900,
+          fadeWindowStart: now + 900,
+          consecutiveBlocks: 1,
+        },
+        {
+          hash: 'newClean',
+          lastExaminedTimestamp: now,
+          blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+          fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+          consecutiveBlocks: 0,
+        },
+      ];
+      expect(countActiveBlocks(timestamps, updated, now)).toEqual(2); // benchedIdle + justBlocked
+    });
+
+    it('treats an unset (0 / undefined) blockUntilTimestamp as unblocked', () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['unsetRow', { lastExaminedTimestamp: 1, blockUntilTimestamp: 0, fadeWindowStart: 0, consecutiveBlocks: 0 }],
+      ]);
+      const updated: ToUpdateTimestampRow[] = [
+        { hash: 'undefRow', lastExaminedTimestamp: now, blockUntilTimestamp: undefined, consecutiveBlocks: 0 },
+      ];
+      expect(countActiveBlocks(timestamps, updated, now)).toEqual(0);
     });
   });
 });

--- a/test/entities/QuoteResponse.test.ts
+++ b/test/entities/QuoteResponse.test.ts
@@ -1,10 +1,10 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { parseEther } from 'ethers/lib/utils';
 import { ethers } from 'ethers';
+import { parseEther } from 'ethers/lib/utils';
 
+import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk';
 import { QuoteResponse } from '../../lib/entities';
 import { ProtocolVersion } from '../../lib/providers';
-import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk';
 import { RFQValidator } from '../../lib/util/rfqValidator';
 
 const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
@@ -12,6 +12,7 @@ const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f7';
 const SWAPPER = '0x0000000000000000000000000000000000000000';
 const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
 const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const FILLER = '0x1234567890123456789012345678901234567890';
 const CHAIN_ID = 1;
 const fixedTime = 4206969;
 const WEBHOOK_URL = 'https://uniswap.org';
@@ -37,6 +38,7 @@ describe('QuoteRequest', () => {
       swapper: SWAPPER,
       tokenIn: TOKEN_IN,
       tokenOut: TOKEN_OUT,
+      filler: FILLER,
     },
     TradeType.EXACT_INPUT,
     METADATA
@@ -81,6 +83,7 @@ describe('QuoteRequest', () => {
           tokenOut: TOKEN_OUT,
           amountOut: parseEther('1').toString(),
           quoteId: QUOTE_ID,
+          filler: FILLER,
         },
         type: TradeType.EXACT_INPUT,
         metadata: METADATA,
@@ -100,11 +103,30 @@ describe('QuoteRequest', () => {
           tokenOut: TOKEN_OUT.toLowerCase(),
           amountOut: parseEther('1').toString(),
           quoteId: QUOTE_ID,
+          filler: FILLER,
         },
         type: TradeType.EXACT_INPUT,
         metadata: METADATA,
       });
       expect(response.validationError).toBe(undefined);
+    });
+
+    it('fromRFQ with invalid response - missing filler', async () => {
+      const response = QuoteResponse.fromRFQ({
+        request: quoteRequest,
+        data: {
+          chainId: CHAIN_ID,
+          requestId: REQUEST_ID,
+          tokenIn: TOKEN_IN,
+          amountIn: parseEther('1').toString(),
+          tokenOut: TOKEN_OUT,
+          amountOut: parseEther('1').toString(),
+          quoteId: QUOTE_ID,
+        } as any,
+        type: TradeType.EXACT_INPUT,
+        metadata: METADATA,
+      });
+      expect(response.validationError?.message).toContain('"filler" is required');
     });
 
     it('fromRFQ with invalid response - wrong type amountIn', async () => {
@@ -116,6 +138,7 @@ describe('QuoteRequest', () => {
         tokenOut: TOKEN_OUT,
         amountOut: parseEther('1').toString(),
         quoteId: QUOTE_ID,
+        filler: FILLER,
       };
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
@@ -138,6 +161,7 @@ describe('QuoteRequest', () => {
         tokenOut: TOKEN_OUT,
         amountOut: parseEther('1').toString(),
         quoteId: QUOTE_ID,
+        filler: FILLER,
       };
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
@@ -161,6 +185,7 @@ describe('QuoteRequest', () => {
         tokenOut: '0x0000000000000000000000000000000000000000',
         amountOut: parseEther('1').toString(),
         quoteId: QUOTE_ID,
+        filler: FILLER,
       };
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
@@ -176,9 +201,8 @@ describe('QuoteRequest', () => {
     });
 
     it('fromRFQ with permissioned tokenIn - no provider', async () => {
-      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken')
-        .mockImplementation((token) => token === TOKEN_IN);
-      
+      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockImplementation((token) => token === TOKEN_IN);
+
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
         data: {
@@ -209,9 +233,8 @@ describe('QuoteRequest', () => {
 
     it('fromRFQ with no permissioned tokens - no provider', async () => {
       jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockReturnValue(false);
-      const preTransferCheckMock = jest.spyOn(PermissionedTokenValidator, 'preTransferCheck')
-        .mockResolvedValue(true);
-      
+      const preTransferCheckMock = jest.spyOn(PermissionedTokenValidator, 'preTransferCheck').mockResolvedValue(true);
+
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
         data: {
@@ -240,9 +263,8 @@ describe('QuoteRequest', () => {
     });
 
     it('fromRFQ with permissioned tokenOut - no provider', async () => {
-      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken')
-        .mockImplementation((token) => token === TOKEN_OUT);
-      
+      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockImplementation((token) => token === TOKEN_OUT);
+
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
         data: {
@@ -274,11 +296,9 @@ describe('QuoteRequest', () => {
     it('fromRFQ with permissioned tokenIn - failed preTransferCheck', async () => {
       const mockProvider = {} as ethers.providers.StaticJsonRpcProvider;
       const filler = '0x1234567890123456789012345678901234567890';
-      
-      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken')
-        .mockImplementation((token) => token === TOKEN_IN);
-      jest.spyOn(PermissionedTokenValidator, 'preTransferCheck')
-        .mockResolvedValue(false);
+
+      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockImplementation((token) => token === TOKEN_IN);
+      jest.spyOn(PermissionedTokenValidator, 'preTransferCheck').mockResolvedValue(false);
 
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
@@ -312,11 +332,9 @@ describe('QuoteRequest', () => {
     it('fromRFQ with permissioned tokenOut - failed preTransferCheck', async () => {
       const mockProvider = {} as ethers.providers.StaticJsonRpcProvider;
       const filler = '0x1234567890123456789012345678901234567890';
-      
-      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken')
-        .mockImplementation((token) => token === TOKEN_OUT);
-      jest.spyOn(PermissionedTokenValidator, 'preTransferCheck')
-        .mockResolvedValue(false);
+
+      jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockImplementation((token) => token === TOKEN_OUT);
+      jest.spyOn(PermissionedTokenValidator, 'preTransferCheck').mockResolvedValue(false);
 
       const response = QuoteResponse.fromRFQ({
         request: quoteRequest,
@@ -352,9 +370,8 @@ describe('QuoteRequest', () => {
       const filler = '0x1234567890123456789012345678901234567890';
       const amountIn = quoteRequest.amount;
       const amountOut = parseEther('1.5');
-      
-      const preTransferCheckMock = jest.spyOn(PermissionedTokenValidator, 'preTransferCheck')
-        .mockResolvedValue(true);
+
+      const preTransferCheckMock = jest.spyOn(PermissionedTokenValidator, 'preTransferCheck').mockResolvedValue(true);
       jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockReturnValue(true);
 
       const response = QuoteResponse.fromRFQ({
@@ -383,14 +400,16 @@ describe('QuoteRequest', () => {
 
       expect(validationError).toBe(undefined);
       expect(preTransferCheckMock).toHaveBeenCalledTimes(2);
-      expect(preTransferCheckMock).toHaveBeenNthCalledWith(1,
+      expect(preTransferCheckMock).toHaveBeenNthCalledWith(
+        1,
         mockProvider,
         TOKEN_IN,
         SWAPPER,
         filler,
         amountIn.toString()
       );
-      expect(preTransferCheckMock).toHaveBeenNthCalledWith(2,
+      expect(preTransferCheckMock).toHaveBeenNthCalledWith(
+        2,
         mockProvider,
         TOKEN_OUT,
         filler,
@@ -403,7 +422,7 @@ describe('QuoteRequest', () => {
       const mockProvider = {} as ethers.providers.StaticJsonRpcProvider;
       const filler = '0x1234567890123456789012345678901234567890';
       const mockLogger = { error: jest.fn() } as any;
-      
+
       jest.spyOn(PermissionedTokenValidator, 'isPermissionedToken').mockReturnValue(true);
       jest.spyOn(PermissionedTokenValidator, 'preTransferCheck').mockImplementation(() => {
         throw new Error('Simulated preTransferCheck error');
@@ -452,7 +471,7 @@ describe('QuoteRequest', () => {
       swapper: SWAPPER,
       tokenIn: TOKEN_IN,
       tokenOut: TOKEN_OUT,
-      filler: undefined,
+      filler: FILLER,
     });
   });
 
@@ -467,8 +486,8 @@ describe('QuoteRequest', () => {
       swapper: SWAPPER,
       tokenIn: TOKEN_IN,
       tokenOut: TOKEN_OUT,
-      filler: undefined,
-      algo_id: undefined,
+      filler: FILLER,
+      algo_id: FILLER,
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
     });
@@ -476,8 +495,6 @@ describe('QuoteRequest', () => {
 
   it('toLog includes fillerResponseLatencyMs when set', () => {
     quoteResponse.setFillerResponseLatencyMs(150);
-    expect(quoteResponse.toLog()).toEqual(
-      expect.objectContaining({ fillerResponseLatencyMs: 150 })
-    );
+    expect(quoteResponse.toLog()).toEqual(expect.objectContaining({ fillerResponseLatencyMs: 150 }));
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -10,7 +10,23 @@ export const WEBHOOK_URL_FOO = 'https://foo.com';
 export const MOCK_V2_CB_PROVIDER = new MockV2CircuitBreakerConfigurationProvider(
   [WEBHOOK_URL, WEBHOOK_URL_ONEINCH, WEBHOOK_URL_SEARCHER],
   new Map([
-    [WEBHOOK_URL_ONEINCH, { blockUntilTimestamp: now + 100000, lastPostTimestamp: now - 10, consecutiveBlocks: 0 }],
-    [WEBHOOK_URL_SEARCHER, { blockUntilTimestamp: now - 10, lastPostTimestamp: now - 100, consecutiveBlocks: NaN }],
+    [
+      WEBHOOK_URL_ONEINCH,
+      {
+        blockUntilTimestamp: now + 100000,
+        fadeWindowStart: now + 100000,
+        lastExaminedTimestamp: now - 10,
+        consecutiveBlocks: 0,
+      },
+    ],
+    [
+      WEBHOOK_URL_SEARCHER,
+      {
+        blockUntilTimestamp: now - 10,
+        fadeWindowStart: now - 10,
+        lastExaminedTimestamp: now - 100,
+        consecutiveBlocks: NaN,
+      },
+    ],
   ])
 );

--- a/test/handlers/quote/handler.test.ts
+++ b/test/handlers/quote/handler.test.ts
@@ -65,9 +65,7 @@ describe('Quote handler', () => {
           return {
             quoters,
             // Mock chainIdRpcMap
-            chainIdRpcMap: new Map([
-              [42161, new ethers.providers.StaticJsonRpcProvider()],
-            ]),
+            chainIdRpcMap: new Map([[42161, new ethers.providers.StaticJsonRpcProvider()]]),
           };
         },
         getRequestInjected: () => requestInjectedMock,
@@ -254,6 +252,7 @@ describe('Quote handler', () => {
               swapper: request.swapper,
               chainId: request.tokenInChainId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         })
@@ -268,6 +267,7 @@ describe('Quote handler', () => {
               swapper: request.swapper,
               chainId: request.tokenInChainId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         })
@@ -282,6 +282,7 @@ describe('Quote handler', () => {
               swapper: request.swapper,
               chainId: request.tokenInChainId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         })
@@ -296,6 +297,7 @@ describe('Quote handler', () => {
               swapper: request.swapper,
               chainId: request.tokenInChainId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         });
@@ -378,6 +380,7 @@ describe('Quote handler', () => {
               swapper: request.swapper,
               chainId: request.tokenInChainId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         })
@@ -542,6 +545,7 @@ describe('Quote handler', () => {
               chainId: request.tokenInChainId,
               requestId: request.requestId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         })
@@ -556,6 +560,7 @@ describe('Quote handler', () => {
               chainId: request.tokenInChainId,
               requestId: request.requestId,
               quoteId: QUOTE_ID,
+              filler: MOCK_FILLER_ADDRESS,
             },
           });
         });
@@ -706,9 +711,7 @@ describe('Quote handler', () => {
       // allQuotes has all 3
       expect(body.allQuotes).toHaveLength(3);
       const amounts = body.allQuotes!.map((q) => q.amountOut).sort();
-      expect(amounts).toEqual(
-        [amountIn.toString(), amountIn.mul(2).toString(), amountIn.mul(3).toString()].sort()
-      );
+      expect(amounts).toEqual([amountIn.toString(), amountIn.mul(2).toString(), amountIn.mul(3).toString()].sort());
     });
 
     it('allQuotes contains all quotes - EXACT_OUTPUT', async () => {

--- a/test/handlers/quote/schema.test.ts
+++ b/test/handlers/quote/schema.test.ts
@@ -7,6 +7,7 @@ import { ProtocolVersion } from '../../../lib/providers';
 const SWAPPER = '0x0000000000000000000000000000000000000000';
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const FILLER = '0x1234567890123456789012345678901234567890';
 const REQUEST_ID = uuidv4();
 const QUOTE_ID = uuidv4();
 
@@ -298,6 +299,7 @@ describe('Schema tests', () => {
         amountIn: '1000',
         amountOut: '1000000000000000000',
         quoteId: QUOTE_ID,
+        filler: FILLER,
       };
       const validated = RfqResponseJoi.validate(body);
       expect(validated.error).toBeUndefined();
@@ -309,7 +311,22 @@ describe('Schema tests', () => {
         amountIn: '1000',
         amountOut: '1000000000000000000',
         quoteId: QUOTE_ID,
+        filler: FILLER,
       });
+    });
+
+    it('requires filler to be defined', () => {
+      const body = {
+        chainId: 1,
+        requestId: REQUEST_ID,
+        tokenIn: USDC,
+        tokenOut: WETH,
+        amountIn: '1000',
+        amountOut: '1000000000000000000',
+        quoteId: QUOTE_ID,
+      };
+      const validated = RfqResponseJoi.validate(body);
+      expect(validated.error?.message).toEqual('"filler" is required');
     });
 
     it('requires requestId to be defined', () => {
@@ -387,6 +404,7 @@ describe('Schema tests', () => {
         amountOut: '1000000000000000000',
         swapper: SWAPPER,
         quoteId: QUOTE_ID,
+        filler: FILLER,
       };
       const validated = RfqResponseJoi.validate(body, {
         allowUnknown: true,
@@ -401,6 +419,7 @@ describe('Schema tests', () => {
         amountIn: '1000000000000000000',
         amountOut: '1000000000000000000',
         quoteId: QUOTE_ID,
+        filler: FILLER,
       });
     });
 
@@ -414,6 +433,7 @@ describe('Schema tests', () => {
         amountOut: '1000000000000000000',
         swapper: null,
         quoteId: QUOTE_ID,
+        filler: FILLER,
       };
       const validated = RfqResponseJoi.validate(body, {
         allowUnknown: true,
@@ -428,6 +448,7 @@ describe('Schema tests', () => {
         amountIn: '1000000000000000000',
         amountOut: '1000000000000000000',
         quoteId: QUOTE_ID,
+        filler: FILLER,
       });
     });
   });

--- a/test/providers/circuit-breaker/cb-provider.test.ts
+++ b/test/providers/circuit-breaker/cb-provider.test.ts
@@ -4,11 +4,36 @@ import { MockV2CircuitBreakerConfigurationProvider } from '../../../lib/provider
 const FILLERS = ['filler1', 'filler2', 'filler3', 'filler4', 'filler5'];
 const now = Math.floor(Date.now() / 1000);
 const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
-  ['filler1', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN, consecutiveBlocks: NaN }],
-  ['filler2', { lastPostTimestamp: now - 75, blockUntilTimestamp: now - 50, consecutiveBlocks: 0 }],
-  ['filler3', { lastPostTimestamp: now - 101, blockUntilTimestamp: now + 1000, consecutiveBlocks: 0 }],
-  ['filler4', { lastPostTimestamp: now - 150, blockUntilTimestamp: NaN, consecutiveBlocks: 0 }],
-  ['filler5', { lastPostTimestamp: now - 150, blockUntilTimestamp: now + 100, consecutiveBlocks: 1 }],
+  [
+    'filler1',
+    { lastExaminedTimestamp: now - 150, blockUntilTimestamp: NaN, fadeWindowStart: NaN, consecutiveBlocks: NaN },
+  ],
+  [
+    'filler2',
+    { lastExaminedTimestamp: now - 75, blockUntilTimestamp: now - 50, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+  ],
+  [
+    'filler3',
+    {
+      lastExaminedTimestamp: now - 101,
+      blockUntilTimestamp: now + 1000,
+      fadeWindowStart: now + 1000,
+      consecutiveBlocks: 0,
+    },
+  ],
+  [
+    'filler4',
+    { lastExaminedTimestamp: now - 150, blockUntilTimestamp: NaN, fadeWindowStart: NaN, consecutiveBlocks: 0 },
+  ],
+  [
+    'filler5',
+    {
+      lastExaminedTimestamp: now - 150,
+      blockUntilTimestamp: now + 100,
+      fadeWindowStart: now + 100,
+      consecutiveBlocks: 1,
+    },
+  ],
 ]);
 
 const WEBHOOK_CONFIGS = [

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -1,7 +1,8 @@
 import { DynamoDBClient, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { getAddress } from 'ethers/lib/utils';
 
-import { DynamoFillerAddressRepository } from '../../lib/repositories/filler-address-repository';
+import { DynamoFillerAddressRepository, MAX_FILLER_ADDRESSES } from '../../lib/repositories/filler-address-repository';
 
 const dynamoConfig: DynamoDBClientConfig = {
   endpoint: 'http://localhost:8000',
@@ -104,5 +105,33 @@ describe('filler address repository test', () => {
 
   it('should checksum address when adding to db', async () => {
     expect(await repository.getFillerAddresses('filler4')).toEqual([CHECKSUMED_ADDR]);
+  });
+
+  it('first-writer-wins: ignores a claim on an address already owned by another filler', async () => {
+    // ADDR1 is owned by filler1 (from beforeAll). A different filler tries to claim it.
+    await repository.addNewAddressToFiller(ADDR1, 'attacker');
+    // ownership is unchanged, and the attacker did not gain the address
+    expect(await repository.getFillerByAddress(ADDR1)).toEqual('filler1');
+    expect(await repository.getFillerAddresses('attacker')).toBeUndefined();
+    expect(await repository.getFillerAddresses('filler1')).toEqual([ADDR1, ADDR2]);
+  });
+
+  it('caps the number of addresses a single filler can register', async () => {
+    const addrs = [
+      '0x0000000000000000000000000000000000000010',
+      '0x0000000000000000000000000000000000000011',
+      '0x0000000000000000000000000000000000000012',
+      '0x0000000000000000000000000000000000000013',
+    ];
+    expect(addrs.length).toBeGreaterThan(MAX_FILLER_ADDRESSES); // guard: test must exceed the cap
+    for (const addr of addrs) {
+      await repository.addNewAddressToFiller(addr, 'capFiller');
+    }
+    // only the first MAX_FILLER_ADDRESSES are registered; the rest are ignored
+    const registered = (await repository.getFillerAddresses('capFiller')) ?? [];
+    expect(registered.length).toEqual(MAX_FILLER_ADDRESSES);
+    expect(registered).toEqual(addrs.slice(0, MAX_FILLER_ADDRESSES).map((a) => getAddress(a)));
+    // the over-cap address is attributed to no filler
+    expect(await repository.getFillerByAddress(addrs[MAX_FILLER_ADDRESSES])).toBeUndefined();
   });
 });

--- a/test/repositories/timestamp-repository.test.ts
+++ b/test/repositories/timestamp-repository.test.ts
@@ -5,12 +5,14 @@ import { ToUpdateTimestampRow } from '../../lib/repositories';
 import { TimestampRepository, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP } from '../../lib/repositories/timestamp-repository';
 import { DYNAMO_CONFIG } from './shared';
 
+// wrapNumbers:false so the number-typed CB attributes round-trip as native JS numbers
+// (matches the client TimestampRepository builds for itself in production).
 const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient(DYNAMO_CONFIG), {
   marshallOptions: {
     convertEmptyValues: true,
   },
   unmarshallOptions: {
-    wrapNumbers: true,
+    wrapNumbers: false,
   },
 });
 
@@ -21,20 +23,23 @@ describe('Dynamo TimestampRepo tests', () => {
     const toUpdate: ToUpdateTimestampRow[] = [
       {
         hash: '0x1',
-        lastPostTimestamp: 1,
+        lastExaminedTimestamp: 1,
         blockUntilTimestamp: undefined,
+        fadeWindowStart: undefined,
         consecutiveBlocks: 0,
       },
       {
         hash: '0x2',
-        lastPostTimestamp: 2,
+        lastExaminedTimestamp: 2,
         blockUntilTimestamp: 5,
+        fadeWindowStart: 5,
         consecutiveBlocks: 0,
       },
       {
         hash: '0x3',
-        lastPostTimestamp: 3,
+        lastExaminedTimestamp: 3,
         blockUntilTimestamp: 6,
+        fadeWindowStart: 4,
         consecutiveBlocks: 1,
       },
     ];
@@ -43,21 +48,24 @@ describe('Dynamo TimestampRepo tests', () => {
 
     let row = await repo.getFillerTimestamps('0x1');
     expect(row).toBeDefined();
-    expect(row?.lastPostTimestamp).toBe(1);
-    // missing attribute coerces to the unblocked sentinel at the parse boundary, not NaN
+    expect(row?.lastExaminedTimestamp).toBe(1);
+    // missing attributes coerce to the unblocked sentinel (undefined ?? sentinel), not NaN
     expect(row?.blockUntilTimestamp).toBe(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
+    expect(row?.fadeWindowStart).toBe(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
     expect(row?.consecutiveBlocks).toBe(0);
 
     row = await repo.getFillerTimestamps('0x2');
     expect(row).toBeDefined();
-    expect(row?.lastPostTimestamp).toBe(2);
+    expect(row?.lastExaminedTimestamp).toBe(2);
     expect(row?.blockUntilTimestamp).toBe(5);
+    expect(row?.fadeWindowStart).toBe(5);
     expect(row?.consecutiveBlocks).toBe(0);
 
     row = await repo.getFillerTimestamps('0x3');
     expect(row).toBeDefined();
-    expect(row?.lastPostTimestamp).toBe(3);
+    expect(row?.lastExaminedTimestamp).toBe(3);
     expect(row?.blockUntilTimestamp).toBe(6);
+    expect(row?.fadeWindowStart).toBe(4);
     expect(row?.consecutiveBlocks).toBe(1);
   });
 
@@ -68,20 +76,23 @@ describe('Dynamo TimestampRepo tests', () => {
       expect.arrayContaining([
         {
           hash: '0x1',
-          lastPostTimestamp: 1,
+          lastExaminedTimestamp: 1,
           blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+          fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
           consecutiveBlocks: 0,
         },
         {
           hash: '0x2',
-          lastPostTimestamp: 2,
+          lastExaminedTimestamp: 2,
           blockUntilTimestamp: 5,
+          fadeWindowStart: 5,
           consecutiveBlocks: 0,
         },
         {
           hash: '0x3',
-          lastPostTimestamp: 3,
+          lastExaminedTimestamp: 3,
           blockUntilTimestamp: 6,
+          fadeWindowStart: 4,
           consecutiveBlocks: 1,
         },
       ])

--- a/test/repositories/timestamp-repository.test.ts
+++ b/test/repositories/timestamp-repository.test.ts
@@ -2,7 +2,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
 import { ToUpdateTimestampRow } from '../../lib/repositories';
-import { TimestampRepository } from '../../lib/repositories/timestamp-repository';
+import { TimestampRepository, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP } from '../../lib/repositories/timestamp-repository';
 import { DYNAMO_CONFIG } from './shared';
 
 const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient(DYNAMO_CONFIG), {
@@ -44,7 +44,8 @@ describe('Dynamo TimestampRepo tests', () => {
     let row = await repo.getFillerTimestamps('0x1');
     expect(row).toBeDefined();
     expect(row?.lastPostTimestamp).toBe(1);
-    expect(row?.blockUntilTimestamp).toBe(NaN);
+    // missing attribute coerces to the unblocked sentinel at the parse boundary, not NaN
+    expect(row?.blockUntilTimestamp).toBe(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
     expect(row?.consecutiveBlocks).toBe(0);
 
     row = await repo.getFillerTimestamps('0x2');
@@ -68,7 +69,7 @@ describe('Dynamo TimestampRepo tests', () => {
         {
           hash: '0x1',
           lastPostTimestamp: 1,
-          blockUntilTimestamp: NaN,
+          blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
           consecutiveBlocks: 0,
         },
         {


### PR DESCRIPTION
## Why

The V2 circuit breaker blocked a filler on **any** new fade within a ~10-minute window — an absolute-count trigger that structurally over-penalizes high-volume fillers (more orders won → more absolute fades, even at a healthy fade *rate*). This reworks it into a volume-aware, rate-based breaker, then hardens the surrounding state model.

## Trigger — Laplace-smoothed fade rate

```
fadeRate = (fades + α) / (total + α + β)      // α=1, β=19 → denominator (total + 20), prior mean = 1/20 = 5%
block when fadeRate > 12%                       // FADE_RATE_BLOCK_THRESHOLD
```

Smoothing seeds every filler with 1 pretend-fade / 19 pretend-clean-fills, pulling small samples toward the 5% prior so a couple of early fades don't trip the breaker, while a sustained high rate on real volume does. (Threshold must exceed the prior mean, else the prior alone blocks everyone — 12% > 5%. ✓)

## Measurement window — 24h, capped at the latest 100 orders/filler

The rate is computed over orders whose `deadline` falls in the last **24 hours**, capped at each filler's **latest 100 orders** (`ORDERS_PER_FILLER_LIMIT`). The cap makes the lookback adaptive, closing the evasion cases raised in review:

| scenario | smoothed rate | blocked? |
|---|---|---|
| low-volume filler fading every order (1/hr) | 2 fades → 3/22 = **13.6%** | ✅ (within ~2h) |
| high-volume chronic ~14% fader (7 of 50/hr) | latest 100 ≈ 14 fades → 15/120 = **12.5%** | ✅ |
| acute failure after clean history | ~12 fades to trip | ✅ (~1–2 cron cycles) |
| legitimate sustained ~10% filler | 11/120 = 9.2% | ❌ (correctly clear) |

In-flight (not-yet-completed) orders are filtered out **before** the per-filler `ROW_NUMBER()` cap, so they can't consume latest-N slots and skew a busy filler's sample.

## Recovery — timer-driven, with a clean slate

A blocked filler receives no RFQs, so it can't improve its rate while benched — recovery is driven by the **block timer**, not the rate. When the block expires the filler is eligible again and is scored on a **clean slate**: only orders completed after the block ended count, via a dedicated `fadeWindowStart` floor (see schema below). `consecutiveBlocks` escalation persists across blocks and decays gradually — but **only on runs where the filler actually completed new orders**, so a filler can't work off escalation by simply idling while stale rows linger in the 24h view.

## In-flight fades while blocked (`duringBlockRate`)

Orders that completed during a block are scored as their own smoothed cohort against the same 12% threshold. This **extends** an active block when the in-flight cohort genuinely faded (rate-based, so a high-volume filler's stray in-flight fade offset by clean fills does *not* extend), and **re-blocks right after expiry** when late in-flight fades landed between the last blocked-state cron run and `blockUntil` — closing a slip-through where such fades were scored by neither path.

Deliberately accepted (documented in code): because the window is a rolling 24h, a filler's rate can cross the threshold on a run with no new completions ("blocked while idle"). Gating the block on new completions would just move the surprise to right after a completed order, which is stranger UX.

## Escalation / block duration

Block length backs off purely on `consecutiveBlocks` (`2^n`, base 15 min); the old per-fade `1.2^(n-1)` multiplier is dropped so block *length* no longer scales with absolute fade count either.

## Fresh V2 state table + schema cleanup

State moves to a **new DynamoDB table (`FillerCBTimestampsV2`), created alongside the V1 table** rather than renaming it. The circuit-breaker state is derived (recomputed each cron run from Redshift), so the new table starts empty — no migration. This gives a **clean rollback**: the table name is compiled into each code version, so reverting to the old code automatically points back at the untouched V1 table, and the new version's writes never contaminate it. (Remove the V1 table in a follow-up once V2 is confirmed stable.)

The fresh table also lets us fix the stored schema, not just the name:
- **Native numbers, not strings.** All fields were `type:'string'` read via `parseInt`; with `wrapNumbers` this was the entire source of the NaN-guard complexity. Now stored as numbers and read via a `wrapNumbers:false` client the repo builds itself — a missing attribute is `undefined` (→ sentinel), never `NaN`.
- **De-overloaded `blockUntilTimestamp`.** It previously meant both "block expiry" and "clean-slate floor". Split out **`fadeWindowStart`** as the floor; `blockUntilTimestamp` now resets cleanly to `0` on decay while `fadeWindowStart` independently holds the last block end.
- **`lastPostTimestamp` → `lastExaminedTimestamp`** (it's the last cron-run boundary, not a post time).

## Row cap

The fade view's `LIMIT` was raised 5000 → **20000** (`FADE_QUERY_ROW_LIMIT`); the 1h→24h widening multiplied row volume ~24×, and above the cap rows are silently truncated (dropping fillers from evaluation). 20000 is ~200 filler-addresses of headroom at the 100/filler cap.

## API changes
- `getFillersNewFades` → `getFillersFadeStats`, returning `{ fadeRate, duringBlockRate, newCompletions }`.
- `calculateBlockUntilTimestamp(fromTimestamp, consecutiveBlocks)` (dropped the `fades` arg).
- `TimestampRepoRow`: `lastPostTimestamp`→`lastExaminedTimestamp`, `+fadeWindowStart`, all numbers.

## Tests
Rewrote `fade-rate-v2.test.ts` and updated the repo/provider/fixtures for the new model: smoothing math, windowing + clean-slate exclusion, address aggregation, backoff, all state transitions (block / decay+preserve-floor / extend-while-blocked / keep-while-blocked / re-block-after-expiry), anti-gaming decay + idle freeze, and the evasion scenarios pinned to the window params. Build + eslint clean; full unit suite passing.

## Rollout / rollback
- Deploy provisions the empty V2 table; the breaker repopulates within a cron cycle or two.
- Rollback = redeploy the previous version → automatically reads the untouched V1 table. No migration, no cleanup.

## Follow-ups (not in this PR)
- Observability (metrics + dashboard) is stacked in #460.
- Threshold / `α,β` / window should be **calibrated against the real per-filler `(fades, total)` distribution** before rollout.
