### PR TITLE
chore: remove deprecated bot processor and fades table

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -4,7 +4,6 @@ import { TableCapacityConfig } from './stacks/cron-stack';
 
 export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
   fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 70, writeCapacity: 250 },
-  fadeRate: { billingMode: BillingMode.PROVISIONED, readCapacity: 50, writeCapacity: 5 },
   synthSwitch: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 5 },
   timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 100, writeCapacity: 10 },
 };

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -364,25 +364,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     unimindResponseBucket.grantReadWrite(firehoseRole);
     unimindParameterUpdateBucket.grantReadWrite(firehoseRole);
 
-    const botOrderEventsProcessorLambda = new aws_lambda_nodejs.NodejsFunction(this, 'BotOrderEventsProcessor', {
-      runtime: aws_lambda.Runtime.NODEJS_20_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
-      handler: 'botOrderEventsProcessor',
-      timeout: cdk.Duration.seconds(60), // AWS suggests 1 min or higher
-      memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
-      environment: {
-        VERSION: '2',
-        NODE_OPTIONS: '--enable-source-maps',
-        ANALYTICS_STREAM_ARN: analyticsStreamArn,
-        ...props.envVars,
-        stage,
-      },
-    });
-
     const quoteProcessorLambda = new aws_lambda_nodejs.NodejsFunction(this, 'QuoteRequestProcessor', {
       runtime: aws_lambda.Runtime.NODEJS_20_X,
       entry: path.join(__dirname, '../../lib/handlers/index.ts'),
@@ -490,7 +471,6 @@ export class AnalyticsStack extends cdk.NestedStack {
           quoteProcessorLambda.functionArn,
           fillEventProcessorLambda.functionArn,
           postOrderProcessorLambda.functionArn,
-          botOrderEventsProcessorLambda.functionArn,
           unimindResponseProcessorLambda.functionArn,
           unimindParameterUpdateProcessorLambda.functionArn,
         ],
@@ -506,7 +486,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       quoteProcessorLambda,
       fillEventProcessorLambda,
       postOrderProcessorLambda,
-      botOrderEventsProcessorLambda,
       unimindResponseProcessorLambda,
       unimindParameterUpdateProcessorLambda,
     ].forEach((lambda) => {

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -12,7 +12,7 @@ import { Construct } from 'constructs';
 import * as path from 'path';
 
 import { ITopic } from 'aws-cdk-lib/aws-sns';
-import { DYNAMO_TABLE_KEY, DYNAMO_TABLE_NAME, FADE_RATE_BUCKET } from '../../lib/constants';
+import { DYNAMO_TABLE_NAME, FADE_RATE_BUCKET } from '../../lib/constants';
 import { PARTITION_KEY } from '../../lib/repositories/switch-repository';
 import { STAGE } from '../../lib/util/stage';
 import { PROD_TABLE_CAPACITY } from '../config';
@@ -29,7 +29,6 @@ type TableCapacityOptions = {
 
 export type TableCapacityConfig = {
   fillerAddress: TableCapacityOptions;
-  fadeRate: TableCapacityOptions;
   synthSwitch: TableCapacityOptions;
   timestamps: TableCapacityOptions;
 };
@@ -108,20 +107,6 @@ export class CronStack extends cdk.NestedStack {
         schedule: aws_events.Schedule.rate(Duration.minutes(10)),
         targets: [new aws_events_targets.LambdaFunction(this.fadeRateV2CronLambda)],
       });
-
-      /* RFQ fade rate table */
-      const fadesTable = new aws_dynamo.Table(this, `${SERVICE_NAME}FadesTable`, {
-        tableName: DYNAMO_TABLE_NAME.FADES,
-        partitionKey: {
-          name: DYNAMO_TABLE_KEY.FILLER,
-          type: aws_dynamo.AttributeType.STRING,
-        },
-        deletionProtection: true,
-        pointInTimeRecovery: true,
-        contributorInsightsEnabled: true,
-        ...PROD_TABLE_CAPACITY.fadeRate,
-      });
-      this.alarmsPerTable(fadesTable, DYNAMO_TABLE_NAME.FADES, chatbotTopic);
     }
 
     this.synthSwitchCronLambda = new aws_lambda_nodejs.NodejsFunction(this, `${SERVICE_NAME}SynthSwitch`, {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -11,7 +11,6 @@ export const PROD_COMPLIANCE_S3_KEY = 'production.json';
 export const BETA_COMPLIANCE_S3_KEY = 'beta.json';
 
 export const DYNAMO_TABLE_NAME = {
-  FADES: 'Fades',
   SYNTHETIC_SWITCH_TABLE: 'SyntheticSwitchTable',
   FILLER_ADDRESS: 'FillerAddress',
   FILLER_CB_TIMESTAMPS: 'FillerCBTimestamps',
@@ -22,7 +21,6 @@ export const DYNAMO_TABLE_NAME = {
 };
 
 export const DYNAMO_TABLE_KEY = {
-  FILLER: 'filler',
   TOKEN_IN: 'tokenIn',
   TOKEN_IN_CHAIN_ID: 'tokenInChainId',
   TOKEN_OUT: 'tokenOut',

--- a/lib/handlers/blueprints/cw-log-firehose-processor.js
+++ b/lib/handlers/blueprints/cw-log-firehose-processor.js
@@ -224,7 +224,6 @@ const handler = async function (event, context, transformFn) {
   return { records: records };
 };
 
-export const botOrderEventsProcessor = async (event, context) => handler(event, context, transformLogEvent);
 export const quoteProcessor = async (event, context) => handler(event, context, transformLogEvent);
 export const fillEventProcessor = async (event, context) => handler(event, context, transformFillLogEvent);
 export const postOrderProcessor = async (event, context) => handler(event, context, transformPostOrderLogEvent);

--- a/lib/handlers/index.ts
+++ b/lib/handlers/index.ts
@@ -1,5 +1,4 @@
 import {
-  botOrderEventsProcessor,
   fillEventProcessor,
   postOrderProcessor,
   quoteProcessor,
@@ -11,7 +10,6 @@ module.exports = {
   fillEventProcessor: fillEventProcessor,
   postOrderProcessor: postOrderProcessor,
   quoteProcessor: quoteProcessor,
-  botOrderEventsProcessor: botOrderEventsProcessor,
   unimindResponseProcessor: unimindResponseProcessor,
   unimindParameterUpdateProcessor: unimindParameterUpdateProcessor,
 };


### PR DESCRIPTION
Despite the name, `Fades` is not the fade-rate system
Live fade detection still runs `lib/cron/fade-rate-v2.ts` → Redshift → `FillerCBTimestampsV2`. The `Fades` DynamoDB table lost its last writer on 2023-09-18 (`a8e2fe6` "write to s3 instead", which moved v1 fade rates to the `fade-rate-config` S3 bucket); the v1 cron itself was deleted in 2024-07-31 (`95c9452`). Only the orphaned CDK resource remained. Verified in prod: **0 items, 0 bytes, 0 writes in 90 days**, and nothing in the repo reads or writes it. It already carries `DeletionPolicy: Retain`, so this deploy **orphans** the table and can be dropped manually.

`FillerCBTimestamps` (v1 circuit-breaker state) is deliberately **kept**: the V2 cutover was only 14 days ago (v1's last write and V2's first write are both 2026-07-15), so its 38 rows stay available as rollback state.

**Removed**
- `BotOrderEventsProcessor` lambda — **0 invocations in 90d** (control `QuoteRequestProcessor`: 460k) — plus its IAM role, 2 alarms, firehose invoke grant, and handler export.
- `Fades` table + its 6 alarms, and the constants it orphaned (`DYNAMO_TABLE_NAME.FADES`, `DYNAMO_TABLE_KEY.FILLER`, `PROD_TABLE_CAPACITY.fadeRate`).
- Bot S3 buckets **kept** — frozen, but still read by `dsRole`.

**Verified**: synth diff 1099 → 1066 resources, every delta accounted for (Function −3, Role −3, Table −3, Alarm −24, ×3 stack instances); table count 15→12 confirms v1 `FillerCBTimestamps` survived. Build/lint/tests green. Note `lib/constants.ts` changing rotates the quote/hard-quote/switch Lambda versions (alias repoint, zero downtime).