### PR TITLE
feat: enable RFQ cosigning for Robinhood (4663) + Arc (5042)

### DIFF
--- a/lib/util/chains.ts
+++ b/lib/util/chains.ts
@@ -25,6 +25,8 @@ export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.CELO,
   ChainId.AVALANCHE,
   ChainId.BLAST,
+  ChainId.ROBINHOOD,
+  ChainId.ARC,
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/async-retry": "^1.4.5",
     "@uniswap/default-token-list": "^6.0.0",
     "@uniswap/router-sdk": "^1.4.0",
-    "@uniswap/sdk-core": "^7.14.0",
+    "@uniswap/sdk-core": "^7.18.0",
     "@uniswap/signer": "0.0.3-beta.4",
     "@uniswap/smart-order-router": "^4.22.20",
     "@uniswap/token-lists": "^1.0.0-beta.31",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@uniswap/signer": "0.0.3-beta.4",
     "@uniswap/smart-order-router": "^4.22.20",
     "@uniswap/token-lists": "^1.0.0-beta.31",
-    "@uniswap/uniswapx-sdk": "3.0.8",
+    "@uniswap/uniswapx-sdk": "3.0.10",
     "@uniswap/v3-sdk": "^3.9.0",
     "aws-cdk-lib": "^2.214.0",
     "aws-embedded-metrics": "^4.1.0",

--- a/test/util/constants.test.ts
+++ b/test/util/constants.test.ts
@@ -15,6 +15,12 @@ describe('V3 chain constants', () => {
     it('tempo: ceil(5/0.5) = 10', () => {
       expect(getV3BlockBuffer(ChainId.TEMPO)).toEqual(10);
     });
+    it('arc: ceil(5/0.48) = 11', () => {
+      expect(getV3BlockBuffer(ChainId.ARC)).toEqual(11);
+    });
+    it('robinhood: ceil(5/0.1) = 50', () => {
+      expect(getV3BlockBuffer(ChainId.ROBINHOOD)).toEqual(50);
+    });
     it('throws on unknown chainId (propagated from sdk-core)', () => {
       expect(() => getV3BlockBuffer(99999)).toThrow(/unsupported chainId 99999/);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,23 +3921,6 @@
     "@uniswap/v3-sdk" "^3.25.2"
     "@uniswap/v4-sdk" "^1.21.2"
 
-"@uniswap/sdk-core@^7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.17.0.tgz#7be02563c1fb9e8fe45b934a55783aea71d6e8de"
-  integrity sha512-5maoaZMcGpvxfg6ZG4hpG8eJYakrFh8y75NhDKB40xenQAnSQt/xz1JMbY6+GGkXMvY+z3pT5mmKYxjGU0S5Bw==
-  dependencies:
-    "@ethersproject/address" "^5.0.2"
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/keccak256" "5.7.0"
-    "@ethersproject/strings" "5.7.0"
-    big.js "^5.2.2"
-    decimal.js-light "^2.5.0"
-    jsbi "^3.1.4"
-    tiny-invariant "^1.1.0"
-    toformat "^2.0.0"
-    tslib "^2.3.0"
-
 "@uniswap/sdk-core@^7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.18.0.tgz#a93f6d67dd8c31415eabf748349c2134cfdfadb1"
@@ -4028,16 +4011,16 @@
   resolved "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.34.tgz#879461f5d4009327a24259bbab797e0f22db58c8"
   integrity sha512-Hc3TfrFaupg0M84e/Zv7BoF+fmMWDV15mZ5s8ZQt2qZxUcNw2GQW+L6L/2k74who31G+p1m3GRYbJpAo7d1pqA==
 
-"@uniswap/uniswapx-sdk@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-3.0.8.tgz#32e3ff23288f2e6ec15fd197dd06d59527d68160"
-  integrity sha512-/e4jgppX5YMcfw8UGdFgaayVMXAKdXjKXiugdL9ouP0db5DSXa3w5PYsOwDxVnm7w3AnQDGg05VaoOEXNgbBWw==
+"@uniswap/uniswapx-sdk@3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-3.0.10.tgz#6fdb915b06fa98b4bccd11aa4a1df3c3ffb1d099"
+  integrity sha512-SBEAKsNQFFm3WB9sZs6bqAFnyOLVV0YNqBTknYm/4tJdtBYXUKdRMaHjk20Xh9gzf/QFhM+IsxBhv0pnuHpBFQ==
   dependencies:
     "@ethersproject/abi" "^5.5.0"
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"
     "@uniswap/permit2-sdk" "^1.4.0"
-    "@uniswap/sdk-core" "^7.17.0"
+    "@uniswap/sdk-core" "^7.18.0"
     ethers "^5.7.0"
     tiny-invariant "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,10 +3921,10 @@
     "@uniswap/v3-sdk" "^3.25.2"
     "@uniswap/v4-sdk" "^1.21.2"
 
-"@uniswap/sdk-core@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.14.0.tgz#be134de267352be14c61a8ec982ca9657f1beb44"
-  integrity sha512-uJe0YmufRXFBKj5qDRS9Nfzo0O3GrhxpIDS9OMJqRUG5yzYtXL+HdUv8kr/byJfWoGyAJUsURte4NAT/04w0zA==
+"@uniswap/sdk-core@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.17.0.tgz#7be02563c1fb9e8fe45b934a55783aea71d6e8de"
+  integrity sha512-5maoaZMcGpvxfg6ZG4hpG8eJYakrFh8y75NhDKB40xenQAnSQt/xz1JMbY6+GGkXMvY+z3pT5mmKYxjGU0S5Bw==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     "@ethersproject/bignumber" "^5.5.0"
@@ -3938,10 +3938,10 @@
     toformat "^2.0.0"
     tslib "^2.3.0"
 
-"@uniswap/sdk-core@^7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.17.0.tgz#7be02563c1fb9e8fe45b934a55783aea71d6e8de"
-  integrity sha512-5maoaZMcGpvxfg6ZG4hpG8eJYakrFh8y75NhDKB40xenQAnSQt/xz1JMbY6+GGkXMvY+z3pT5mmKYxjGU0S5Bw==
+"@uniswap/sdk-core@^7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.18.0.tgz#a93f6d67dd8c31415eabf748349c2134cfdfadb1"
+  integrity sha512-Fy/U/yEweEYbGZi1cOpFBRTE0rwrueBesG8MPRlfhVXwutLn5OXZe5TjFSdIrjp7vqrNqgdmKIHIwg9k6MMSLQ==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     "@ethersproject/bignumber" "^5.5.0"


### PR DESCRIPTION
## Summary

Turns on V3 RFQ cosigning for **Robinhood (4663)** and **Arc (5042)** — the Phase-3 step in the DutchV3 rollout. The reactors are deployed and integration-tested ([Uniswap/UniswapX#371](https://github.com/Uniswap/UniswapX/pull/371)) and the SDK entries are in flight ([Uniswap/sdks#615](https://github.com/Uniswap/sdks/pull/615)).

## Changes

- **`SUPPORTED_CHAINS` += ROBINHOOD, ARC.** This is the single source of truth: the hard/soft-quote injectors build their `chainIdRpcMap` by iterating it, and the Joi `chainId` validator gates inbound requests on it. Adding the chains here both provisions their RPC providers and lets requests through.
- **Bump `@uniswap/sdk-core` `^7.14.0` → `^7.18.0`.** 7.14.0 predates these chains — `ChainId.ARC` was absent and `ChainId.ROBINHOOD` resolved to the **46630 testnet**. 7.17.0+ ships the mainnet ids (`ARC=5042`, `ROBINHOOD=4663`) and their `AVERAGE_BLOCK_TIMES_SECONDS` (Arc 0.48s, Robinhood 0.1s). The cosigner's `getV3BlockBuffer` → `secondsToBlocks` needs those — it throws for unregistered chains rather than guessing a default.

## Why nothing else is needed

- **RPC**: generic `RPC_PREFIX_URL/{chainId}` — no per-chain env.
- **uniswapx-sdk reactor mapping**: the cosigner reads the reactor from the swapper-signed order, so it doesn't depend on `REACTOR_ADDRESS_MAPPING` (that gates x-service's `validateReactorAddress` and trading-api order construction — handled in those repos).
- **Circuit breaker / fade-rate**: chain-agnostic; new chains flow through automatically.

## Verification

- `getV3BlockBuffer` resolves to **11 blocks (Arc)** and **50 blocks (Robinhood)** for the 5s decay-start lead — new unit tests assert both.
- `yarn build` (tsc) clean; full unit suite passes (183).

## Test plan
- [x] `yarn build`
- [x] `yarn test:unit`
- [ ] Confirm Lambda RPC provider is provisioned for 4663/5042 in the deploy env (RPC_PREFIX_URL covers them, but verify the upstream provider actually serves these chains)

⚠️ **Robinhood block time note:** sdk-core lists Robinhood at 0.1s, giving a 50-block decay-start buffer. The chain currently produces blocks on-demand with multi-minute idle gaps, so on an idle chain that buffer's wallclock lead is unbounded. RFQ-cosigned fills resolve at the override immediately and are unaffected, but worth confirming launch timing — see playbook/chains/robinhood.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)