### PR TITLE
fix: first-writer-wins filler-address ownership + per-filler address cap

### DIFF
--- a/lib/repositories/filler-address-repository.ts
+++ b/lib/repositories/filler-address-repository.ts
@@ -10,6 +10,13 @@ export type DynamoFillerToAddressRow = {
   addresses: string[];
 };
 
+// Max distinct on-chain addresses a single filler (webhook endpoint) may register. Bounds
+// Sybil breadth: without a cap a filler could register unbounded addresses to spread fades or
+// inflate the circuit-breaker's row set. Rejected registrations are a safe no-op (the order
+// still quotes/fills; the address just isn't attributed), so this can't break quoting.
+// NOTE: tune against the real per-endpoint address distribution before tightening.
+export const MAX_FILLER_ADDRESSES = 3;
+
 export interface FillerAddressRepository {
   getFillerAddresses(filler: string): Promise<string[] | undefined>;
   getFillerByAddress(address: string): Promise<string | undefined>;
@@ -79,20 +86,43 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
 
   async addNewAddressToFiller(address: string, filler?: string): Promise<void> {
     const addrToAdd = getAddress(address);
-    await this._addressToFillerEntity.put({ pk: addrToAdd, filler: filler });
-    if (filler) {
-      const fillerAddresses = await this.getFillerAddresses(filler);
-      if (!fillerAddresses || fillerAddresses.length === 0) {
-        await this._fillerToAddressEntity.put({ pk: filler, addresses: [addrToAdd] });
-      } else {
-        await this._fillerToAddressEntity.update({ pk: filler, addresses: { $add: [addrToAdd] } });
-      }
+    const existingOwner = await this.getFillerByAddress(addrToAdd);
+    const owner = filler ?? existingOwner;
+    if (!owner) {
+      throw new Error(`Filler not found for address ${addrToAdd}`);
+    }
+
+    // First-writer-wins: an address belongs to whichever filler registered it first. A claim
+    // from a different filler is ignored (prevents attribution poisoning / griefing). A genuine
+    // address migration between endpoints needs a manual override.
+    if (existingOwner && existingOwner !== owner) {
+      DynamoFillerAddressRepository.log.info(
+        { address: addrToAdd, existingOwner, attemptedOwner: owner },
+        'address already owned by another filler; ignoring claim'
+      );
+      return;
+    }
+
+    // Already registered to this owner — idempotent no-op.
+    if (existingOwner === owner) {
+      return;
+    }
+
+    // New address for this owner — enforce the per-filler cap.
+    const fillerAddresses = (await this.getFillerAddresses(owner)) ?? [];
+    if (fillerAddresses.length >= MAX_FILLER_ADDRESSES) {
+      DynamoFillerAddressRepository.log.info(
+        { filler: owner, address: addrToAdd, count: fillerAddresses.length, max: MAX_FILLER_ADDRESSES },
+        'filler address cap reached; ignoring new address'
+      );
+      return;
+    }
+
+    await this._addressToFillerEntity.put({ pk: addrToAdd, filler: owner });
+    if (fillerAddresses.length === 0) {
+      await this._fillerToAddressEntity.put({ pk: owner, addresses: [addrToAdd] });
     } else {
-      const existingFiller = await this.getFillerByAddress(addrToAdd);
-      if (!existingFiller) {
-        throw new Error(`Filler not found for address ${addrToAdd}`);
-      }
-      await this._fillerToAddressEntity.update({ pk: existingFiller, addresses: { $add: [addrToAdd] } });
+      await this._fillerToAddressEntity.update({ pk: owner, addresses: { $add: [addrToAdd] } });
     }
   }
 
@@ -148,20 +178,27 @@ export class MockFillerAddressRepository implements FillerAddressRepository {
   }
 
   async addNewAddressToFiller(address: string, filler?: string): Promise<void> {
-    if (filler) {
-      const fillerAddresses = this._fillerToAddress.get(filler) || new Set<string>();
-      fillerAddresses.add(address);
-      this._fillerToAddress.set(filler, fillerAddresses);
-      this._addressToFiller.set(address, filler);
-    } else {
-      const existingFiller = this._addressToFiller.get(address);
-      if (!existingFiller) {
-        throw new Error(`Filler not found for address ${address}`);
-      }
-      const fillerAddresses = this._fillerToAddress.get(existingFiller) || new Set<string>();
-      fillerAddresses.add(address);
-      this._fillerToAddress.set(existingFiller, fillerAddresses);
+    const existingOwner = this._addressToFiller.get(address);
+    const owner = filler ?? existingOwner;
+    if (!owner) {
+      throw new Error(`Filler not found for address ${address}`);
     }
+    // First-writer-wins: ignore a claim on an address owned by another filler.
+    if (existingOwner && existingOwner !== owner) {
+      return;
+    }
+    // Already registered to this owner — idempotent no-op.
+    if (existingOwner === owner) {
+      return;
+    }
+    // New address for this owner — enforce the per-filler cap.
+    const fillerAddresses = this._fillerToAddress.get(owner) || new Set<string>();
+    if (fillerAddresses.size >= MAX_FILLER_ADDRESSES) {
+      return;
+    }
+    fillerAddresses.add(address);
+    this._fillerToAddress.set(owner, fillerAddresses);
+    this._addressToFiller.set(address, owner);
   }
 
   async getFillerAddressesBatch(fillers: string[]): Promise<Map<string, Set<string>>> {

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -1,7 +1,8 @@
 import { DynamoDBClient, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { getAddress } from 'ethers/lib/utils';
 
-import { DynamoFillerAddressRepository } from '../../lib/repositories/filler-address-repository';
+import { DynamoFillerAddressRepository, MAX_FILLER_ADDRESSES } from '../../lib/repositories/filler-address-repository';
 
 const dynamoConfig: DynamoDBClientConfig = {
   endpoint: 'http://localhost:8000',
@@ -104,5 +105,33 @@ describe('filler address repository test', () => {
 
   it('should checksum address when adding to db', async () => {
     expect(await repository.getFillerAddresses('filler4')).toEqual([CHECKSUMED_ADDR]);
+  });
+
+  it('first-writer-wins: ignores a claim on an address already owned by another filler', async () => {
+    // ADDR1 is owned by filler1 (from beforeAll). A different filler tries to claim it.
+    await repository.addNewAddressToFiller(ADDR1, 'attacker');
+    // ownership is unchanged, and the attacker did not gain the address
+    expect(await repository.getFillerByAddress(ADDR1)).toEqual('filler1');
+    expect(await repository.getFillerAddresses('attacker')).toBeUndefined();
+    expect(await repository.getFillerAddresses('filler1')).toEqual([ADDR1, ADDR2]);
+  });
+
+  it('caps the number of addresses a single filler can register', async () => {
+    const addrs = [
+      '0x0000000000000000000000000000000000000010',
+      '0x0000000000000000000000000000000000000011',
+      '0x0000000000000000000000000000000000000012',
+      '0x0000000000000000000000000000000000000013',
+    ];
+    expect(addrs.length).toBeGreaterThan(MAX_FILLER_ADDRESSES); // guard: test must exceed the cap
+    for (const addr of addrs) {
+      await repository.addNewAddressToFiller(addr, 'capFiller');
+    }
+    // only the first MAX_FILLER_ADDRESSES are registered; the rest are ignored
+    const registered = (await repository.getFillerAddresses('capFiller')) ?? [];
+    expect(registered.length).toEqual(MAX_FILLER_ADDRESSES);
+    expect(registered).toEqual(addrs.slice(0, MAX_FILLER_ADDRESSES).map((a) => getAddress(a)));
+    // the over-cap address is attributed to no filler
+    expect(await repository.getFillerByAddress(addrs[MAX_FILLER_ADDRESSES])).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

The RFQ circuit breaker attributes fades to a filler (webhook endpoint) via an address→filler map that is populated from the **caller-supplied `response.filler`** on every OK quote (`WebhookQuoter` → `addNewAddressToFiller`). The security review on #454 flagged two holes in that registration path:

1. **Attribution poisoning** — `addNewAddressToFiller` did an unconditional, last-write-wins put, so a filler could claim an address owned by *another* filler. With the rate-based breaker, binding a high-volume clean competitor's address to your own hash dilutes your smoothed fade rate below the block threshold (and griefs the competitor). One valid-looking quote, no auction win needed.
2. **Unbounded squatting** — there was no cap on how many addresses a single filler could register (`$add` to a set, forever).

## Fix

Both enforced in `addNewAddressToFiller` (the sole writer of the map), mirrored in the mock:

- **First-writer-wins ownership:** an address belongs to whichever filler registered it first; a claim from a different filler is ignored (logged). A genuine address migration between endpoints needs a manual override.
- **Per-filler cap:** `MAX_FILLER_ADDRESSES = 3`; registrations beyond the cap are ignored (logged).

Both rejections are **safe no-ops** — the order still quotes and fills; the address just isn't added to the attribution map — so this cannot break quoting. Registration is already fire-and-forget from the quote path.

## How much can a quoter squat on now?
**3** (was unlimited), and it can no longer claim addresses owned by other fillers at all.

## Scope / caveats
- This caps the **attribution map**, which is what the circuit breaker reads. Fully bounding `postedorders.filler` diversity (the raw rows the fade SQL counts) additionally requires **cosign-time enforcement** — refusing to cosign an order for a filler's (N+1)th address — which touches the quote hot path and is left as a follow-up. Residual without it: a filler rotating to an over-cap address gets that address's orders *unattributed* (uncounted), i.e. a mild evasion rather than a dilution/poison — acceptable given the breaker treats unknown addresses as new identities anyway.
- `MAX_FILLER_ADDRESSES = 3` matches the value discussed in review, but should be **calibrated against the real per-endpoint address distribution** before we rely on it — a legit high-rotation filler above the cap would be under-monitored (safe direction, not a break). Easy one-constant tune.

## Tests
`filler-address-repository.test.ts`: first-writer-wins (a different filler's claim on an owned address is ignored, ownership unchanged) and the cap (only the first `MAX_FILLER_ADDRESSES` register; the over-cap address is attributed to no filler). Full unit suite passing (191).

## Related
Follow-up from the #454 security review (independent subsystem; branches off `main`). The cosign-time cap and a `FILLERS_EVALUATED` truncation alarm remain as further follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
