### PR TITLE
refactor, test: shared injector base for soft and hard quotes

### DIFF
--- a/lib/entities/HardQuoteRequest.ts
+++ b/lib/entities/HardQuoteRequest.ts
@@ -81,8 +81,11 @@ export class HardQuoteRequest {
     return this.data.tokenInChainId;
   }
 
+  // See the matching note in QuoteRequest: this getter previously returned the tokenIn chain
+  // id. Value-identical today because HardQuoteRequestBodyJoi pins tokenOutChainId to
+  // Joi.ref('tokenInChainId').
   public get tokenOutChainId(): number {
-    return this.data.tokenInChainId;
+    return this.data.tokenOutChainId;
   }
 
   public get swapper(): string {

--- a/lib/entities/QuoteRequest.ts
+++ b/lib/entities/QuoteRequest.ts
@@ -113,8 +113,13 @@ export class QuoteRequest {
     return this.data.tokenInChainId;
   }
 
+  // Returns the tokenOut chain id, which this getter previously ignored in favour of the
+  // tokenIn chain id. Value-identical today: PostQuoteRequestBodyJoi pins tokenOutChainId to
+  // Joi.ref('tokenInChainId'), so every validated request has the two equal. Fixed so the
+  // getter is correct by construction rather than by that constraint — the values reach the
+  // RFQ payloads sent to market makers.
   public get tokenOutChainId(): number {
-    return this.data.tokenInChainId;
+    return this.data.tokenOutChainId;
   }
 
   public get swapper(): string {

--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -20,12 +20,12 @@ import { HardQuoteRequest, Metric, QuoteResponse } from '../../entities';
 import { V2HardQuoteResponse } from '../../entities/V2HardQuoteResponse';
 import { V3HardQuoteResponse } from '../../entities/V3HardQuoteResponse';
 import { checkDefined } from '../../preconditions/preconditions';
+import { getBestQuote } from '../../quoters/best-quote';
 import { ChainId } from '../../util/chains';
 import { NoQuotesAvailable, OrderDeadlineExpired, OrderPostError, UnknownOrderCosignerError } from '../../util/errors';
 import { timestampInMstoSeconds } from '../../util/time';
 import { APIGLambdaHandler } from '../base';
 import { APIHandleRequestParams, ErrorResponse, Response } from '../base/api-handler';
-import { getBestQuote } from '../quote/handler';
 import { ContainerInjected, RequestInjected } from './injector';
 import {
   HardQuoteRequestBody,

--- a/lib/handlers/hard-quote/injector.ts
+++ b/lib/handlers/hard-quote/injector.ts
@@ -1,86 +1,46 @@
-import { IMetric, setGlobalLogger, setGlobalMetric } from '@uniswap/smart-order-router';
 import { MetricsLogger } from 'aws-embedded-metrics';
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import { default as bunyan, default as Logger } from 'bunyan';
+import { default as Logger } from 'bunyan';
 
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { ethers } from 'ethers';
-import { BETA_S3_KEY, PRODUCTION_S3_KEY, RPC_HEADERS, WEBHOOK_CONFIG_BUCKET } from '../../constants';
-import { AWSMetricsLogger, HardQuoteMetricDimension } from '../../entities/aws-metrics-logger';
+import { HardQuoteMetricDimension } from '../../entities/aws-metrics-logger';
 import { checkDefined } from '../../preconditions/preconditions';
-import { OrderServiceProvider, S3WebhookConfigurationProvider, UniswapXServiceProvider } from '../../providers';
-import { FirehoseLogger } from '../../providers/analytics';
-import { DynamoCircuitBreakerConfigurationProvider } from '../../providers/circuit-breaker/dynamo';
+import { OrderServiceProvider, UniswapXServiceProvider } from '../../providers';
 import { MockFillerComplianceConfigurationProvider } from '../../providers/compliance';
-import { Quoter, WebhookQuoter } from '../../quoters';
-import { DynamoFillerAddressRepository } from '../../repositories/filler-address-repository';
-import { ChainId, getRpcUrl, SUPPORTED_CHAINS } from '../../util/chains';
-import { STAGE } from '../../util/stage';
-import { ApiInjector, ApiRInj } from '../base/api-handler';
+import { ApiInjector } from '../base/api-handler';
+import {
+  BaseQuoteContainerInjected,
+  BaseQuoteRequestInjected,
+  buildQuoteContainerInjected,
+  buildQuoteRequestInjected,
+  createInjectorLogger,
+} from '../shared/quote-injector';
 import { HardQuoteRequestBody } from './schema';
 
-export interface ContainerInjected {
-  quoters: Quoter[];
-  firehose: FirehoseLogger;
+export interface ContainerInjected extends BaseQuoteContainerInjected {
   orderServiceProvider: OrderServiceProvider;
-  chainIdRpcMap: Map<ChainId, ethers.providers.StaticJsonRpcProvider>;
 }
 
-export interface RequestInjected extends ApiRInj {
-  metric: IMetric;
-}
+export interface RequestInjected extends BaseQuoteRequestInjected {}
 
 export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjected, HardQuoteRequestBody, void> {
   public async buildContainerInjected(): Promise<ContainerInjected> {
-    const log: Logger = bunyan.createLogger({
-      name: this.injectorName,
-      serializers: bunyan.stdSerializers,
-      level: bunyan.INFO,
-    });
+    const log: Logger = createInjectorLogger(this.injectorName);
 
     const stage = process.env['stage'];
-    const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
 
     const orderServiceUrl = checkDefined(process.env.ORDER_SERVICE_URL, 'ORDER_SERVICE_URL is not defined');
 
-    const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
-    const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(log, webhookProvider);
-
-    const orderServiceProvider = new UniswapXServiceProvider(log, orderServiceUrl);
-
+    // Hard quotes are cosigned and posted to the order service rather than dispatched
+    // per-swapper, so no swapper-based filler exclusion applies. An empty config list makes
+    // passFillerCompliance() always true and keeps the compliance S3 reads (and the
+    // outbound compliance-list fetch) off this Lambda's hot path.
     const fillerComplianceProvider = new MockFillerComplianceConfigurationProvider([]);
 
-    const firehose = new FirehoseLogger(log, process.env.ANALYTICS_STREAM_ARN!);
-
-    const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
-      marshallOptions: {
-        convertEmptyValues: true,
-      },
-      unmarshallOptions: {
-        wrapNumbers: true,
-      },
-    });
-    const repository = DynamoFillerAddressRepository.create(documentClient);
-
-    const quoters: Quoter[] = [
-      new WebhookQuoter(log, firehose, webhookProvider, circuitBreakerProvider, fillerComplianceProvider, repository),
-    ];
-
-    const chainIdRpcMap = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>();
-    SUPPORTED_CHAINS.forEach((chainId) => {
-      const provider = new ethers.providers.StaticJsonRpcProvider(
-        { url: getRpcUrl(chainId), headers: RPC_HEADERS },
-        chainId
-      );
-      chainIdRpcMap.set(chainId, provider);
-    });
+    const base = buildQuoteContainerInjected(log, stage, fillerComplianceProvider);
 
     return {
-      quoters: quoters,
-      firehose: firehose,
-      orderServiceProvider,
-      chainIdRpcMap,
+      ...base,
+      orderServiceProvider: new UniswapXServiceProvider(log, orderServiceUrl),
     };
   }
 
@@ -93,29 +53,12 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     log: Logger,
     metricsLogger: MetricsLogger
   ): Promise<RequestInjected> {
-    const requestId = context.awsRequestId;
-
-    log = log.child({
-      serializers: bunyan.stdSerializers,
+    return buildQuoteRequestInjected({
       requestBody,
-      requestId,
-    });
-    setGlobalLogger(log);
-
-    metricsLogger.setNamespace('Uniswap');
-    metricsLogger.setDimensions(HardQuoteMetricDimension);
-    // additional dimension set so every metric is also queryable per-chain
-    metricsLogger.putDimensions({
-      ...HardQuoteMetricDimension,
-      ChainId: requestBody.tokenInChainId.toString(),
-    });
-    const metric = new AWSMetricsLogger(metricsLogger);
-    setGlobalMetric(metric);
-
-    return {
+      context,
       log,
-      metric,
-      requestId,
-    };
+      metricsLogger,
+      metricDimension: HardQuoteMetricDimension,
+    });
   }
 }

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -1,11 +1,9 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { IMetric, MetricLoggerUnit } from '@uniswap/smart-order-router';
-import Logger from 'bunyan';
-import { ethers } from 'ethers';
+import { MetricLoggerUnit } from '@uniswap/smart-order-router';
 import Joi from 'joi';
 
-import { Metric, QuoteRequest, QuoteResponse } from '../../entities';
-import { Quoter } from '../../quoters';
+import { Metric, QuoteRequest } from '../../entities';
+import { getBestQuote } from '../../quoters/best-quote';
 import { NoQuotesAvailable } from '../../util/errors';
 import { timestampInMstoSeconds } from '../../util/time';
 import { APIGLambdaHandler } from '../base';
@@ -17,13 +15,6 @@ import {
   PostQuoteResponseWithAllQuotes,
   URAResponseJoi,
 } from './schema';
-
-export type EventType = 'QuoteResponse' | 'HardResponse';
-
-export interface BestQuoteResult {
-  bestQuote: QuoteResponse | null;
-  allQuotes: QuoteResponse[];
-}
 
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,
@@ -52,7 +43,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       body: {
         requestId: request.requestId,
         tokenInChainId: request.tokenInChainId,
-        tokenOutChainId: request.tokenInChainId,
+        tokenOutChainId: request.tokenOutChainId,
         offerer: request.swapper,
         tokenIn: request.tokenIn,
         tokenOut: request.tokenOut,
@@ -94,52 +85,4 @@ export class QuoteHandler extends APIGLambdaHandler<
   protected responseBodySchema(): Joi.ObjectSchema | null {
     return URAResponseJoi;
   }
-}
-
-// fetch quotes from all quoters and return the best one along with all quotes
-export async function getBestQuote(
-  quoters: Quoter[],
-  quoteRequest: QuoteRequest,
-  log: Logger,
-  metric: IMetric,
-  provider?: ethers.providers.StaticJsonRpcProvider,
-  eventType: EventType = 'QuoteResponse'
-): Promise<BestQuoteResult> {
-  const responses: QuoteResponse[] = (await Promise.all(quoters.map((q) => q.quote(quoteRequest, provider)))).flat();
-  switch (responses.length) {
-    case 0:
-      metric.putMetric(Metric.RFQ_COUNT_0, 1, MetricLoggerUnit.Count);
-      break;
-    case 1:
-      metric.putMetric(Metric.RFQ_COUNT_1, 1, MetricLoggerUnit.Count);
-      break;
-    case 2:
-      metric.putMetric(Metric.RFQ_COUNT_2, 1, MetricLoggerUnit.Count);
-      break;
-    case 3:
-      metric.putMetric(Metric.RFQ_COUNT_3, 1, MetricLoggerUnit.Count);
-      break;
-    default:
-      metric.putMetric(Metric.RFQ_COUNT_4_PLUS, 1, MetricLoggerUnit.Count);
-      break;
-  }
-
-  // return the response with the highest amountOut value
-  const bestQuote = responses.reduce((best: QuoteResponse | null, quote: QuoteResponse) => {
-    log.info({
-      eventType: eventType,
-      body: { ...quote.toLog(), offerer: quote.swapper, endpoint: quote.endpoint, fillerName: quote.fillerName },
-    });
-
-    if (
-      !best ||
-      (quoteRequest.type == TradeType.EXACT_INPUT && quote.amountOut.gt(best.amountOut)) ||
-      (quoteRequest.type == TradeType.EXACT_OUTPUT && quote.amountIn.lt(best.amountIn))
-    ) {
-      return quote;
-    }
-    return best;
-  }, null);
-
-  return { bestQuote, allQuotes: responses };
 }

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -1,56 +1,33 @@
-import { IMetric, setGlobalLogger, setGlobalMetric } from '@uniswap/smart-order-router';
 import { MetricsLogger } from 'aws-embedded-metrics';
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import { default as bunyan, default as Logger } from 'bunyan';
+import { default as Logger } from 'bunyan';
 
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { ethers } from 'ethers';
-import {
-  BETA_COMPLIANCE_S3_KEY,
-  BETA_S3_KEY,
-  COMPLIANCE_CONFIG_BUCKET,
-  PRODUCTION_S3_KEY,
-  PROD_COMPLIANCE_S3_KEY,
-  RPC_HEADERS,
-  WEBHOOK_CONFIG_BUCKET,
-} from '../../constants';
-import { AWSMetricsLogger, SoftQuoteMetricDimension } from '../../entities/aws-metrics-logger';
-import { S3WebhookConfigurationProvider } from '../../providers';
-import { FirehoseLogger } from '../../providers/analytics';
-import { DynamoCircuitBreakerConfigurationProvider } from '../../providers/circuit-breaker/dynamo';
+import { BETA_COMPLIANCE_S3_KEY, COMPLIANCE_CONFIG_BUCKET, PROD_COMPLIANCE_S3_KEY } from '../../constants';
+import { SoftQuoteMetricDimension } from '../../entities/aws-metrics-logger';
 import { S3FillerComplianceConfigurationProvider } from '../../providers/compliance/s3';
-import { Quoter, WebhookQuoter } from '../../quoters';
-import { DynamoFillerAddressRepository } from '../../repositories/filler-address-repository';
-import { ChainId, getRpcUrl, SUPPORTED_CHAINS } from '../../util/chains';
 import { STAGE } from '../../util/stage';
-import { ApiInjector, ApiRInj } from '../base/api-handler';
+import { ApiInjector } from '../base/api-handler';
+import {
+  BaseQuoteContainerInjected,
+  BaseQuoteRequestInjected,
+  buildQuoteContainerInjected,
+  buildQuoteRequestInjected,
+  createInjectorLogger,
+} from '../shared/quote-injector';
 import { PostQuoteRequestBody } from './schema';
 
-export interface ContainerInjected {
-  quoters: Quoter[];
-  firehose: FirehoseLogger;
-  chainIdRpcMap: Map<ChainId, ethers.providers.StaticJsonRpcProvider>;
-}
+export interface ContainerInjected extends BaseQuoteContainerInjected {}
 
-export interface RequestInjected extends ApiRInj {
-  metric: IMetric;
-}
+export interface RequestInjected extends BaseQuoteRequestInjected {}
 
 export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjected, PostQuoteRequestBody, void> {
   public async buildContainerInjected(): Promise<ContainerInjected> {
-    const log: Logger = bunyan.createLogger({
-      name: this.injectorName,
-      serializers: bunyan.stdSerializers,
-      level: bunyan.INFO,
-    });
+    const log: Logger = createInjectorLogger(this.injectorName);
 
     const stage = process.env['stage'];
-    const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
 
-    const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
-    const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(log, webhookProvider);
-
+    // Soft quotes are dispatched per-swapper, so the real compliance list applies: it
+    // excludes specific swappers from specific filler endpoints.
     const complianceKey = stage === STAGE.BETA ? BETA_COMPLIANCE_S3_KEY : PROD_COMPLIANCE_S3_KEY;
     const fillerComplianceProvider = new S3FillerComplianceConfigurationProvider(
       log,
@@ -58,39 +35,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
       complianceKey
     );
 
-    const firehose = new FirehoseLogger(log, process.env.ANALYTICS_STREAM_ARN!);
-
-    const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
-      marshallOptions: {
-        convertEmptyValues: true,
-      },
-      unmarshallOptions: {
-        wrapNumbers: true,
-      },
-    });
-    const repository = DynamoFillerAddressRepository.create(documentClient);
-
-    const quoters: Quoter[] = [
-      new WebhookQuoter(log, firehose, webhookProvider, circuitBreakerProvider, fillerComplianceProvider, repository),
-    ];
-
-    const chainIdRpcMap = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>();
-    SUPPORTED_CHAINS.forEach((chainId) => {
-      const provider = new ethers.providers.StaticJsonRpcProvider(
-        {
-          url: getRpcUrl(chainId),
-          headers: RPC_HEADERS,
-        },
-        chainId
-      );
-      chainIdRpcMap.set(chainId, provider);
-    });
-
-    return {
-      quoters: quoters,
-      firehose: firehose,
-      chainIdRpcMap: chainIdRpcMap,
-    };
+    return buildQuoteContainerInjected(log, stage, fillerComplianceProvider);
   }
 
   public async getRequestInjected(
@@ -102,29 +47,12 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, RequestInjecte
     log: Logger,
     metricsLogger: MetricsLogger
   ): Promise<RequestInjected> {
-    const requestId = context.awsRequestId;
-
-    log = log.child({
-      serializers: bunyan.stdSerializers,
+    return buildQuoteRequestInjected({
       requestBody,
-      requestId,
-    });
-    setGlobalLogger(log);
-
-    metricsLogger.setNamespace('Uniswap');
-    metricsLogger.setDimensions(SoftQuoteMetricDimension);
-    // additional dimension set so every metric is also queryable per-chain
-    metricsLogger.putDimensions({
-      ...SoftQuoteMetricDimension,
-      ChainId: requestBody.tokenInChainId.toString(),
-    });
-    const metric = new AWSMetricsLogger(metricsLogger);
-    setGlobalMetric(metric);
-
-    return {
+      context,
       log,
-      metric,
-      requestId,
-    };
+      metricsLogger,
+      metricDimension: SoftQuoteMetricDimension,
+    });
   }
 }

--- a/lib/handlers/shared/quote-injector.ts
+++ b/lib/handlers/shared/quote-injector.ts
@@ -1,0 +1,158 @@
+import { IMetric, setGlobalLogger, setGlobalMetric } from '@uniswap/smart-order-router';
+import { MetricsLogger } from 'aws-embedded-metrics';
+import { Context } from 'aws-lambda';
+import { default as bunyan, default as Logger } from 'bunyan';
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { ethers } from 'ethers';
+import { BETA_S3_KEY, PRODUCTION_S3_KEY, RPC_HEADERS, WEBHOOK_CONFIG_BUCKET } from '../../constants';
+import { AWSMetricsLogger } from '../../entities/aws-metrics-logger';
+import { S3WebhookConfigurationProvider } from '../../providers';
+import { FirehoseLogger } from '../../providers/analytics';
+import { DynamoCircuitBreakerConfigurationProvider } from '../../providers/circuit-breaker/dynamo';
+import { FillerComplianceConfigurationProvider } from '../../providers/compliance';
+import { Quoter, WebhookQuoter } from '../../quoters';
+import { DynamoFillerAddressRepository } from '../../repositories/filler-address-repository';
+import { ChainId, getRpcUrl, SUPPORTED_CHAINS } from '../../util/chains';
+import { STAGE } from '../../util/stage';
+import { ApiRInj } from '../base/api-handler';
+
+/** Container state shared by both quote Lambdas (soft `/quote` and hard `/hard-quote`). */
+export interface BaseQuoteContainerInjected {
+  quoters: Quoter[];
+  firehose: FirehoseLogger;
+  chainIdRpcMap: Map<ChainId, ethers.providers.StaticJsonRpcProvider>;
+}
+
+/** Per-request state shared by both quote Lambdas. */
+export interface BaseQuoteRequestInjected extends ApiRInj {
+  metric: IMetric;
+}
+
+/**
+ * Builds the injector's root logger. The `name` field lands on every log line the
+ * providers and quoters emit, so it stays the injector's own name.
+ */
+export function createInjectorLogger(injectorName: string): Logger {
+  return bunyan.createLogger({
+    name: injectorName,
+    serializers: bunyan.stdSerializers,
+    level: bunyan.INFO,
+  });
+}
+
+/**
+ * One RPC provider per supported chain. The chainId is passed as the second constructor
+ * argument so ethers treats the network as static and skips an `eth_chainId` round trip
+ * on cold start.
+ */
+export function buildChainIdRpcMap(): Map<ChainId, ethers.providers.StaticJsonRpcProvider> {
+  const chainIdRpcMap = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>();
+  SUPPORTED_CHAINS.forEach((chainId) => {
+    const provider = new ethers.providers.StaticJsonRpcProvider(
+      {
+        url: getRpcUrl(chainId),
+        headers: RPC_HEADERS,
+      },
+      chainId
+    );
+    chainIdRpcMap.set(chainId, provider);
+  });
+  return chainIdRpcMap;
+}
+
+/**
+ * Builds the RFQ container both quote Lambdas share. Callers supply their own compliance
+ * provider because the two Lambdas deliberately differ there — see each injector.
+ *
+ * INVARIANT: exactly one S3WebhookConfigurationProvider is created here and that same
+ * instance is given to both the circuit breaker and the WebhookQuoter. The circuit breaker
+ * reads `fillerEndpoints()`, a cache populated only by the quoter's `getEndpoints()` call
+ * one line earlier in the request path. Two instances would leave the breaker's timestamp
+ * map empty, which fails open — every benched filler silently re-enabled, with no error
+ * and no metric. The types do not protect against this: the breaker takes the concrete
+ * S3WebhookConfigurationProvider while the quoter takes only the interface, so a split
+ * compiles cleanly.
+ *
+ * Construction is synchronous and does no I/O; every client here is lazy. It must stay
+ * inside the injector call (not module scope) so BaseInjector.build() keeps caching one
+ * container per Lambda execution environment, preserving each provider's refresh window.
+ */
+export function buildQuoteContainerInjected(
+  log: Logger,
+  stage: string | undefined,
+  fillerComplianceProvider: FillerComplianceConfigurationProvider
+): BaseQuoteContainerInjected {
+  const s3Key = stage === STAGE.BETA ? BETA_S3_KEY : PRODUCTION_S3_KEY;
+
+  const webhookProvider = new S3WebhookConfigurationProvider(log, `${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key);
+  const circuitBreakerProvider = new DynamoCircuitBreakerConfigurationProvider(log, webhookProvider);
+
+  const firehose = new FirehoseLogger(log, process.env.ANALYTICS_STREAM_ARN!);
+
+  const documentClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+    marshallOptions: {
+      convertEmptyValues: true,
+    },
+    unmarshallOptions: {
+      wrapNumbers: true,
+    },
+  });
+  const repository = DynamoFillerAddressRepository.create(documentClient);
+
+  const quoters: Quoter[] = [
+    new WebhookQuoter(log, firehose, webhookProvider, circuitBreakerProvider, fillerComplianceProvider, repository),
+  ];
+
+  return {
+    quoters,
+    firehose,
+    chainIdRpcMap: buildChainIdRpcMap(),
+  };
+}
+
+/**
+ * Per-request logger and metric setup, identical for both quote Lambdas apart from the
+ * metric dimension. Takes an options object because the only thing that varies is a
+ * dimension constant structurally identical to the other Lambda's, which a positional
+ * argument would make easy to swap silently.
+ *
+ * The call order is load-bearing: `setDimensions` REPLACES the dimension-set list while
+ * `putDimensions` APPENDS one, so the per-chain set must be added second. `setGlobalMetric`
+ * must run because WebhookQuoter emits every RFQ_* metric through the smart-order-router
+ * module global rather than the injected IMetric.
+ */
+export function buildQuoteRequestInjected<ReqBody extends { tokenInChainId: number }>(params: {
+  requestBody: ReqBody;
+  context: Context;
+  log: Logger;
+  metricsLogger: MetricsLogger;
+  metricDimension: Record<string, string>;
+}): BaseQuoteRequestInjected {
+  const { requestBody, context, metricsLogger, metricDimension } = params;
+  const requestId = context.awsRequestId;
+
+  const log = params.log.child({
+    serializers: bunyan.stdSerializers,
+    requestBody,
+    requestId,
+  });
+  setGlobalLogger(log);
+
+  metricsLogger.setNamespace('Uniswap');
+  metricsLogger.setDimensions(metricDimension);
+  // additional dimension set so every metric is also queryable per-chain
+  metricsLogger.putDimensions({
+    ...metricDimension,
+    ChainId: requestBody.tokenInChainId.toString(),
+  });
+  const metric = new AWSMetricsLogger(metricsLogger);
+  setGlobalMetric(metric);
+
+  return {
+    log,
+    metric,
+    requestId,
+  };
+}

--- a/lib/quoters/best-quote.ts
+++ b/lib/quoters/best-quote.ts
@@ -1,0 +1,62 @@
+import { TradeType } from '@uniswap/sdk-core';
+import { IMetric, MetricLoggerUnit } from '@uniswap/smart-order-router';
+import Logger from 'bunyan';
+import { ethers } from 'ethers';
+
+import { Quoter } from '.';
+import { Metric, QuoteRequest, QuoteResponse } from '../entities';
+
+export type EventType = 'QuoteResponse' | 'HardResponse';
+
+export interface BestQuoteResult {
+  bestQuote: QuoteResponse | null;
+  allQuotes: QuoteResponse[];
+}
+
+// fetch quotes from all quoters and return the best one along with all quotes
+export async function getBestQuote(
+  quoters: Quoter[],
+  quoteRequest: QuoteRequest,
+  log: Logger,
+  metric: IMetric,
+  provider?: ethers.providers.StaticJsonRpcProvider,
+  eventType: EventType = 'QuoteResponse'
+): Promise<BestQuoteResult> {
+  const responses: QuoteResponse[] = (await Promise.all(quoters.map((q) => q.quote(quoteRequest, provider)))).flat();
+  switch (responses.length) {
+    case 0:
+      metric.putMetric(Metric.RFQ_COUNT_0, 1, MetricLoggerUnit.Count);
+      break;
+    case 1:
+      metric.putMetric(Metric.RFQ_COUNT_1, 1, MetricLoggerUnit.Count);
+      break;
+    case 2:
+      metric.putMetric(Metric.RFQ_COUNT_2, 1, MetricLoggerUnit.Count);
+      break;
+    case 3:
+      metric.putMetric(Metric.RFQ_COUNT_3, 1, MetricLoggerUnit.Count);
+      break;
+    default:
+      metric.putMetric(Metric.RFQ_COUNT_4_PLUS, 1, MetricLoggerUnit.Count);
+      break;
+  }
+
+  // return the response with the highest amountOut value
+  const bestQuote = responses.reduce((best: QuoteResponse | null, quote: QuoteResponse) => {
+    log.info({
+      eventType: eventType,
+      body: { ...quote.toLog(), offerer: quote.swapper, endpoint: quote.endpoint, fillerName: quote.fillerName },
+    });
+
+    if (
+      !best ||
+      (quoteRequest.type == TradeType.EXACT_INPUT && quote.amountOut.gt(best.amountOut)) ||
+      (quoteRequest.type == TradeType.EXACT_OUTPUT && quote.amountIn.lt(best.amountIn))
+    ) {
+      return quote;
+    }
+    return best;
+  }, null);
+
+  return { bestQuote, allQuotes: responses };
+}

--- a/test/entities/HardQuoteRequest.test.ts
+++ b/test/entities/HardQuoteRequest.test.ts
@@ -235,4 +235,24 @@ describe('QuoteRequest', () => {
       protocol: ProtocolVersion.V3,
     });
   });
+
+  // Pins the tokenOutChainId getter, which previously returned the tokenIn chain id. Every
+  // other fixture sets the two equal, so nothing else here distinguishes the fix from the bug.
+  // Constructed directly because HardQuoteRequestBodyJoi pins tokenOutChainId to
+  // Joi.ref('tokenInChainId'), so a validated request can never carry differing ids.
+  it('reads tokenOutChainId from its own field', () => {
+    const order = new UnsignedV2DutchOrder(
+      getOrderInfo({
+        swapper: SWAPPER,
+      }),
+      CHAIN_ID
+    );
+    const request = makeRequest({
+      encodedInnerOrder: order.serialize(),
+      innerSig: '0x',
+      tokenOutChainId: 42161,
+    });
+    expect(request.tokenInChainId).toEqual(CHAIN_ID);
+    expect(request.tokenOutChainId).toEqual(42161);
+  });
 });

--- a/test/entities/QuoteRequest.test.ts
+++ b/test/entities/QuoteRequest.test.ts
@@ -73,4 +73,42 @@ describe('QuoteRequest', () => {
       protocol: ProtocolVersion.V1,
     });
   });
+
+  // Every other fixture here sets the two chain ids equal, which cannot tell a correct
+  // tokenOutChainId getter apart from one returning tokenInChainId. These construct the entity
+  // directly because the API cannot produce differing ids today — PostQuoteRequestBodyJoi pins
+  // tokenOutChainId to Joi.ref('tokenInChainId').
+  describe('with distinct tokenIn/tokenOut chain ids', () => {
+    const OTHER_CHAIN_ID = 42161;
+
+    const crossChainRequest = new QuoteRequest({
+      tokenInChainId: CHAIN_ID,
+      tokenOutChainId: OTHER_CHAIN_ID,
+      requestId: REQUEST_ID,
+      swapper: SWAPPER,
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amount: ethers.utils.parseEther('1'),
+      type: TradeType.EXACT_INPUT,
+      numOutputs: 1,
+      protocol: ProtocolVersion.V1,
+    });
+
+    it('reads each chain id from its own field', () => {
+      expect(crossChainRequest.tokenInChainId).toEqual(CHAIN_ID);
+      expect(crossChainRequest.tokenOutChainId).toEqual(OTHER_CHAIN_ID);
+    });
+
+    it('carries both chain ids through toCleanJSON', () => {
+      const json = crossChainRequest.toCleanJSON();
+      expect(json.tokenInChainId).toEqual(CHAIN_ID);
+      expect(json.tokenOutChainId).toEqual(OTHER_CHAIN_ID);
+    });
+
+    it('swaps the chain ids for the opposing side', () => {
+      const opposing = crossChainRequest.toOpposingCleanJSON();
+      expect(opposing.tokenInChainId).toEqual(OTHER_CHAIN_ID);
+      expect(opposing.tokenOutChainId).toEqual(CHAIN_ID);
+    });
+  });
 });

--- a/test/handlers/shared/quote-injector.test.ts
+++ b/test/handlers/shared/quote-injector.test.ts
@@ -1,0 +1,139 @@
+import { MetricsLogger } from 'aws-embedded-metrics';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import bunyan from 'bunyan';
+
+import { QuoteInjector as HardQuoteInjector } from '../../../lib/handlers/hard-quote/injector';
+import { QuoteInjector as SoftQuoteInjector } from '../../../lib/handlers/quote/injector';
+import { SUPPORTED_CHAINS } from '../../../lib/util/chains';
+
+/**
+ * Wiring tests for the shared quote-injector factory.
+ *
+ * These exist because the container's most important property is not expressible in the
+ * type system: the circuit breaker and the WebhookQuoter must hold the SAME
+ * S3WebhookConfigurationProvider instance. The breaker takes the concrete class while the
+ * quoter takes only the interface, so handing them two separate instances compiles fine
+ * and fails silently in production (the breaker's timestamp map stays empty, so it fails
+ * open and every benched filler is re-enabled with no error and no metric).
+ *
+ * buildContainerInjected does no I/O — every AWS client in the graph is constructed lazily
+ * and the RPC providers are given an explicit network — so these run offline with no
+ * credentials.
+ */
+
+// Quieted so building a real container doesn't spam the test output.
+const log = bunyan.createLogger({ name: 'quote-injector.test', level: bunyan.FATAL });
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+beforeAll(() => {
+  process.env.stage = 'beta';
+  process.env.RPC_PREFIX_URL = 'https://rpc.example/';
+  process.env.ANALYTICS_STREAM_ARN = 'arn:aws:firehose:us-east-2:1:deliverystream/dummy';
+  process.env.ORDER_SERVICE_URL = 'https://order.example';
+});
+
+function stubMetricsLogger() {
+  return {
+    setNamespace: jest.fn(),
+    setDimensions: jest.fn(),
+    putDimensions: jest.fn(),
+    putMetric: jest.fn(),
+    setProperty: jest.fn(),
+  };
+}
+
+describe('shared quote injector wiring', () => {
+  describe.each([
+    ['soft quote', () => new SoftQuoteInjector('quoteInjector'), 'S3FillerComplianceConfigurationProvider', false],
+    ['hard quote', () => new HardQuoteInjector('hardQuoteInjector'), 'MockFillerComplianceConfigurationProvider', true],
+  ])('%s container', (_name, makeInjector, expectedComplianceProvider, expectsOrderService) => {
+    let container: any;
+    let quoter: any;
+
+    beforeAll(async () => {
+      container = (await (makeInjector() as any).build()).getContainerInjected();
+      quoter = container.quoters[0];
+    });
+
+    it('shares ONE webhook provider between the circuit breaker and the quoter', () => {
+      expect(quoter.webhookProvider).toBeDefined();
+      expect(quoter.circuitBreakerProvider.webhookProvider).toBeDefined();
+      // Compared as a boolean rather than with toBe(instance): a split yields two
+      // structurally identical providers, so toBe would dump ~2kb of bunyan internals
+      // and report only "serializes to the same string".
+      const sharesOneInstance = quoter.circuitBreakerProvider.webhookProvider === quoter.webhookProvider;
+      expect(sharesOneInstance).toBe(true);
+    });
+
+    it('shares one firehose logger between the container and the quoter', () => {
+      expect(quoter.firehose).toBe(container.firehose);
+    });
+
+    it('registers exactly one quoter', () => {
+      expect(container.quoters).toHaveLength(1);
+    });
+
+    it('scopes the webhook config bucket to the stage', () => {
+      expect(quoter.webhookProvider.bucket).toContain('-beta-1');
+    });
+
+    it('uses the expected compliance provider for this lambda', () => {
+      expect(quoter.complianceProvider.constructor.name).toEqual(expectedComplianceProvider);
+    });
+
+    it('builds one static RPC provider per supported chain', () => {
+      expect(container.chainIdRpcMap.size).toEqual(SUPPORTED_CHAINS.length);
+
+      const mainnet = container.chainIdRpcMap.get(1);
+      expect(mainnet.connection.url).toEqual('https://rpc.example/1');
+      expect(mainnet.connection.headers['x-uni-service-id']).toEqual('x_parameterization_api');
+      // explicit network => no eth_chainId round trip on cold start
+      expect(mainnet.network.chainId).toEqual(1);
+    });
+
+    it('provides the order service only where it is needed', () => {
+      if (expectsOrderService) {
+        expect(container.orderServiceProvider).toBeDefined();
+      } else {
+        expect(container.orderServiceProvider).toBeUndefined();
+      }
+    });
+  });
+
+  describe('getRequestInjected', () => {
+    it.each([
+      ['soft quote', () => new SoftQuoteInjector('quoteInjector'), 'SoftQuote', 42161],
+      ['hard quote', () => new HardQuoteInjector('hardQuoteInjector'), 'HardQuote', 1],
+    ])('sets the %s metric dimensions and request id', async (_name, makeInjector, service, chainId) => {
+      const metricsLogger = stubMetricsLogger();
+
+      const requestInjected = await (makeInjector() as any).getRequestInjected(
+        {} as any,
+        { tokenInChainId: chainId } as any,
+        undefined,
+        {} as APIGatewayProxyEvent,
+        { awsRequestId: 'req-1' } as Context,
+        log,
+        metricsLogger as unknown as MetricsLogger
+      );
+
+      expect(metricsLogger.setNamespace).toHaveBeenCalledWith('Uniswap');
+      expect(metricsLogger.setDimensions).toHaveBeenCalledWith({ Service: service });
+      expect(metricsLogger.putDimensions).toHaveBeenCalledWith({
+        Service: service,
+        ChainId: chainId.toString(),
+      });
+      // Order is load-bearing, so assert it rather than just the payloads: setDimensions
+      // REPLACES the dimension-set list while putDimensions APPENDS, so reversing the two
+      // silently drops the per-chain dimension set from every metric.
+      expect(metricsLogger.setDimensions.mock.invocationCallOrder[0]).toBeLessThan(
+        metricsLogger.putDimensions.mock.invocationCallOrder[0]
+      );
+      expect(requestInjected.requestId).toEqual('req-1');
+      // The child logger is what carries requestBody/requestId onto every downstream log line.
+      expect(requestInjected.log).not.toBe(log);
+      expect(requestInjected.log.fields.requestId).toEqual('req-1');
+    });
+  });
+});


### PR DESCRIPTION
Pure refactor — no behavior change. Prep for WebSocket RFQ work.

**Changes**
- New `lib/handlers/shared/quote-injector.ts`: the container + per-request wiring both quote injectors duplicated (9 of 12 construction steps were byte-identical; `getRequestInjected` differed only by one metric-dimension constant). Each injector keeps just what differs — soft: real S3 compliance provider, hard: mock + order service.
- `getBestQuote` → `lib/quoters/best-quote.ts`, removing the handler→handler import. Moved verbatim (diffed byte-identical); the `QuoteResponse`/`HardResponse` `eventType` strings are matched by CloudWatch filters, so they're unchanged.
- `tokenOutChainId` getters in `QuoteRequest`/`HardQuoteRequest` returned the **tokenIn** chain id; now read their own field. Value-identical today — both Joi schemas pin `tokenOutChainId` to `Joi.ref('tokenInChainId')` — so this is correctness, not an observable change. Same for the hardcoded log line in the soft-quote handler.
- New `test/handlers/shared/quote-injector.test.ts` (16 tests, offline) + 4 additive entity tests.

Not `lib/services/` (no precedent; `lib/` is role-based). Not `lib/handlers/base/` (`lib/providers/order/*` import from it → runtime cycle).

**Please review this invariant**: exactly one `S3WebhookConfigurationProvider` must be shared by the circuit breaker and the `WebhookQuoter` — the breaker reads a cache only the quoter populates. Split them and the breaker silently fails open (benched fillers re-enabled, no error, no metric), and types won't catch it (breaker takes the concrete class, quoter the interface). The new test pins it; confirmed red when split.

**Verified**: build + lint clean; 229 tests pass (was 208); entity test diffs additive-only; both handler barrels byte-identical; both Lambda entries bundle.
