### PR TITLE
test: unskip and fix hard quote tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,27 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
-    "@typescript-eslint/ban-ts-comment": "off"
+    "@typescript-eslint/ban-ts-comment": "off",
+    // An it.only sat in test/handlers/hard-quote/handler.test.ts from March 2024 to July 2026
+    // and silenced 22 tests. CI stayed green, so a later intentional behavior change
+    // (the requestId derivation) broke those tests with nobody noticing. These three
+    // selectors catch the whole class. no jest plugin needed -- jest itself has no config
+    // option that fails a run containing focused tests, and jest/no-nested-tests
+    // does not exist.
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.object.name=/^(it|test|describe)$/][callee.property.name='only']",
+        "message": "Focused test (.only) silently skips every sibling test. Remove it before committing."
+      },
+      {
+        "selector": "CallExpression[callee.name=/^(fit|fdescribe)$/]",
+        "message": "Focused test (fit/fdescribe) silently skips every sibling test. Use it()/describe() instead."
+      },
+      {
+        "selector": "CallExpression[callee.name=/^(it|test)$/] CallExpression[callee.name=/^(it|test|describe)$/]",
+        "message": "A test block nested inside an it()/test() callback never registers as a test. Move it out to the enclosing describe()."
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,12 +31,12 @@
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/ban-ts-comment": "off",
-    // An it.only sat in test/handlers/hard-quote/handler.test.ts from March 2024 to July 2026
-    // and silenced 22 tests. CI stayed green, so a later intentional behavior change
-    // (the requestId derivation) broke those tests with nobody noticing. These three
-    // selectors catch the whole class. no jest plugin needed -- jest itself has no config
-    // option that fails a run containing focused tests, and jest/no-nested-tests
-    // does not exist.
+    // Two ways a test can silently stop running while CI still reports green: a focused test
+    // (.only/fit/fdescribe) skips all its siblings, and a test block nested inside an it()
+    // callback never registers at all. Both are lint-only problems -- jest has no config
+    // option that fails a run containing focused tests, and eslint-plugin-jest has no
+    // equivalent of the third selector, so core no-restricted-syntax covers both without
+    // adding a dependency.
     "no-restricted-syntax": [
       "error",
       {

--- a/test/entities/HardQuoteRequest.test.ts
+++ b/test/entities/HardQuoteRequest.test.ts
@@ -12,9 +12,10 @@ const RAW_AMOUNT = BigNumber.from('1000000');
 // held regardless of whether requestId carried the caller's id or the quoteId.
 const REQUEST_ID = 'b45c2d1e-7f30-4a92-8c65-1d8e4f2a9b03';
 const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
-// HardQuoteRequest's constructor derives `requestId: _data.quoteId ?? uuidv4()` (e542951 /
-// PR #317), so every JSON view below reports the indicative QUOTE_ID as the requestId -- the
-// caller's REQUEST_ID is discarded. Named rather than inlined so the substitution is visible.
+// HardQuoteRequest's constructor derives `requestId: _data.quoteId ?? uuidv4()`, so every JSON
+// view below reports the indicative QUOTE_ID as the requestId -- the caller's REQUEST_ID is
+// discarded. This is deliberate: `hardrequests` has no quoteId column, so requestId is how the
+// indicative quoteId reaches Redshift. Named rather than inlined so the substitution is visible.
 const DERIVED_REQUEST_ID = QUOTE_ID;
 const SWAPPER = '0x0000000000000000000000000000000000000000';
 const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
@@ -238,7 +239,7 @@ describe('QuoteRequest', () => {
   });
 
   // The quoteId-absent branch falls back to a fresh uuidv4(). Characterization test: this
-  // documents current behavior, it does not endorse it. See the requestId-contract follow-up.
+  // documents current behavior, it does not endorse it.
   it('with no quoteId, generates a requestId that is not the client requestId', () => {
     const order = new UnsignedV2DutchOrder(getOrderInfo({ swapper: SWAPPER }), CHAIN_ID);
     const request = makeRequest({ encodedInnerOrder: order.serialize(), innerSig: '0x', quoteId: undefined });

--- a/test/entities/HardQuoteRequest.test.ts
+++ b/test/entities/HardQuoteRequest.test.ts
@@ -1,53 +1,25 @@
 import { TradeType } from '@uniswap/sdk-core';
-import {
-  OrderType,
-  UnsignedV2DutchOrder,
-  UnsignedV2DutchOrderInfo,
-  UnsignedV3DutchOrder,
-  V3DutchOrderBuilder,
-} from '@uniswap/uniswapx-sdk';
+import { OrderType, UnsignedV2DutchOrder, UnsignedV3DutchOrder, V3DutchOrderBuilder } from '@uniswap/uniswapx-sdk';
 import { BigNumber, ethers } from 'ethers';
 
 import { HardQuoteRequest } from '../../lib/entities';
 import { HardQuoteRequestBody } from '../../lib/handlers/hard-quote';
 import { ProtocolVersion } from '../../lib/providers';
+import { getOrderInfo } from '../fixtures/hard-quote';
 
-const NOW = Math.floor(new Date().getTime() / 1000);
 const RAW_AMOUNT = BigNumber.from('1000000');
-const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
+// Deliberately DIFFERENT uuids. These were identical, so every toCleanJSON assertion below
+// held regardless of whether requestId carried the caller's id or the quoteId.
+const REQUEST_ID = 'b45c2d1e-7f30-4a92-8c65-1d8e4f2a9b03';
 const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
+// HardQuoteRequest's constructor derives `requestId: _data.quoteId ?? uuidv4()` (e542951 /
+// PR #317), so every JSON view below reports the indicative QUOTE_ID as the requestId -- the
+// caller's REQUEST_ID is discarded. Named rather than inlined so the substitution is visible.
+const DERIVED_REQUEST_ID = QUOTE_ID;
 const SWAPPER = '0x0000000000000000000000000000000000000000';
 const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
 const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const CHAIN_ID = 1;
-
-export const getOrderInfo = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV2DutchOrderInfo => {
-  return Object.assign(
-    {
-      deadline: NOW + 1000,
-      reactor: ethers.constants.AddressZero,
-      swapper: ethers.constants.AddressZero,
-      nonce: BigNumber.from(10),
-      additionalValidationContract: ethers.constants.AddressZero,
-      additionalValidationData: '0x',
-      cosigner: ethers.constants.AddressZero,
-      input: {
-        token: TOKEN_IN,
-        startAmount: RAW_AMOUNT,
-        endAmount: RAW_AMOUNT,
-      },
-      outputs: [
-        {
-          token: TOKEN_OUT,
-          startAmount: RAW_AMOUNT.mul(2),
-          endAmount: RAW_AMOUNT.mul(90).div(100),
-          recipient: ethers.constants.AddressZero,
-        },
-      ],
-    },
-    data
-  );
-};
 
 const makeRequest = (
   data: Partial<HardQuoteRequestBody>,
@@ -136,7 +108,7 @@ describe('QuoteRequest', () => {
     expect(request.toCleanJSON()).toEqual({
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
-      requestId: REQUEST_ID,
+      requestId: DERIVED_REQUEST_ID,
       quoteId: QUOTE_ID,
       tokenIn: TOKEN_IN,
       tokenOut: TOKEN_OUT,
@@ -159,7 +131,7 @@ describe('QuoteRequest', () => {
     expect(request.toOpposingCleanJSON()).toEqual({
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
-      requestId: REQUEST_ID,
+      requestId: DERIVED_REQUEST_ID,
       quoteId: QUOTE_ID,
       tokenIn: TOKEN_OUT,
       tokenOut: TOKEN_IN,
@@ -202,7 +174,7 @@ describe('QuoteRequest', () => {
     expect(request.toCleanJSON()).toEqual({
       tokenInChainId: V3_CHAIN_ID,
       tokenOutChainId: V3_CHAIN_ID,
-      requestId: REQUEST_ID,
+      requestId: DERIVED_REQUEST_ID,
       quoteId: QUOTE_ID,
       tokenIn: TOKEN_IN,
       tokenOut: TOKEN_OUT,
@@ -224,7 +196,7 @@ describe('QuoteRequest', () => {
     expect(request.toOpposingCleanJSON()).toEqual({
       tokenInChainId: V3_CHAIN_ID,
       tokenOutChainId: V3_CHAIN_ID,
-      requestId: REQUEST_ID,
+      requestId: DERIVED_REQUEST_ID,
       quoteId: QUOTE_ID,
       tokenIn: TOKEN_OUT,
       tokenOut: TOKEN_IN,
@@ -254,5 +226,24 @@ describe('QuoteRequest', () => {
     });
     expect(request.tokenInChainId).toEqual(CHAIN_ID);
     expect(request.tokenOutChainId).toEqual(42161);
+  });
+
+  // Pins the requestId derivation directly, so the four toCleanJSON expectations above are not
+  // the only thing standing between this contract and a silent change.
+  it('derives requestId from quoteId, discarding the client requestId', () => {
+    const order = new UnsignedV2DutchOrder(getOrderInfo({ swapper: SWAPPER }), CHAIN_ID);
+    const request = makeRequest({ encodedInnerOrder: order.serialize(), innerSig: '0x' });
+    expect(request.requestId).toEqual(QUOTE_ID);
+    expect(request.requestId).not.toEqual(REQUEST_ID);
+  });
+
+  // The quoteId-absent branch falls back to a fresh uuidv4(). Characterization test: this
+  // documents current behavior, it does not endorse it. See the requestId-contract follow-up.
+  it('with no quoteId, generates a requestId that is not the client requestId', () => {
+    const order = new UnsignedV2DutchOrder(getOrderInfo({ swapper: SWAPPER }), CHAIN_ID);
+    const request = makeRequest({ encodedInnerOrder: order.serialize(), innerSig: '0x', quoteId: undefined });
+    expect(request.quoteId).toBeUndefined();
+    expect(request.requestId).toEqual(expect.any(String));
+    expect(request.requestId).not.toEqual(REQUEST_ID);
   });
 });

--- a/test/entities/HardQuoteResponse.test.ts
+++ b/test/entities/HardQuoteResponse.test.ts
@@ -11,7 +11,7 @@ import { parseEther } from 'ethers/lib/utils';
 import { HardQuoteRequest } from '../../lib/entities';
 import { V2HardQuoteResponse } from '../../lib/entities/V2HardQuoteResponse';
 import { HardQuoteRequestBody } from '../../lib/handlers/hard-quote';
-import { getOrder } from '../handlers/hard-quote/handler.test';
+import { getOrder } from '../fixtures/hard-quote';
 
 const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
 const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f7';
@@ -21,6 +21,11 @@ const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
 const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const CHAIN_ID = 1;
 const fixedTime = 4206969;
+// Only Date.now() is mocked. The `getOrder` fixture reads the clock via `new Date().getTime()`,
+// which ignores this spy, so the order deadline stays a real future timestamp. Do NOT add
+// `resetMocks`/`restoreMocks` to jest.config.js without revisiting: mockReset() drops the
+// implementation, Date.now() would return undefined, and every `now + 100` below becomes NaN.
+// `jest.clearAllMocks()` in afterEach is safe -- mockClear() keeps the implementation.
 jest.spyOn(Date, 'now').mockImplementation(() => fixedTime);
 
 const DEFAULT_EXCLUSIVITY_OVERRIDE_BPS = ethers.BigNumber.from(100);
@@ -33,11 +38,16 @@ describe('HardQuoteResponse', () => {
     jest.clearAllMocks();
   });
 
-  const getRequest = async (order: UnsignedV2DutchOrder): Promise<HardQuoteRequestBody> => {
+  const getRequest = async (
+    order: UnsignedV2DutchOrder,
+    // `null` omits quoteId from the body. An explicit `undefined` would re-trigger the default.
+    quoteId: string | null = QUOTE_ID
+  ): Promise<HardQuoteRequestBody> => {
     const { types, domain, values } = order.permitData();
     const sig = await swapperWallet._signTypedData(domain, types, values);
     return {
       requestId: REQUEST_ID,
+      ...(quoteId !== null && { quoteId }),
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
       encodedInnerOrder: order.serialize(),
@@ -45,32 +55,46 @@ describe('HardQuoteResponse', () => {
     };
   };
 
-  const getResponse = async (data: Partial<UnsignedV2DutchOrderInfo>, cosignerData: CosignerData) => {
-    const unsigned = getOrder(data);
+  const getResponse = async (
+    data: Partial<UnsignedV2DutchOrderInfo>,
+    cosignerData: CosignerData,
+    quoteId: string | null = QUOTE_ID
+  ) => {
+    // getOrder defaults swapper to AddressZero -- which is also the default for reactor,
+    // cosigner, additionalValidationContract and outputs[0].recipient, so an
+    // `swapper: AddressZero` assertion could not tell `swapper` apart from any of them.
+    // Overriding makes the swapper assertions load-bearing. (innerSig is still signed by
+    // swapperWallet; nothing under test recovers or validates the permit signer.)
+    const unsigned = getOrder({ swapper: SWAPPER, ...data });
     const cosignature = cosignerWallet._signingKey().signDigest(unsigned.cosignatureHash(cosignerData));
     const order = CosignedV2DutchOrder.fromUnsignedOrder(
       unsigned,
       cosignerData,
       ethers.utils.joinSignature(cosignature)
     );
-    return new V2HardQuoteResponse(new HardQuoteRequest(await getRequest(unsigned), OrderType.Dutch_V2), order);
+    return new V2HardQuoteResponse(
+      new HardQuoteRequest(await getRequest(unsigned, quoteId), OrderType.Dutch_V2),
+      order
+    );
   };
+
+  const makeCosignerData = (now: number, overrides: Partial<CosignerData> = {}): CosignerData => ({
+    decayStartTime: now + 100,
+    decayEndTime: now + 200,
+    exclusiveFiller: FILLER,
+    exclusivityOverrideBps: DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
+    inputOverride: parseEther('1'),
+    outputOverrides: [parseEther('1')],
+    ...overrides,
+  });
 
   it('toResponseJSON', async () => {
     const now = Math.floor(Date.now() / 1000);
-    const quoteResponse = await getResponse(
-      {},
-      {
-        decayStartTime: now + 100,
-        decayEndTime: now + 200,
-        exclusiveFiller: FILLER,
-        exclusivityOverrideBps: DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
-        inputOverride: parseEther('1'),
-        outputOverrides: [parseEther('1')],
-      }
-    );
+    const quoteResponse = await getResponse({}, makeCosignerData(now));
     expect(quoteResponse.toResponseJSON()).toEqual({
-      requestId: REQUEST_ID,
+      // HardQuoteRequest's constructor does `requestId: _data.quoteId ?? uuidv4()`, so the
+      // echoed requestId is the indicative quoteId; the client's REQUEST_ID is discarded.
+      requestId: QUOTE_ID,
       quoteId: QUOTE_ID,
       chainId: CHAIN_ID,
       filler: FILLER,
@@ -79,79 +103,77 @@ describe('HardQuoteResponse', () => {
     });
   });
 
+  it('requestId is the indicative quoteId, not the client-supplied requestId', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const quoteResponse = await getResponse({}, makeCosignerData(now));
+    expect(quoteResponse.requestId).toEqual(QUOTE_ID);
+    expect(quoteResponse.requestId).not.toEqual(REQUEST_ID);
+  });
+
   it('toLog', async () => {
     const now = Math.floor(Date.now() / 1000);
-    const quoteResponse = await getResponse(
-      {},
-      {
-        decayStartTime: now + 100,
-        decayEndTime: now + 200,
-        exclusiveFiller: FILLER,
-        exclusivityOverrideBps: DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
-        inputOverride: ethers.utils.parseEther('1'),
-        outputOverrides: [ethers.utils.parseEther('1')],
-      }
-    );
+    const quoteResponse = await getResponse({}, makeCosignerData(now));
     expect(quoteResponse.toLog()).toEqual({
-      createdAt: expect.any(String),
-      createdAtMs: expect.any(String),
+      createdAt: Math.floor(fixedTime / 1000).toString(),
+      createdAtMs: fixedTime.toString(),
       amountOut: parseEther('1').toString(),
       amountIn: parseEther('1').toString(),
       quoteId: QUOTE_ID,
-      requestId: REQUEST_ID,
+      requestId: QUOTE_ID,
       swapper: SWAPPER,
       tokenIn: TOKEN_IN,
       tokenOut: TOKEN_OUT,
       filler: FILLER,
+      orderHash: quoteResponse.order.hash(),
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
     });
+  });
 
-    it('amountOut uses post cosigned resolution', async () => {
-      const now = Math.floor(Date.now() / 1000);
-      const quoteResponse = await getResponse(
-        {},
-        {
-          decayStartTime: now + 100,
-          decayEndTime: now + 200,
-          exclusiveFiller: FILLER,
-          exclusivityOverrideBps: DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
-          inputOverride: parseEther('1'),
-          outputOverrides: [parseEther('2')],
-        }
-      );
-      expect(quoteResponse.amountOut).toEqual(parseEther('2'));
-    });
+  it('amountOut uses post cosigned resolution', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const quoteResponse = await getResponse(
+      {},
+      makeCosignerData(now, { inputOverride: parseEther('1'), outputOverrides: [parseEther('2')] })
+    );
+    expect(quoteResponse.amountOut).toEqual(parseEther('2'));
+  });
 
-    it('amountIn uses post cosigned resolution', async () => {
-      const now = Math.floor(Date.now() / 1000);
-      const quoteResponse = await getResponse(
-        {
-          cosigner: cosignerWallet.address,
-          input: {
-            token: TOKEN_IN,
-            startAmount: parseEther('1'),
-            endAmount: parseEther('1.1'),
-          },
-          outputs: [
-            {
-              token: TOKEN_OUT,
-              startAmount: parseEther('1'),
-              endAmount: parseEther('1'),
-              recipient: ethers.constants.AddressZero,
-            },
-          ],
+  it('amountIn uses post cosigned resolution', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const quoteResponse = await getResponse(
+      {
+        cosigner: cosignerWallet.address,
+        input: {
+          token: TOKEN_IN,
+          startAmount: parseEther('1'),
+          endAmount: parseEther('1.1'),
         },
-        {
-          decayStartTime: now + 100,
-          decayEndTime: now + 200,
-          exclusiveFiller: FILLER,
-          exclusivityOverrideBps: DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
-          inputOverride: parseEther('0.8'),
-          outputOverrides: [parseEther('1')],
-        }
-      );
-      expect(quoteResponse.amountIn).toEqual(parseEther('0.8'));
-    });
+        outputs: [
+          {
+            token: TOKEN_OUT,
+            startAmount: parseEther('1'),
+            endAmount: parseEther('1'),
+            recipient: ethers.constants.AddressZero,
+          },
+        ],
+      },
+      makeCosignerData(now, { inputOverride: parseEther('0.8'), outputOverrides: [parseEther('1')] })
+    );
+    expect(quoteResponse.amountIn).toEqual(parseEther('0.8'));
+  });
+
+  // Characterization test for a known wart, NOT an endorsement: toResponseJSON reads the raw
+  // `request.quoteId` while the `quoteId` getter used by toLog falls back to a fresh uuidv4()
+  // on every access. With no quoteId on the request the two disagree, and toLog is not even
+  // self-consistent between calls, so hardresponses.quoteid cannot be joined to
+  // postedorders.quoteid for open orders. Delete this test when the getter is memoized.
+  it('with no request quoteId, toResponseJSON omits quoteId while toLog fabricates a new one', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const quoteResponse = await getResponse({}, makeCosignerData(now), null);
+
+    expect(quoteResponse.toResponseJSON().quoteId).toBeUndefined();
+    expect(quoteResponse.toLog().quoteId).toEqual(expect.any(String));
+    expect(quoteResponse.toLog().quoteId).not.toEqual(quoteResponse.toLog().quoteId);
   });
 });

--- a/test/fixtures/hard-quote.ts
+++ b/test/fixtures/hard-quote.ts
@@ -1,13 +1,12 @@
 // Shared V2 hard-quote order fixtures.
 //
-// WHY THIS FILE EXISTS: `getOrder` used to be exported from
-// test/handlers/hard-quote/handler.test.ts and `getOrderInfo` from
-// test/entities/HardQuoteRequest.test.ts, and imported across suites. Importing a *.test.ts
-// module runs its body inside the importer's jest context, so the imported file's
-// describe/it blocks re-register in the importer's suite. Two consequences:
+// WHY THIS FILE EXISTS: these builders were previously exported from the suites that used them
+// and imported across test files. Importing a *.test.ts module runs its body inside the
+// importer's jest context, so the imported file's describe/it blocks re-register in the
+// importer's suite. Two consequences:
 //   1. the imported suite executes twice (once on its own, once inside the importer), and
-//   2. a single `it.only` anywhere in either file silences BOTH files.
-// (2) is what hid 22 tests from March 2024 to July 2026. Never import from a *.test.ts file.
+//   2. a single `it.only` in either file silences BOTH files, with no warning.
+// Never import from a *.test.ts file -- put anything shared here instead.
 //
 // This module deliberately has no `.test.ts` suffix and is not under a `__tests__/`
 // directory, so jest's default testMatch does not collect it as a suite.

--- a/test/fixtures/hard-quote.ts
+++ b/test/fixtures/hard-quote.ts
@@ -1,0 +1,113 @@
+// Shared V2 hard-quote order fixtures.
+//
+// WHY THIS FILE EXISTS: `getOrder` used to be exported from
+// test/handlers/hard-quote/handler.test.ts and `getOrderInfo` from
+// test/entities/HardQuoteRequest.test.ts, and imported across suites. Importing a *.test.ts
+// module runs its body inside the importer's jest context, so the imported file's
+// describe/it blocks re-register in the importer's suite. Two consequences:
+//   1. the imported suite executes twice (once on its own, once inside the importer), and
+//   2. a single `it.only` anywhere in either file silences BOTH files.
+// (2) is what hid 22 tests from March 2024 to July 2026. Never import from a *.test.ts file.
+//
+// This module deliberately has no `.test.ts` suffix and is not under a `__tests__/`
+// directory, so jest's default testMatch does not collect it as a suite.
+//
+// TIMESTAMPS: both builders read the clock at CALL time via `new Date().getTime()`, which is
+// deliberately NOT `Date.now()`. test/entities/HardQuoteResponse.test.ts installs
+// `jest.spyOn(Date, 'now')` at module scope; `new Date()` ignores that spy, so the order
+// deadline stays a real future timestamp instead of collapsing to ~1970 and tripping the
+// handler's deadline validation. Do not switch to `Date.now()`, and do not hoist the
+// computation to a module-level const (module bodies of imported modules run before the
+// importer's `jest.spyOn` line, so a hoisted const would silently depend on import order).
+
+import { UnsignedV2DutchOrder, UnsignedV2DutchOrderInfo } from '@uniswap/uniswapx-sdk';
+import { BigNumber, ethers } from 'ethers';
+
+/** UNI. Same value in every hard-quote suite. */
+export const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
+/** WETH. Same value in every hard-quote suite. */
+export const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+/** Mainnet. `getOrder` bakes this in; `getOrderInfo` leaves the chain id to its caller. */
+export const CHAIN_ID = 1;
+
+/** Amount baked into `getOrder`. 1e18 == parseEther('1'). */
+export const GET_ORDER_RAW_AMOUNT = BigNumber.from('1000000000000000000');
+
+/**
+ * Amount baked into `getOrderInfo`. 1e6, NOT 1e18 — the two builders intentionally use
+ * different scales, so they cannot share one RAW_AMOUNT constant.
+ */
+export const GET_ORDER_INFO_RAW_AMOUNT = BigNumber.from('1000000');
+
+/**
+ * A signable, un-cosigned V2 Dutch order on mainnet. Input start == input end, so
+ * HardQuoteRequest.type resolves to EXACT_INPUT unless the caller overrides `input`.
+ * Default swapper/cosigner are AddressZero.
+ */
+export const getOrder = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV2DutchOrder => {
+  const now = Math.floor(new Date().getTime() / 1000);
+  return new UnsignedV2DutchOrder(
+    Object.assign(
+      {
+        deadline: now + 1000,
+        reactor: ethers.constants.AddressZero,
+        swapper: ethers.constants.AddressZero,
+        nonce: BigNumber.from(10),
+        additionalValidationContract: ethers.constants.AddressZero,
+        additionalValidationData: '0x',
+        cosigner: ethers.constants.AddressZero,
+        cosignerData: undefined,
+        input: {
+          token: TOKEN_IN,
+          startAmount: GET_ORDER_RAW_AMOUNT,
+          endAmount: GET_ORDER_RAW_AMOUNT,
+        },
+        outputs: [
+          {
+            token: TOKEN_OUT,
+            startAmount: GET_ORDER_RAW_AMOUNT,
+            endAmount: GET_ORDER_RAW_AMOUNT.mul(90).div(100),
+            recipient: ethers.constants.AddressZero,
+          },
+        ],
+        cosignature: undefined,
+      },
+      data
+    ),
+    CHAIN_ID
+  );
+};
+
+/**
+ * The raw order-info struct only — the caller supplies the chain id to
+ * `new UnsignedV2DutchOrder(info, chainId)`. Note the output startAmount is 2x the input,
+ * unlike `getOrder`, and the amount scale is 1e6.
+ */
+export const getOrderInfo = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV2DutchOrderInfo => {
+  const now = Math.floor(new Date().getTime() / 1000);
+  return Object.assign(
+    {
+      deadline: now + 1000,
+      reactor: ethers.constants.AddressZero,
+      swapper: ethers.constants.AddressZero,
+      nonce: BigNumber.from(10),
+      additionalValidationContract: ethers.constants.AddressZero,
+      additionalValidationData: '0x',
+      cosigner: ethers.constants.AddressZero,
+      input: {
+        token: TOKEN_IN,
+        startAmount: GET_ORDER_INFO_RAW_AMOUNT,
+        endAmount: GET_ORDER_INFO_RAW_AMOUNT,
+      },
+      outputs: [
+        {
+          token: TOKEN_OUT,
+          startAmount: GET_ORDER_INFO_RAW_AMOUNT.mul(2),
+          endAmount: GET_ORDER_INFO_RAW_AMOUNT.mul(90).div(100),
+          recipient: ethers.constants.AddressZero,
+        },
+      ],
+    },
+    data
+  );
+};

--- a/test/handlers/hard-quote/handler.test.ts
+++ b/test/handlers/hard-quote/handler.test.ts
@@ -238,12 +238,12 @@ describe('Quote handler', () => {
     });
   });
 
-  // Pins the requestId contract introduced by e542951 (PR #317): HardQuoteRequest's
-  // constructor sets `requestId: _data.quoteId ?? uuidv4()`, so the response echoes the
-  // indicative quoteId and the client-supplied requestId is discarded. This is deliberate --
-  // `hardrequests` has no quoteId column, so requestId is how the indicative quoteId reaches
-  // Redshift. The `.not.toEqual` is the load-bearing line: it fails if the derivation is
-  // removed without updating this test.
+  // Pins the requestId contract: HardQuoteRequest's constructor sets
+  // `requestId: _data.quoteId ?? uuidv4()`, so the response echoes the indicative quoteId and
+  // the client-supplied requestId is discarded. This is deliberate -- `hardrequests` has no
+  // quoteId column, so requestId is how the indicative quoteId reaches Redshift. The
+  // `.not.toEqual` is the load-bearing line: it fails if the derivation is removed without
+  // updating this test.
   it('echoes the indicative quoteId as requestId, discarding the client requestId', async () => {
     const quoters = [new MockQuoter(logger, 1, 1)];
     const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
@@ -264,7 +264,6 @@ describe('Quote handler', () => {
   // quoteId is optional in HardQuoteRequestBodyJoi, and on that branch the derivation falls
   // back to a fresh uuidv4(). The caller therefore gets back a requestId it has never seen.
   // Characterization test: this documents current behavior, it does not endorse it.
-  // See the follow-up ticket on the requestId contract.
   it('with no quoteId, returns a generated requestId that is neither id the caller sent', async () => {
     const quoters = [new MockQuoter(logger, 1, 1)];
     const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }), null);

--- a/test/handlers/hard-quote/handler.test.ts
+++ b/test/handlers/hard-quote/handler.test.ts
@@ -1,12 +1,6 @@
 import { KMSClient } from '@aws-sdk/client-kms';
 import { TradeType } from '@uniswap/sdk-core';
-import {
-  CosignedV2DutchOrder,
-  CosignerData,
-  OrderType,
-  UnsignedV2DutchOrder,
-  UnsignedV2DutchOrderInfo,
-} from '@uniswap/uniswapx-sdk';
+import { CosignedV2DutchOrder, CosignerData, OrderType, UnsignedV2DutchOrder } from '@uniswap/uniswapx-sdk';
 import { createMetricsLogger } from 'aws-embedded-metrics';
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 // import axios from 'axios';
@@ -27,13 +21,16 @@ import {
 import { getCosignerData } from '../../../lib/handlers/hard-quote/handler';
 import { MockOrderServiceProvider } from '../../../lib/providers';
 import { MockQuoter, MOCK_FILLER_ADDRESS, Quoter } from '../../../lib/quoters';
+import { getOrder } from '../../fixtures/hard-quote';
 
 jest.mock('axios');
 jest.mock('@aws-sdk/client-kms');
 jest.mock('@uniswap/signer');
 
 const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
-const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
+// Deliberately DIFFERENT from QUOTE_ID. These were the same uuid, which made every
+// requestId assertion below hold no matter which of the two ids the handler echoed.
+const REQUEST_ID = 'b45c2d1e-7f30-4a92-8c65-1d8e4f2a9b03';
 const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
 const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const RAW_AMOUNT = BigNumber.from('1000000000000000000');
@@ -45,40 +42,6 @@ logger.level(Logger.FATAL);
 
 process.env.KMS_KEY_ID = 'test-key-id';
 process.env.REGION = 'us-east-2';
-
-export const getOrder = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV2DutchOrder => {
-  const now = Math.floor(new Date().getTime() / 1000);
-  return new UnsignedV2DutchOrder(
-    Object.assign(
-      {
-        deadline: now + 1000,
-        reactor: ethers.constants.AddressZero,
-        swapper: ethers.constants.AddressZero,
-        nonce: BigNumber.from(10),
-        additionalValidationContract: ethers.constants.AddressZero,
-        additionalValidationData: '0x',
-        cosigner: ethers.constants.AddressZero,
-        cosignerData: undefined,
-        input: {
-          token: TOKEN_IN,
-          startAmount: RAW_AMOUNT,
-          endAmount: RAW_AMOUNT,
-        },
-        outputs: [
-          {
-            token: TOKEN_OUT,
-            startAmount: RAW_AMOUNT,
-            endAmount: RAW_AMOUNT.mul(90).div(100),
-            recipient: ethers.constants.AddressZero,
-          },
-        ],
-        cosignature: undefined,
-      },
-      data
-    ),
-    CHAIN_ID
-  );
-};
 
 describe('Quote handler', () => {
   const swapperWallet = Wallet.createRandom();
@@ -129,11 +92,17 @@ describe('Quote handler', () => {
       body: JSON.stringify(request),
     } as APIGatewayProxyEvent);
 
-  const getRequest = async (order: UnsignedV2DutchOrder): Promise<HardQuoteRequestBody> => {
+  const getRequest = async (
+    order: UnsignedV2DutchOrder,
+    // `null` omits quoteId from the body. An explicit `undefined` would re-trigger the
+    // default, silently testing the quoteId-present path instead.
+    quoteId: string | null = QUOTE_ID
+  ): Promise<HardQuoteRequestBody> => {
     const { types, domain, values } = order.permitData();
     const sig = await swapperWallet._signTypedData(domain, types, values);
     return {
       requestId: REQUEST_ID,
+      ...(quoteId !== null && { quoteId }),
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
       encodedInnerOrder: order.serialize(),
@@ -155,7 +124,7 @@ describe('Quote handler', () => {
     );
     const quoteResponse: HardQuoteResponseData = JSON.parse(response.body); // random quoteId
     expect(response.statusCode).toEqual(200);
-    expect(quoteResponse.requestId).toEqual(request.requestId);
+    expect(quoteResponse.requestId).toEqual(request.quoteId);
     expect(quoteResponse.quoteId).toEqual(request.quoteId);
     expect(quoteResponse.chainId).toEqual(request.tokenInChainId);
     expect(quoteResponse.filler).toEqual(ethers.constants.AddressZero);
@@ -178,7 +147,7 @@ describe('Quote handler', () => {
     );
     const quoteResponse: HardQuoteResponseData = JSON.parse(response.body); // random quoteId
     expect(response.statusCode).toEqual(200);
-    expect(quoteResponse.requestId).toEqual(request.requestId);
+    expect(quoteResponse.requestId).toEqual(request.quoteId);
     expect(quoteResponse.quoteId).toEqual(request.quoteId);
     expect(quoteResponse.chainId).toEqual(request.tokenInChainId);
     expect(quoteResponse.filler).toEqual(MOCK_FILLER_ADDRESS);
@@ -217,7 +186,7 @@ describe('Quote handler', () => {
     );
     const quoteResponse: HardQuoteResponseData = JSON.parse(response.body); // random quoteId
     expect(response.statusCode).toEqual(200);
-    expect(quoteResponse.requestId).toEqual(request.requestId);
+    expect(quoteResponse.requestId).toEqual(request.quoteId);
     expect(quoteResponse.quoteId).toEqual(request.quoteId);
     expect(quoteResponse.chainId).toEqual(request.tokenInChainId);
     expect(quoteResponse.filler).toEqual(MOCK_FILLER_ADDRESS);
@@ -240,7 +209,7 @@ describe('Quote handler', () => {
     );
     const quoteResponse: HardQuoteResponseData = JSON.parse(response.body); // random quoteId
     expect(response.statusCode).toEqual(200);
-    expect(quoteResponse.requestId).toEqual(request.requestId);
+    expect(quoteResponse.requestId).toEqual(request.quoteId);
     expect(quoteResponse.quoteId).toEqual(request.quoteId);
     expect(quoteResponse.chainId).toEqual(request.tokenInChainId);
     expect(quoteResponse.filler).toEqual(ethers.constants.AddressZero);
@@ -269,7 +238,50 @@ describe('Quote handler', () => {
     });
   });
 
-  it.only('No quotes', async () => {
+  // Pins the requestId contract introduced by e542951 (PR #317): HardQuoteRequest's
+  // constructor sets `requestId: _data.quoteId ?? uuidv4()`, so the response echoes the
+  // indicative quoteId and the client-supplied requestId is discarded. This is deliberate --
+  // `hardrequests` has no quoteId column, so requestId is how the indicative quoteId reaches
+  // Redshift. The `.not.toEqual` is the load-bearing line: it fails if the derivation is
+  // removed without updating this test.
+  it('echoes the indicative quoteId as requestId, discarding the client requestId', async () => {
+    const quoters = [new MockQuoter(logger, 1, 1)];
+    const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+    expect(request.requestId).toEqual(REQUEST_ID);
+    expect(request.quoteId).toEqual(QUOTE_ID);
+
+    const response: APIGatewayProxyResult = await getQuoteHandler(quoters).handler(
+      getEvent(request),
+      {} as unknown as Context
+    );
+    const quoteResponse: HardQuoteResponseData = JSON.parse(response.body);
+    expect(response.statusCode).toEqual(200);
+    expect(quoteResponse.requestId).toEqual(QUOTE_ID);
+    expect(quoteResponse.requestId).not.toEqual(REQUEST_ID);
+    expect(quoteResponse.quoteId).toEqual(QUOTE_ID);
+  });
+
+  // quoteId is optional in HardQuoteRequestBodyJoi, and on that branch the derivation falls
+  // back to a fresh uuidv4(). The caller therefore gets back a requestId it has never seen.
+  // Characterization test: this documents current behavior, it does not endorse it.
+  // See the follow-up ticket on the requestId contract.
+  it('with no quoteId, returns a generated requestId that is neither id the caller sent', async () => {
+    const quoters = [new MockQuoter(logger, 1, 1)];
+    const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }), null);
+    expect(request.quoteId).toBeUndefined();
+
+    const response: APIGatewayProxyResult = await getQuoteHandler(quoters).handler(
+      getEvent(request),
+      {} as unknown as Context
+    );
+    const quoteResponse: HardQuoteResponseData = JSON.parse(response.body);
+    expect(response.statusCode).toEqual(200);
+    expect(quoteResponse.requestId).toEqual(expect.any(String));
+    expect(quoteResponse.requestId).not.toEqual(REQUEST_ID);
+    expect(quoteResponse.requestId).not.toEqual(QUOTE_ID);
+  });
+
+  it('No quotes', async () => {
     const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
 
     const response: APIGatewayProxyResult = await getQuoteHandler([]).handler(
@@ -323,10 +335,39 @@ describe('Quote handler', () => {
       expect(cosignerData.decayEndTime).toBeLessThan(cosignerData.decayStartTime + 1000);
     });
 
+    // getCosignerData branches on `request.type`, which HardQuoteRequest derives from the
+    // ORDER's input curve (startAmount == endAmount => EXACT_INPUT). It does NOT read the
+    // TradeType passed to `getQuoteResponse`. getOrder()'s default input is non-decaying, so
+    // an exact-output case needs an input-decaying order -- same shape as
+    // 'Pick the lesser of two quotes - EXACT_OUT' above.
+    const getExactOutputRequest = (): Promise<HardQuoteRequestBody> =>
+      getRequest(
+        getOrder({
+          cosigner: cosignerWallet.address,
+          input: {
+            token: TOKEN_IN,
+            startAmount: RAW_AMOUNT,
+            endAmount: RAW_AMOUNT.mul(110).div(100),
+          },
+          outputs: [
+            {
+              token: TOKEN_OUT,
+              startAmount: RAW_AMOUNT,
+              endAmount: RAW_AMOUNT,
+              recipient: ethers.constants.AddressZero,
+            },
+          ],
+        })
+      );
+
     it('exact input quote worse, no exclusivity', async () => {
       const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+      const hardRequest = new HardQuoteRequest(request, OrderType.Dutch_V2);
+      // guards against the fixture silently drifting to the other branch
+      expect(hardRequest.type).toEqual(TradeType.EXACT_INPUT);
       const cosignerData = (await getCosignerData(
-        new HardQuoteRequest(request, OrderType.Dutch_V2),
+        hardRequest,
+        // amountOut (0.8) is not greater than totalOutputAmountStart (1.0)
         getQuoteResponse({ amountOut: ethers.utils.parseEther('0.8') }),
         OrderType.Dutch_V2
       )) as CosignerData;
@@ -338,9 +379,12 @@ describe('Quote handler', () => {
 
     it('exact input quote better, sets exclusivity and updates amounts', async () => {
       const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+      const hardRequest = new HardQuoteRequest(request, OrderType.Dutch_V2);
+      expect(hardRequest.type).toEqual(TradeType.EXACT_INPUT);
       const outputAmount = ethers.utils.parseEther('2');
       const cosignerData = (await getCosignerData(
-        new HardQuoteRequest(request, OrderType.Dutch_V2),
+        hardRequest,
+        // amountOut (2.0) > totalOutputAmountStart (1.0): the whole increase goes to outputs[0]
         getQuoteResponse({ amountOut: outputAmount }),
         OrderType.Dutch_V2
       )) as CosignerData;
@@ -350,10 +394,52 @@ describe('Quote handler', () => {
       expect(cosignerData.outputOverrides[0]).toEqual(outputAmount);
     });
 
-    it('exact output quote worse, no exclusivity', async () => {
-      const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+    it('exact input quote better, multi-output: entire increase goes to outputs[0]', async () => {
+      const request = await getRequest(
+        getOrder({
+          cosigner: cosignerWallet.address,
+          outputs: [
+            {
+              token: TOKEN_OUT,
+              startAmount: RAW_AMOUNT,
+              endAmount: RAW_AMOUNT.mul(90).div(100),
+              recipient: ethers.constants.AddressZero,
+            },
+            {
+              token: TOKEN_OUT,
+              startAmount: RAW_AMOUNT.mul(10).div(100),
+              endAmount: RAW_AMOUNT.mul(9).div(100),
+              recipient: '0x1111111111111111111111111111111111111111',
+            },
+          ],
+        })
+      );
+      const hardRequest = new HardQuoteRequest(request, OrderType.Dutch_V2);
+      expect(hardRequest.type).toEqual(TradeType.EXACT_INPUT);
+      // totalOutputAmountStart is the SUM of all outputs (1.0 + 0.1)
+      expect(hardRequest.totalOutputAmountStart).toEqual(ethers.utils.parseEther('1.1'));
       const cosignerData = (await getCosignerData(
-        new HardQuoteRequest(request, OrderType.Dutch_V2),
+        hardRequest,
+        getQuoteResponse({ amountOut: ethers.utils.parseEther('1.5') }),
+        OrderType.Dutch_V2
+      )) as CosignerData;
+      expect(cosignerData.exclusiveFiller).toEqual(MOCK_FILLER_ADDRESS);
+      expect(cosignerData.inputOverride).toEqual(BigNumber.from(0));
+      expect(cosignerData.outputOverrides.length).toEqual(2);
+      // outputs[0].startAmount (1.0) + increase (1.5 - 1.1 = 0.4); measured against the SUM
+      // but added to outputs[0] only
+      expect(cosignerData.outputOverrides[0]).toEqual(ethers.utils.parseEther('1.4'));
+      // the fee output is left at 0, i.e. "use the order's own amount"
+      expect(cosignerData.outputOverrides[1]).toEqual(BigNumber.from(0));
+    });
+
+    it('exact output quote worse, no exclusivity', async () => {
+      const request = await getExactOutputRequest();
+      const hardRequest = new HardQuoteRequest(request, OrderType.Dutch_V2);
+      expect(hardRequest.type).toEqual(TradeType.EXACT_OUTPUT);
+      const cosignerData = (await getCosignerData(
+        hardRequest,
+        // amountIn (1.2) is not less than totalInputAmountStart (1.0)
         getQuoteResponse({ amountIn: ethers.utils.parseEther('1.2') }, TradeType.EXACT_OUTPUT),
         OrderType.Dutch_V2
       )) as CosignerData;
@@ -363,18 +449,28 @@ describe('Quote handler', () => {
       expect(cosignerData.outputOverrides[0]).toEqual(BigNumber.from(0));
     });
 
-    it('exact input quote better, sets exclusivity and updates amounts', async () => {
-      const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+    it('exact output quote better, sets exclusivity and updates amounts', async () => {
+      const request = await getExactOutputRequest();
+      const hardRequest = new HardQuoteRequest(request, OrderType.Dutch_V2);
+      expect(hardRequest.type).toEqual(TradeType.EXACT_OUTPUT);
       const inputOverride = ethers.utils.parseEther('0.8');
       const cosignerData = (await getCosignerData(
-        new HardQuoteRequest(request, OrderType.Dutch_V2),
-        getQuoteResponse({ amountIn: ethers.utils.parseEther('1.2') }, TradeType.EXACT_OUTPUT),
+        hardRequest,
+        // amountIn (0.8) < totalInputAmountStart (1.0): the swapper pays less
+        getQuoteResponse({ amountIn: inputOverride }, TradeType.EXACT_OUTPUT),
         OrderType.Dutch_V2
       )) as CosignerData;
       expect(cosignerData.exclusiveFiller).toEqual(MOCK_FILLER_ADDRESS);
       expect(cosignerData.inputOverride).toEqual(inputOverride);
       expect(cosignerData.outputOverrides.length).toEqual(1);
       expect(cosignerData.outputOverrides[0]).toEqual(BigNumber.from(0));
+    });
+
+    it('unsupported order type throws', async () => {
+      const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+      await expect(
+        getCosignerData(new HardQuoteRequest(request, OrderType.Dutch_V2), getQuoteResponse({}), OrderType.Dutch)
+      ).rejects.toThrow('Unsupported order type');
     });
   });
 });

--- a/test/handlers/hard-quote/handlerDeadline.test.ts
+++ b/test/handlers/hard-quote/handlerDeadline.test.ts
@@ -1,10 +1,10 @@
 import { KMSClient } from '@aws-sdk/client-kms';
 import { KmsSigner } from '@uniswap/signer';
-import { UnsignedV2DutchOrder, UnsignedV2DutchOrderInfo } from '@uniswap/uniswapx-sdk';
+import { UnsignedV2DutchOrder } from '@uniswap/uniswapx-sdk';
 import { createMetricsLogger } from 'aws-embedded-metrics';
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { default as Logger } from 'bunyan';
-import { BigNumber, ethers, Wallet } from 'ethers';
+import { ethers, Wallet } from 'ethers';
 
 import { AWSMetricsLogger } from '../../../lib/entities/aws-metrics-logger';
 import { ApiInjector } from '../../../lib/handlers/base/api-handler';
@@ -16,15 +16,13 @@ import {
 } from '../../../lib/handlers/hard-quote';
 import { MockOrderServiceProvider } from '../../../lib/providers';
 import { MockQuoter, Quoter } from '../../../lib/quoters';
+import { getOrder } from '../../fixtures/hard-quote';
 
 jest.mock('axios');
 jest.mock('@aws-sdk/client-kms');
 jest.mock('@uniswap/signer');
 
 const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
-const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
-const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-const RAW_AMOUNT = BigNumber.from('1000000000000000000');
 const CHAIN_ID = 1;
 
 const logger = Logger.createLogger({ name: 'test' });
@@ -32,40 +30,6 @@ logger.level(Logger.FATAL);
 
 process.env.KMS_KEY_ID = 'test-key-id';
 process.env.REGION = 'us-east-2';
-
-const getOrder = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV2DutchOrder => {
-  const now = Math.floor(new Date().getTime() / 1000);
-  return new UnsignedV2DutchOrder(
-    Object.assign(
-      {
-        deadline: now + 1000,
-        reactor: ethers.constants.AddressZero,
-        swapper: ethers.constants.AddressZero,
-        nonce: BigNumber.from(10),
-        additionalValidationContract: ethers.constants.AddressZero,
-        additionalValidationData: '0x',
-        cosigner: ethers.constants.AddressZero,
-        cosignerData: undefined,
-        input: {
-          token: TOKEN_IN,
-          startAmount: RAW_AMOUNT,
-          endAmount: RAW_AMOUNT,
-        },
-        outputs: [
-          {
-            token: TOKEN_OUT,
-            startAmount: RAW_AMOUNT,
-            endAmount: RAW_AMOUNT.mul(90).div(100),
-            recipient: ethers.constants.AddressZero,
-          },
-        ],
-        cosignature: undefined,
-      },
-      data
-    ),
-    CHAIN_ID
-  );
-};
 
 describe('Hard quote handler - order deadline validation', () => {
   const swapperWallet = Wallet.createRandom();

--- a/test/handlers/hard-quote/handlerDutchV3.test.ts
+++ b/test/handlers/hard-quote/handlerDutchV3.test.ts
@@ -11,6 +11,7 @@ import { createMetricsLogger } from 'aws-embedded-metrics';
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { default as Logger } from 'bunyan';
 import { BigNumber, ethers, Wallet } from 'ethers';
+import { getV3BlockBuffer } from '../../../lib/constants';
 import { AWSMetricsLogger } from '../../../lib/entities/aws-metrics-logger';
 import { ApiInjector } from '../../../lib/handlers/base/api-handler';
 import {
@@ -27,12 +28,17 @@ jest.mock('axios');
 jest.mock('@aws-sdk/client-kms');
 jest.mock('@uniswap/signer');
 
-//const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
-const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
+const QUOTE_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
+// Deliberately DIFFERENT from QUOTE_ID. HardQuoteRequest derives
+// `requestId: _data.quoteId ?? uuidv4()`, so an assertion that the response echoes the
+// requestId proves nothing while the two constants are the same uuid.
+const REQUEST_ID = 'b45c2d1e-7f30-4a92-8c65-1d8e4f2a9b03';
 const TOKEN_IN = USDT_ARBITRUM;
 const TOKEN_OUT = WBTC_ARBITRUM;
 const RAW_AMOUNT = BigNumber.from('1000000000000000000');
 const CHAIN_ID = 42161;
+// Arbitrary; the V3 path derives decayStartBlock from it, which the test asserts.
+const CURRENT_BLOCK = 1_000_000;
 
 const logger = Logger.createLogger({ name: 'test' });
 logger.level(Logger.FATAL);
@@ -40,7 +46,9 @@ logger.level(Logger.FATAL);
 process.env.KMS_KEY_ID = 'test-key-id';
 process.env.REGION = 'us-east-2';
 
-export const getPartialOrder = (data: Partial<UnsignedV3DutchOrderInfo>): UnsignedV3DutchOrder => {
+// Not exported: nothing outside this file uses it, and exporting a helper from a *.test.ts
+// file is what lets a stray `.only` here silence an unrelated suite (see test/fixtures/hard-quote.ts).
+const getPartialOrder = (data: Partial<UnsignedV3DutchOrderInfo>): UnsignedV3DutchOrder => {
   const now = Math.floor(new Date().getTime() / 1000);
   const validPartialOrder = new V3DutchOrderBuilder(CHAIN_ID)
     .cosigner(data.cosigner ?? ethers.constants.AddressZero)
@@ -74,6 +82,13 @@ export const getPartialOrder = (data: Partial<UnsignedV3DutchOrderInfo>): Unsign
 
   return validPartialOrder;
 };
+
+// Mirrors makeProvider in handlerDutchV3.cosigner.test.ts. Only getBlockNumber is used by the
+// V3 cosigner path (lib/handlers/hard-quote/handler.ts:277 and :418).
+const makeProvider = (): ethers.providers.StaticJsonRpcProvider =>
+  ({
+    getBlockNumber: jest.fn().mockResolvedValue(CURRENT_BLOCK),
+  } as unknown as ethers.providers.StaticJsonRpcProvider);
 
 describe('Quote handler', () => {
   const swapperWallet = Wallet.createRandom();
@@ -109,8 +124,11 @@ describe('Quote handler', () => {
           return {
             quoters,
             orderServiceProvider: new MockOrderServiceProvider(),
-            // Mock chainIdRpcMap
-            chainIdRpcMap: new Map([[42161, new ethers.providers.StaticJsonRpcProvider()]]),
+            // The V3 path calls provider.getBlockNumber() to derive decayStartBlock. A real
+            // StaticJsonRpcProvider here defaults to http://localhost:8545, so the call fails
+            // and the handler returns 500 -- which is why this suite was skipped rather than
+            // being blocked on the order service. Duck-typed to keep the test offline.
+            chainIdRpcMap: new Map([[CHAIN_ID, makeProvider()]]),
           };
         },
         getRequestInjected: () => requestInjectedMock,
@@ -129,6 +147,7 @@ describe('Quote handler', () => {
     const sig = await swapperWallet._signTypedData(domain, types, values);
     return {
       requestId: REQUEST_ID,
+      quoteId: QUOTE_ID,
       tokenInChainId: CHAIN_ID,
       tokenOutChainId: CHAIN_ID,
       encodedInnerOrder: order.serialize(),
@@ -140,8 +159,7 @@ describe('Quote handler', () => {
     jest.clearAllMocks();
   });
 
-  it.skip('Simple request and response', async () => {
-    // Skip until V3 Order Service is ready
+  it('Simple request and response', async () => {
     const quoters = [new MockQuoter(logger, 1, 1)];
     const request = await getRequest(getPartialOrder({ cosigner: cosignerWallet.address }));
 
@@ -149,18 +167,27 @@ describe('Quote handler', () => {
       getEvent(request),
       {} as unknown as Context
     );
-    const quoteResponse: HardQuoteResponseData = JSON.parse(response.body); // random quoteId
+    const quoteResponse: HardQuoteResponseData = JSON.parse(response.body);
     expect(response.statusCode).toEqual(200);
-    expect(quoteResponse.requestId).toEqual(request.requestId);
-    expect(quoteResponse.quoteId).toEqual(request.quoteId);
+    // requestId is the indicative quoteId, not the client-supplied requestId
+    expect(quoteResponse.requestId).toEqual(QUOTE_ID);
+    expect(quoteResponse.requestId).not.toEqual(REQUEST_ID);
+    expect(quoteResponse.quoteId).toEqual(QUOTE_ID);
     expect(quoteResponse.chainId).toEqual(request.tokenInChainId);
     expect(quoteResponse.filler).toEqual(ethers.constants.AddressZero);
     const cosignedOrder = CosignedV3DutchOrder.parse(quoteResponse.encodedOrder, CHAIN_ID);
 
-    // no overrides since quote was same as request
+    // MockQuoter(1, 1) quotes exactly the requested amount, so the quote is not strictly
+    // better for the swapper and nothing is overridden.
     expect(cosignedOrder.info.cosignerData.exclusiveFiller).toEqual(ethers.constants.AddressZero);
     expect(cosignedOrder.info.cosignerData.inputOverride).toEqual(BigNumber.from(0));
     expect(cosignedOrder.info.cosignerData.outputOverrides.length).toEqual(1);
     expect(cosignedOrder.info.cosignerData.outputOverrides[0]).toEqual(BigNumber.from(0));
+
+    // V3-specific: decay is block-based, derived from the mocked getBlockNumber. Without this
+    // the mocked provider would be untested scaffolding.
+    expect(cosignedOrder.info.cosignerData.decayStartBlock).toEqual(CURRENT_BLOCK + getV3BlockBuffer(CHAIN_ID));
+    // V3 uses a tighter exclusivity override than V2's 100 bps.
+    expect(cosignedOrder.info.cosignerData.exclusivityOverrideBps).toEqual(BigNumber.from(25));
   });
 });

--- a/test/handlers/hard-quote/handlerPostError.test.ts
+++ b/test/handlers/hard-quote/handlerPostError.test.ts
@@ -1,9 +1,9 @@
 import { KMSClient } from '@aws-sdk/client-kms';
-import { UnsignedV2DutchOrder, UnsignedV2DutchOrderInfo } from '@uniswap/uniswapx-sdk';
+import { UnsignedV2DutchOrder } from '@uniswap/uniswapx-sdk';
 import { createMetricsLogger } from 'aws-embedded-metrics';
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import { default as Logger } from 'bunyan';
-import { BigNumber, ethers, Wallet } from 'ethers';
+import { ethers, Wallet } from 'ethers';
 
 import { KmsSigner } from '@uniswap/signer';
 import { AWSMetricsLogger } from '../../../lib/entities/aws-metrics-logger';
@@ -17,15 +17,13 @@ import {
 import { OrderServiceProvider } from '../../../lib/providers/order';
 import { MockQuoter, Quoter } from '../../../lib/quoters';
 import { ErrorCode } from '../../../lib/util/errors';
+import { getOrder } from '../../fixtures/hard-quote';
 
 jest.mock('axios');
 jest.mock('@aws-sdk/client-kms');
 jest.mock('@uniswap/signer');
 
 const REQUEST_ID = 'a83f397c-8ef4-4801-a9b7-6e79155049f6';
-const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
-const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-const RAW_AMOUNT = BigNumber.from('1000000000000000000');
 const CHAIN_ID = 1;
 
 const logger = Logger.createLogger({ name: 'test' });
@@ -33,40 +31,6 @@ logger.level(Logger.FATAL);
 
 process.env.KMS_KEY_ID = 'test-key-id';
 process.env.REGION = 'us-east-2';
-
-const getOrder = (data: Partial<UnsignedV2DutchOrderInfo>): UnsignedV2DutchOrder => {
-  const now = Math.floor(new Date().getTime() / 1000);
-  return new UnsignedV2DutchOrder(
-    Object.assign(
-      {
-        deadline: now + 1000,
-        reactor: ethers.constants.AddressZero,
-        swapper: ethers.constants.AddressZero,
-        nonce: BigNumber.from(10),
-        additionalValidationContract: ethers.constants.AddressZero,
-        additionalValidationData: '0x',
-        cosigner: ethers.constants.AddressZero,
-        cosignerData: undefined,
-        input: {
-          token: TOKEN_IN,
-          startAmount: RAW_AMOUNT,
-          endAmount: RAW_AMOUNT,
-        },
-        outputs: [
-          {
-            token: TOKEN_OUT,
-            startAmount: RAW_AMOUNT,
-            endAmount: RAW_AMOUNT.mul(90).div(100),
-            recipient: ethers.constants.AddressZero,
-          },
-        ],
-        cosignature: undefined,
-      },
-      data
-    ),
-    CHAIN_ID
-  );
-};
 
 // Status mapping when the order service post fails: only genuine 4xx
 // rejections may surface as 400; indeterminate outcomes (timeouts, 5xx) must

--- a/test/handlers/hard-quote/schema.test.ts
+++ b/test/handlers/hard-quote/schema.test.ts
@@ -3,7 +3,7 @@ import { BigNumber, utils } from 'ethers';
 import { v4 as uuidv4 } from 'uuid';
 
 import { HardQuoteRequestBodyJoi } from '../../../lib/handlers/hard-quote';
-import { getOrderInfo } from '../../entities/HardQuoteRequest.test';
+import { getOrderInfo } from '../../fixtures/hard-quote';
 
 const SWAPPER = '0x0000000000000000000000000000000000000000';
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';


### PR DESCRIPTION
## Why

`test/handlers/hard-quote/handler.test.ts` had an `it.only` from 2024-03-14 (`8becf4db`). It silenced the rest of that file **and** all of `HardQuoteResponse.test.ts`, which imported `getOrder` from it — jest's `.only` scoping spans a cross-test-file import. 22 tests, dark for two years.

The cost wasn't the hidden tests. Six weeks later `e542951` changed `HardQuoteRequest` to derive `requestId` from `quoteId`, breaking 7 of the invisible tests. CI stayed green, so nobody learned.

## No production source changed

`requestId: _data.quoteId ?? uuidv4()` looks like a bug that discards the client's `requestId`. It isn't — it landed via reviewed PR #317 (which contains a *rejected* schema-level alternative), and it's load-bearing: `hardrequests` has no `quoteId` column, so this is the only way the indicative quoteId reaches Redshift. **The tests were stale, not the source.** Follow-up to add that column is filed separately.

## What changed

- Removed the `.only`; un-nested 2 tests buried inside an `it()` callback (they never registered — they pass unmodified)
- New `test/fixtures/hard-quote.ts`, absorbing **4 duplicate `getOrder` copies**. Kills both cross-test-file imports (`schema.test.ts` had a second one) and the duplicate suite execution
- Repaired `getCosignerData` tests. `'exact output quote worse'` was **passing for the wrong reason**: the function branches on `request.type` (derived from the order's input curve), not the `TradeType` passed to the mock quote, which is inert. Exact-output cases need an input-decaying order; added `expect(hardRequest.type)` guards so this can't drift silently again
- Made `QUOTE_ID`/`REQUEST_ID` distinct — they were byte-identical, so every "echoes the requestId" assertion was vacuous
- `.eslintrc`: zero-dependency `no-restricted-syntax` guard for `.only`/`fit`/`fdescribe` **and** nested-`it`. Jest has no config option that fails on focused tests, and `eslint-plugin-jest` has no nested-tests rule

## Verification

`yarn test:unit`: 12 failed / 252 → **0 failed, 242 passed, 1 skipped / 243**. Total drops because the duplicate execution is gone. `yarn build` and `yarn lint` unchanged (0 errors).

Green wasn't enough — the old suite was green too, so it's mutation-tested:
- revert the `requestId` derivation → **15 failures across 3 suites** (previously zero)
- plant an `it.only` → sibling file still runs 6/6 instead of going fully skipped

## Notes for review

- `HardQuoteResponse.test.ts:177` asserts `expect(x).not.toEqual(x)` across two `toLog()` calls. Not a typo — it pins the non-memoized `quoteId` getter, which mints a new uuid per access. Fine to drop; nothing else depends on it.
- Only **7** distinct tests were failing, not 12 — the cross-test import double-counted 5.
- `handlerDutchV3.test.ts` un-skipped: its only test was `it.skip`, so the suite was inert. The stated
  reason ("until V3 Order Service is ready") was wrong — it uses `MockOrderServiceProvider`. The real
  blocker was an unmocked `StaticJsonRpcProvider` defaulting to `localhost:8545`, which made the V3
  `getBlockNumber()` call fail and the handler 500. Now mocked like its sibling, with added assertions
  on `decayStartBlock` and V3's 25-bps exclusivity. **Suite is now 29/29, zero skips.**