### PR TITLE
feat: add fillTimeBlocks column to ArchivedOrders Redshift table

### DIFF
--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -315,6 +315,9 @@ export class AnalyticsStack extends cdk.NestedStack {
         { name: 'gasUsed', dataType: RS_DATA_TYPES.UINT256 },
         { name: 'gasCostInETH', dataType: RS_DATA_TYPES.UnitInETH },
         { name: 'logTime', dataType: RS_DATA_TYPES.TIMESTAMP },
+        // Blocks between the order's decay start and the fill (fillBlock - decayStartBlock),
+        // emitted by x-service. Consumed by the RFQ circuit breaker for Dutch_V3 fade detection.
+        { name: 'fillTimeBlocks', dataType: RS_DATA_TYPES.INTEGER },
       ],
     });
 


### PR DESCRIPTION
## Problem

The fade-rate cron is failing in prod:
```
ERROR: column archivedorders.filltimeblocks does not exist
```

The circuit breaker's fade query references `archivedorders.fillTimeBlocks` for Dutch_V3 fade detection, but that column was never added to the **Redshift** `ArchivedOrders` table. It exists in the **BigQuery** analytics schema (`data-eng-workflows .../archived_orders.yaml`) and is emitted by x-service, but the Redshift table — defined right here in `bin/stacks/analytics-stack.ts` — only had the original column set.

(Root cause of the confusion: the BigQuery and Redshift tables are two separate materializations of the same analytics logs with different schemas. The columns we need were added to BigQuery + the analytics event but not to this Redshift table definition.)

## Change

Add `fillTimeBlocks` (`INTEGER`) to the `ArchivedOrders` `tableColumns`.

- `aws_rs.Table` manages the table via a custom resource, so deploy issues `ALTER TABLE ADD COLUMN`.
- The fill analytics event already emits `fillTimeBlocks` (x-service `logFillInfo`, computed for Dutch_V3 as `fillBlock - decayStartBlock`).
- The Firehose COPY uses `JSON 'auto ignorecase'` with the column list derived from `tableColumns`, so the field maps by name and populates for **new** fills once deployed.
- Existing rows backfill as `NULL`, which the V3 fade `CASE` (`fillTimeBlocks >= 0`) treats as not-faded — safe.

`INTEGER` is signed, so it correctly stores negative values (fills before `decayStartBlock`).

## Rollout note
The cron will keep erroring until this is deployed and the column exists. After deploy, V3 fade-by-late-fill detection only applies to fills recorded after the column goes live (older rows are NULL). No backfill is attempted here.

## Verified schema
Confirmed against the live prod Redshift schema: `archivedorders` has `blocknumber` but lacked `filltimeblocks`; `postedorders` has `starttime` but no `startblock`/`decaystartblock` (so block-delta must come from the precomputed `fillTimeBlocks`, not from joining a decay-start-block column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)