### PR TITLE
feat: circuit breaker observability — metrics + dashboard

### DIFF
--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -395,7 +395,9 @@ const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
     },
   },
   // Per-filler smoothed fade rates against the block threshold: healthy fillers should sit
-  // near the 5% prior; anyone trending toward the 12% line is about to be benched.
+  // near the 5% prior; anyone trending toward the 12% line is about to be benched. The
+  // during-block rate is charted alongside because a benched filler's post-block fade rate
+  // sits at the prior — the during-block rate is what shows them above the threshold.
   {
     height: 8,
     width: 12,
@@ -406,6 +408,13 @@ const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
           {
             expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_FADE_RATE}_', 'Average', 600)`,
             id: 'fadeRates',
+            region,
+          },
+        ],
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE}_', 'Average', 600)`,
+            id: 'duringBlockRates',
             region,
           },
         ],

--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -10,6 +10,7 @@ import {
   Metric,
   SoftQuoteMetricDimension,
 } from '../../lib/entities';
+import { FADE_RATE_BLOCK_THRESHOLD } from '../../lib/cron/fade-rate-v2';
 import { ChainId, SUPPORTED_CHAINS } from '../../lib/util/chains';
 
 export const NAMESPACE = 'Uniswap';
@@ -45,6 +46,12 @@ export type LambdaWidget = {
         label: string;
         showUnits: boolean;
       };
+    };
+    annotations?: {
+      horizontal: {
+        label?: string;
+        value: number;
+      }[];
     };
   };
 };
@@ -290,7 +297,7 @@ const FailingRFQLogsWidget = (region: string, logGroup: string): LambdaWidget =>
     width: 24,
     height: 6,
     properties: {
-      query: `SOURCE '${logGroup}' | fields @timestamp, msg\n| filter quoter = 'WebhookQuoter' and msg like \"Error fetching quote\"\n| sort @timestamp desc\n| limit 20`,
+      query: `SOURCE '${logGroup}' | fields @timestamp, msg\n| filter quoter = 'WebhookQuoter' and msg like "Error fetching quote"\n| sort @timestamp desc\n| limit 20`,
       region,
       stacked: false,
       view: 'table',
@@ -360,29 +367,88 @@ const RFQFailRatesWidget = (region: string, rfqProviders: string[]): LambdaWidge
     };
   });
 
-const CircuitBreakerV2Widget = (region: string): LambdaWidget => {
-  return {
-    height: 11,
-    width: 11,
+const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
+  // How often the breaker fires: new blocks / extensions per run, fillers currently benched,
+  // and how many fillers were evaluated (sample-health denominator).
+  {
+    height: 8,
+    width: 12,
     type: 'metric',
     properties: {
       metrics: [
         [
           'Uniswap',
-          Metric.CIRCUIT_BREAKER_V2_BLOCKED,
+          Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS,
           'Service',
           CircuitBreakerMetricDimension.Service,
-          { stat: 'Average', label: 'avg' },
+          { stat: 'Sum', label: 'new blocks' },
+        ],
+        ['.', Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, '.', '.', { stat: 'Sum', label: 'extended blocks' }],
+        ['.', Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS, '.', '.', { stat: 'Maximum', label: 'active blocks' }],
+        ['.', Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, '.', '.', { stat: 'Maximum', label: 'fillers evaluated' }],
+      ],
+      view: 'timeSeries',
+      stacked: false,
+      region,
+      period: 600,
+      title: 'Circuit Breaker Activity | 10 minutes',
+    },
+  },
+  // Per-filler smoothed fade rates against the block threshold: healthy fillers should sit
+  // near the 5% prior; anyone trending toward the 12% line is about to be benched.
+  {
+    height: 8,
+    width: 12,
+    type: 'metric',
+    properties: {
+      metrics: [
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_FADE_RATE}_', 'Average', 600)`,
+            id: 'fadeRates',
+            region,
+          },
         ],
       ],
       view: 'timeSeries',
       stacked: false,
       region,
       period: 600,
-      title: 'Blocked Filler On Average | 10 minutes',
+      title: 'Filler Fade Rates (smoothed) vs Block Threshold',
+      yAxis: {
+        left: {
+          label: 'fade rate',
+          showUnits: false,
+        },
+      },
+      annotations: {
+        horizontal: [{ label: 'block threshold', value: FADE_RATE_BLOCK_THRESHOLD }],
+      },
     },
-  };
-};
+  },
+  // Escalation state per filler: repeat offenders climb, recovered fillers decay back to 0.
+  {
+    height: 8,
+    width: 12,
+    type: 'metric',
+    properties: {
+      metrics: [
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS}_', 'Maximum', 600)`,
+            id: 'consecutiveBlocks',
+            region,
+          },
+        ],
+      ],
+      view: 'timeSeries',
+      stacked: false,
+      region,
+      period: 600,
+      title: 'Filler Consecutive Blocks (escalation)',
+    },
+  },
+];
 
 export interface DashboardProps extends cdk.NestedStackProps {
   quoteLambda: aws_lambda_nodejs.NodejsFunction;
@@ -412,7 +478,7 @@ export class ParamDashboardStack extends cdk.NestedStack {
           RFQFailRatesWidget(region, RFQ_PROVIDERS),
           LambdaErrorRatesWidget(region, scope),
           FailingRFQLogsWidget(region, props.quoteLambda.logGroup.logGroupArn),
-          CircuitBreakerV2Widget(region),
+          CircuitBreakerWidgets(region),
         ].flat(),
       }),
     });

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -117,15 +117,16 @@ async function main(metrics: MetricsLogger) {
     //  | hash        |lastExaminedTimestamp|blockUntilTimestamp|fadeWindowStart|
     //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
     //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
-    const updatedTimestamps = calculateNewTimestamps(
-      fillerTimestamps,
-      fillerFadeStats,
-      Math.floor(Date.now() / 1000),
-      log,
-      metrics
-    );
+    const now = Math.floor(Date.now() / 1000);
+    const updatedTimestamps = calculateNewTimestamps(fillerTimestamps, fillerFadeStats, now, log, metrics);
     log.info({ updatedTimestamps }, 'filler for which to update timestamp');
     metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_BLOCKED, updatedTimestamps.length, Unit.Count);
+    metrics.putMetric(
+      Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS,
+      countActiveBlocks(fillerTimestamps, updatedTimestamps, now),
+      Unit.Count
+    );
+    metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, Object.keys(fillerFadeStats).length, Unit.Count);
     if (updatedTimestamps.length > 0) {
       await timestampDB.updateTimestampsBatch(updatedTimestamps);
     } else {
@@ -170,10 +171,15 @@ export function calculateNewTimestamps(
   metrics?: MetricsLogger
 ): ToUpdateTimestampRow[] {
   const updatedTimestamps: ToUpdateTimestampRow[] = [];
+  let newBlocks = 0;
+  let extendedBlocks = 0;
   Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
     const { fadeRate, duringBlockRate, newCompletions } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
+
+    // Per-filler rate so the distribution can be charted against FADE_RATE_BLOCK_THRESHOLD
+    metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, hash), fadeRate, Unit.None);
 
     if (isCurrentlyBlocked && duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
       // In-flight orders faded at over the threshold rate while blocked: stack the penalty,
@@ -185,6 +191,7 @@ export function calculateNewTimestamps(
       );
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
 
+      extendedBlocks++;
       log?.info(
         { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, duringBlockRate },
         'Extending block for filler who faded while blocked'
@@ -220,6 +227,7 @@ export function calculateNewTimestamps(
       const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
       const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
 
+      newBlocks++;
       log?.info(
         { hash, fadeRate, duringBlockRate, blockUntilTimestamp },
         'Blocking filler for exceeding fade rate threshold'
@@ -255,8 +263,28 @@ export function calculateNewTimestamps(
       });
     }
   });
-  log?.info({ updatedTimestamps }, 'updated timestamps');
+  metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, newBlocks, Unit.Count);
+  metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, extendedBlocks, Unit.Count);
+  log?.info({ updatedTimestamps, newBlocks, extendedBlocks }, 'updated timestamps');
   return updatedTimestamps;
+}
+
+/* Number of fillers benched (blockUntilTimestamp in the future) after applying this run's
+   updates on top of stored state. Includes benched fillers with no completions this run —
+   they produce no stats row, but their stored block is still active. */
+export function countActiveBlocks(
+  fillerTimestamps: FillerTimestamps,
+  updatedTimestamps: ToUpdateTimestampRow[],
+  now: number
+): number {
+  const effectiveBlockUntil = new Map<string, number>();
+  fillerTimestamps.forEach((row, hash) =>
+    effectiveBlockUntil.set(hash, row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP)
+  );
+  updatedTimestamps.forEach((row) =>
+    effectiveBlockUntil.set(row.hash, row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP)
+  );
+  return [...effectiveBlockUntil.values()].filter((blockUntil) => blockUntil > now).length;
 }
 
 /* Laplace-smoothed fade rate: pretend we've already seen LAPLACE_ALPHA fades and

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -177,9 +177,20 @@ export function calculateNewTimestamps(
     const { fadeRate, duringBlockRate, newCompletions } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
+    const previousBlocks = fillerTimestamp?.consecutiveBlocks || 0;
 
-    // Per-filler rate so the distribution can be charted against FADE_RATE_BLOCK_THRESHOLD
+    // Per-filler rate so the distribution can be charted against FADE_RATE_BLOCK_THRESHOLD. While
+    // blocked, fadeRate sits at the prior (post-block window is empty), so also emit the
+    // during-block rate — the signal that actually drives extend/re-block — to chart benched
+    // fillers against the same threshold.
     metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, hash), fadeRate, Unit.None);
+    if (isCurrentlyBlocked) {
+      metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, hash), duringBlockRate, Unit.None);
+    }
+
+    // Resulting escalation level for this filler, emitted once below so the dashboard can chart
+    // climbs, plateaus, and decay back to 0 (not just the block/extend steps).
+    let consecutiveBlocks: number;
 
     if (isCurrentlyBlocked && duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
       // In-flight orders faded at over the threshold rate while blocked: stack the penalty,
@@ -189,17 +200,12 @@ export function calculateNewTimestamps(
         fillerTimestamp.blockUntilTimestamp, // Extend from when current block ends
         fillerTimestamp.consecutiveBlocks
       );
-      const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
+      consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
 
       extendedBlocks++;
       log?.info(
         { hash, currentBlockUntil: fillerTimestamp.blockUntilTimestamp, extendedBlockUntil, duringBlockRate },
         'Extending block for filler who faded while blocked'
-      );
-      metrics?.putMetric(
-        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash),
-        consecutiveBlocks,
-        Unit.Count
       );
 
       updatedTimestamps.push({
@@ -211,12 +217,13 @@ export function calculateNewTimestamps(
       });
     } else if (isCurrentlyBlocked) {
       // Blocked but no new fades - keep existing block and floor, don't decay
+      consecutiveBlocks = fillerTimestamp.consecutiveBlocks;
       updatedTimestamps.push({
         hash,
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: fillerTimestamp.blockUntilTimestamp,
         fadeWindowStart: fillerTimestamp.fadeWindowStart,
-        consecutiveBlocks: fillerTimestamp.consecutiveBlocks,
+        consecutiveBlocks,
       });
     } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD || duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
       // duringBlockRate covers in-flight fades that landed near the end of a block that
@@ -225,17 +232,12 @@ export function calculateNewTimestamps(
       // threshold on a run with no new completions ("blocked while idle") as clean orders age
       // out; that is accepted behavior.
       const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
-      const consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
+      consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
 
       newBlocks++;
       log?.info(
         { hash, fadeRate, duringBlockRate, blockUntilTimestamp },
         'Blocking filler for exceeding fade rate threshold'
-      );
-      metrics?.putMetric(
-        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash),
-        consecutiveBlocks,
-        Unit.Count
       );
 
       updatedTimestamps.push({
@@ -243,7 +245,7 @@ export function calculateNewTimestamps(
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp,
         fadeWindowStart: blockUntilTimestamp, // clean slate resumes when the block ends
-        consecutiveBlocks: consecutiveBlocks,
+        consecutiveBlocks,
       });
     } else {
       // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked and decay
@@ -252,15 +254,21 @@ export function calculateNewTimestamps(
       // escalation requires demonstrated clean activity rather than idling. fadeWindowStart
       // is left as-is: it holds the last block end as the clean-slate floor, so a returning
       // filler is scored only on orders completed after their block ended.
-      const currentBlocks = fillerTimestamp?.consecutiveBlocks || 0;
-      const decayedBlocks = newCompletions > 0 ? Math.max(0, currentBlocks - 1) : currentBlocks;
+      consecutiveBlocks = newCompletions > 0 ? Math.max(0, previousBlocks - 1) : previousBlocks;
       updatedTimestamps.push({
         hash,
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         fadeWindowStart: fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-        consecutiveBlocks: decayedBlocks,
+        consecutiveBlocks,
       });
+    }
+
+    // Emit the escalation level whenever the filler is or was escalated, so the chart steps
+    // down through decay and plots the 0 when a filler fully recovers. Skip never-blocked
+    // fillers (0 -> 0) to avoid a flat-zero series per filler.
+    if (consecutiveBlocks > 0 || previousBlocks > 0) {
+      metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, hash), consecutiveBlocks, Unit.Count);
     }
   });
   metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, newBlocks, Unit.Count);

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -90,6 +90,11 @@ export enum Metric {
   CIRCUIT_BREAKER_TRIGGERED = 'CIRCUIT_BREAKER_TRIGGERED',
   // Per-filler Laplace-smoothed fade rate over the post-block window (compare to FADE_RATE_BLOCK_THRESHOLD)
   CIRCUIT_BREAKER_V2_FADE_RATE = 'CIRCUIT_BREAKER_V2_FADE_RATE',
+  // Per-filler Laplace-smoothed fade rate over the in-flight-during-block cohort, emitted while
+  // a filler is benched. This is the rate that drives extend/re-block decisions, so it (not the
+  // post-block FADE_RATE, which sits at the prior while blocked) is what shows a benched filler
+  // above the threshold. Compare to FADE_RATE_BLOCK_THRESHOLD.
+  CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE = 'CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE',
   // Fillers newly blocked in a cron run (unblocked -> blocked)
   CIRCUIT_BREAKER_V2_NEW_BLOCKS = 'CIRCUIT_BREAKER_V2_NEW_BLOCKS',
   // Active blocks extended in a cron run (in-flight cohort faded over threshold while blocked)
@@ -115,7 +120,8 @@ type MetricNeedingContext =
   | Metric.SYNTH_ORDERS_POSITIVE_OUTCOME
   | Metric.SYNTH_ORDERS_NEGATIVE_OUTCOME
   | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS
-  | Metric.CIRCUIT_BREAKER_V2_FADE_RATE;
+  | Metric.CIRCUIT_BREAKER_V2_FADE_RATE
+  | Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE;
 
 export function metricContext(metric: MetricNeedingContext, context: string): string {
   return `${metric}_${context}`;

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -27,7 +27,7 @@ export const HardQuoteMetricDimension = {
 
 export class AWSMetricsLogger implements IMetric {
   constructor(private awsMetricLogger: AWSEmbeddedMetricsLogger) {}
-  
+
   public setProperty(key: string, value: unknown): void {
     this.awsMetricLogger.setProperty(key, value);
   }
@@ -88,6 +88,16 @@ export enum Metric {
   CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS = 'CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS',
   CIRCUIT_BREAKER_V2_BLOCKED = 'CIRCUIT_BREAKER_V2_BLOCKED',
   CIRCUIT_BREAKER_TRIGGERED = 'CIRCUIT_BREAKER_TRIGGERED',
+  // Per-filler Laplace-smoothed fade rate over the post-block window (compare to FADE_RATE_BLOCK_THRESHOLD)
+  CIRCUIT_BREAKER_V2_FADE_RATE = 'CIRCUIT_BREAKER_V2_FADE_RATE',
+  // Fillers newly blocked in a cron run (unblocked -> blocked)
+  CIRCUIT_BREAKER_V2_NEW_BLOCKS = 'CIRCUIT_BREAKER_V2_NEW_BLOCKS',
+  // Active blocks extended in a cron run (in-flight cohort faded over threshold while blocked)
+  CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS = 'CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS',
+  // Fillers currently benched (blockUntilTimestamp in the future) after a cron run
+  CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS = 'CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS',
+  // Fillers with fade stats evaluated in a cron run (sample-health denominator)
+  CIRCUIT_BREAKER_V2_FILLERS_EVALUATED = 'CIRCUIT_BREAKER_V2_FILLERS_EVALUATED',
 }
 
 type MetricNeedingContext =
@@ -104,7 +114,8 @@ type MetricNeedingContext =
   | Metric.SYNTH_PAIR_DISABLED
   | Metric.SYNTH_ORDERS_POSITIVE_OUTCOME
   | Metric.SYNTH_ORDERS_NEGATIVE_OUTCOME
-  | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS;
+  | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS
+  | Metric.CIRCUIT_BREAKER_V2_FADE_RATE;
 
 export function metricContext(metric: MetricNeedingContext, context: string): string {
   return `${metric}_${context}`;

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -4,6 +4,7 @@ import {
   BASE_BLOCK_SECS,
   calculateBlockUntilTimestamp,
   calculateNewTimestamps,
+  countActiveBlocks,
   FADE_RATE_BLOCK_THRESHOLD,
   FillerFadeStatsMap,
   FillerTimestamps,
@@ -13,6 +14,7 @@ import {
   LAPLACE_BETA,
   UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
 } from '../../lib/cron/fade-rate-v2';
+import { Metric, metricContext } from '../../lib/entities';
 import { ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
 
 const now = Math.floor(Date.now() / 1000);
@@ -393,6 +395,94 @@ describe('FadeRateV2 cron', () => {
       expect(byHash['breach'].blockUntilTimestamp).toBeGreaterThan(now);
       expect(byHash['clean'].blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
       expect(byHash['blocked'].blockUntilTimestamp).toEqual(now + 500); // unchanged
+    });
+
+    it('emits per-filler fade rates and new/extended block counters', () => {
+      const metrics = { putMetric: jest.fn() } as any;
+      const timestamps: FillerTimestamps = new Map([
+        [
+          'extendMe',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
+      ]);
+      const stats: FillerFadeStatsMap = {
+        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1 }, // trips a new block
+        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1 }, // decays
+        extendMe: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1 }, // extends an active block
+      };
+      calculateNewTimestamps(timestamps, stats, now, logger, metrics);
+
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, 'breach'),
+        0.25,
+        expect.anything()
+      );
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, 'clean'),
+        0.03,
+        expect.anything()
+      );
+      expect(metrics.putMetric).toHaveBeenCalledWith(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, 1, expect.anything());
+      expect(metrics.putMetric).toHaveBeenCalledWith(Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, 1, expect.anything());
+    });
+  });
+
+  describe('countActiveBlocks', () => {
+    it('counts benched fillers across stored and updated state, updates taking precedence', () => {
+      const timestamps: FillerTimestamps = new Map([
+        // benched with no completions this run: no update row, still active
+        [
+          'benchedIdle',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: now + 500,
+            fadeWindowStart: now + 500,
+            consecutiveBlocks: 1,
+          },
+        ],
+        // recovered: past block, no update
+        [
+          'recovered',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+        ],
+        // stored state says unblocked, but this run blocks them
+        [
+          'justBlocked',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+        ],
+      ]);
+      const updated: ToUpdateTimestampRow[] = [
+        {
+          hash: 'justBlocked',
+          lastExaminedTimestamp: now,
+          blockUntilTimestamp: now + 900,
+          fadeWindowStart: now + 900,
+          consecutiveBlocks: 1,
+        },
+        {
+          hash: 'newClean',
+          lastExaminedTimestamp: now,
+          blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+          fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+          consecutiveBlocks: 0,
+        },
+      ];
+      expect(countActiveBlocks(timestamps, updated, now)).toEqual(2); // benchedIdle + justBlocked
+    });
+
+    it('treats an unset (0 / undefined) blockUntilTimestamp as unblocked', () => {
+      const timestamps: FillerTimestamps = new Map([
+        ['unsetRow', { lastExaminedTimestamp: 1, blockUntilTimestamp: 0, fadeWindowStart: 0, consecutiveBlocks: 0 }],
+      ]);
+      const updated: ToUpdateTimestampRow[] = [
+        { hash: 'undefRow', lastExaminedTimestamp: now, blockUntilTimestamp: undefined, consecutiveBlocks: 0 },
+      ];
+      expect(countActiveBlocks(timestamps, updated, now)).toEqual(0);
     });
   });
 });

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -429,6 +429,58 @@ describe('FadeRateV2 cron', () => {
       );
       expect(metrics.putMetric).toHaveBeenCalledWith(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, 1, expect.anything());
       expect(metrics.putMetric).toHaveBeenCalledWith(Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, 1, expect.anything());
+
+      // during-block rate is charted only for the currently-blocked filler (its post-block
+      // fadeRate sits at the prior while benched)
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, 'extendMe'),
+        0.2,
+        expect.anything()
+      );
+      expect(metrics.putMetric).not.toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, 'breach'),
+        expect.anything(),
+        expect.anything()
+      );
+
+      // escalation level emitted for blocked/blocking fillers; never-blocked 'clean' (0 -> 0)
+      // emits nothing
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'breach'),
+        1,
+        expect.anything()
+      );
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'extendMe'),
+        2,
+        expect.anything()
+      );
+      expect(metrics.putMetric).not.toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'clean'),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('emits the decayed escalation level so recovery is visible (steps down to 0)', () => {
+      const metrics = { putMetric: jest.fn() } as any;
+      const timestamps: FillerTimestamps = new Map([
+        [
+          'recovering',
+          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 1 },
+        ],
+      ]);
+      const stats: FillerFadeStatsMap = {
+        recovering: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 5 }, // clean run, decays 1 -> 0
+      };
+      calculateNewTimestamps(timestamps, stats, now, logger, metrics);
+
+      // the step down to 0 is emitted (previousBlocks was 1), not silently dropped
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'recovering'),
+        0,
+        expect.anything()
+      );
     });
   });
 


### PR DESCRIPTION
> Stacked on #454 (base branch = `feat/circuit-breaker-laplace-fade-rate`); retarget to `main` once that merges.

## Why

#454 changes how fillers get benched (Laplace-smoothed fade rate, 24h/latest-100 window, clean-slate recovery). This adds the observability to verify it's behaving as designed after rollout — the only existing signal was `CIRCUIT_BREAKER_V2_BLOCKED`, which counts **all** timestamp-row updates (including no-op decays), so it can't distinguish a trip from a quiet run.

## New metrics (`Service=CircuitBreaker`, every 10-min cron run)

| metric | what it tells us |
|---|---|
| `CIRCUIT_BREAKER_V2_FADE_RATE_{filler}` | per-filler smoothed rate — watch the distribution vs the 12% threshold; healthy fillers sit near the 5% prior |
| `CIRCUIT_BREAKER_V2_NEW_BLOCKS` | fillers tripped this run — spikes = threshold too tight or a real incident |
| `CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS` | active blocks extended (in-flight cohort faded over threshold) — should be rare; sustained values suggest the extend path is over-firing |
| `CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS` | fillers currently benched, **including** benched fillers with no completions this run (via new `countActiveBlocks` helper — updated rows override stored state) |
| `CIRCUIT_BREAKER_V2_FILLERS_EVALUATED` | sample-health denominator — a drop to 0 means the Redshift query/view broke (this metric would have surfaced the `startblock`/`filltimeblocks` failures immediately) |

`CIRCUIT_BREAKER_V2_BLOCKED` is still emitted for continuity.

## Dashboard (`UniswapXParamDashboard`)

Replaces the misleading "Blocked Filler On Average" widget with:
1. **Circuit Breaker Activity** — new blocks (Sum), extended blocks (Sum), active blocks (Max), fillers evaluated (Max)
2. **Filler Fade Rates vs Block Threshold** — per-filler series via CloudWatch `SEARCH` (auto-discovers filler hashes; no hardcoded list) with a horizontal annotation at `FADE_RATE_BLOCK_THRESHOLD` imported from the cron, so the line moves if the constant is ever tuned
3. **Filler Consecutive Blocks** — escalation state per filler (`SEARCH` on the existing, previously-uncharted metric); repeat offenders climb, recovered fillers decay to 0

Drive-by: fixed two pre-existing `no-useless-escape` lint errors in the failing-RFQ-logs widget query.

## What "working well" looks like on these charts
- Fade rates clustered near 5% (prior) with real spread below 12%; occasional crossings followed by short benches
- New blocks: low and bursty, not sustained; extended blocks near zero
- Active blocks: small fraction of evaluated fillers; no filler pinned at high consecutive blocks (would suggest the clean-slate recovery isn't working)
- Fillers evaluated: stable at ~the number of active RFQ fillers

## Tests
- `countActiveBlocks`: stored+updated merge with update precedence; benched-idle fillers counted; NaN/undefined treated as unblocked
- Metrics emission from `calculateNewTimestamps`: per-filler fade rate + new/extended counters (mocked `MetricsLogger`)
- 24/24 in the cron suite; 190 unit tests passing; build + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)