### PR TITLE
test: deflake hard-quote integ hooks with bounded waits and capped fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc -w",
     "test": "run-s build test:*",
     "test:unit": "jest --detectOpenHandles --forceExit --testPathIgnorePatterns test/integ dist/",
-    "test:integ": "ts-mocha -p tsconfig.cdk.json -r dotenv/config test/integ/**/*.test.ts --timeout 120000",
+    "test:integ": "ts-mocha -p tsconfig.cdk.json -r dotenv/config test/integ/**/*.test.ts --timeout 120000 --exit",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"lib/**/*.ts\" \"test/**/*.ts\" \"bin/**/*.ts\" --write",
     "fix:eslint": "eslint lib test bin --ext .ts --fix",

--- a/test/integ/hard-quote.test.ts
+++ b/test/integ/hard-quote.test.ts
@@ -53,6 +53,15 @@ const ERC20_ABI = [
 // Amount of USDC (6 decimals) and ETH to fund the dynamic wallet
 const USDC_FUND_AMOUNT = BigNumber.from(100); // 100 wei of USDC (order only needs 1)
 const ETH_FUND_AMOUNT = ethers.utils.parseEther('0.001'); // enough for gas
+const ETH_TRANSFER_GAS_LIMIT = 21_000;
+
+// Bound every RPC call and confirmation wait so a stalled gateway or stuck tx
+// can't run a mocha hook into its timeout (ethers' default HTTP timeout is
+// 120s and tx.wait() polls forever, either of which fails the whole pipeline).
+// Sepolia blocks are ~12s: a tx not confirmed within a few blocks is stuck,
+// and waiting longer won't unstick it.
+const RPC_TIMEOUT_MS = 15_000;
+const TX_CONFIRM_TIMEOUT_MS = 30_000;
 
 let builder: V2DutchOrderBuilder;
 let provider: ethers.providers.JsonRpcProvider;
@@ -60,13 +69,41 @@ let dynamicWallet: ethers.Wallet;
 let dynamicSwapper: ethers.Wallet;
 let faucetSigner: ethers.Wallet;
 
+// Fee overrides with a 4x base-fee cap. Under EIP-1559 the tx still pays only
+// base + tip, but it stays includable through the base-fee spikes Sepolia sees
+// between fee estimation and inclusion.
+async function spikeResistantFees(): Promise<{ maxFeePerGas: BigNumber; maxPriorityFeePerGas: BigNumber }> {
+  const fee = await provider.getFeeData();
+  const tip = fee.maxPriorityFeePerGas ?? ethers.utils.parseUnits('1.5', 'gwei');
+  const base = fee.lastBaseFeePerGas ?? fee.gasPrice ?? ethers.utils.parseUnits('10', 'gwei');
+  return { maxFeePerGas: base.mul(4).add(tip), maxPriorityFeePerGas: tip };
+}
+
+async function waitForTx(tx: ethers.providers.TransactionResponse, label: string): Promise<void> {
+  let receipt: ethers.providers.TransactionReceipt;
+  try {
+    receipt = await provider.waitForTransaction(tx.hash, 1, TX_CONFIRM_TIMEOUT_MS);
+  } catch (e) {
+    throw new Error(
+      `${label} tx ${tx.hash} not confirmed within ${TX_CONFIRM_TIMEOUT_MS / 1000}s: ${(e as Error).message}`
+    );
+  }
+  if (receipt.status === 0) {
+    throw new Error(`${label} tx ${tx.hash} reverted`);
+  }
+}
+
 describe('Hard Quote endpoint integration test', function () {
-  before(async () => {
+  before(async function () {
+    this.timeout(180_000);
     // The RPC gateway requires the x-internal-service-secret header (see
     // RPC_HEADERS in lib/constants.ts), so attach it the same way the Lambda
     // injectors do. Without it the gateway rejects requests and ethers reports
     // "could not detect network".
-    provider = new ethers.providers.JsonRpcProvider({ url: SEPOLIA_RPC, headers: RPC_HEADERS }, SEPOLIA);
+    provider = new ethers.providers.JsonRpcProvider(
+      { url: SEPOLIA_RPC, headers: RPC_HEADERS, timeout: RPC_TIMEOUT_MS },
+      SEPOLIA
+    );
     faucetSigner = faucetWallet.connect(provider);
 
     // Generate a fresh wallet for tests that post orders to avoid TOO_MANY_OPEN_ORDERS
@@ -77,47 +114,56 @@ describe('Hard Quote endpoint integration test', function () {
 
     // Fund the dynamic wallet with ETH and USDC from the faucet wallet.
     // Send sequentially to avoid nonce conflicts with public RPCs.
+    const fees = await spikeResistantFees();
     const ethTx = await faucetSigner.sendTransaction({
       to: dynamicWallet.address,
       value: ETH_FUND_AMOUNT,
+      ...fees,
     });
-    await ethTx.wait(1);
+    await waitForTx(ethTx, 'ETH funding');
     const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, faucetSigner);
-    const usdcTx = await usdc.transfer(dynamicWallet.address, USDC_FUND_AMOUNT);
-    await usdcTx.wait(1);
+    const usdcTx = await usdc.transfer(dynamicWallet.address, USDC_FUND_AMOUNT, fees);
+    await waitForTx(usdcTx, 'USDC funding');
 
     // Approve USDC to Permit2 so the order service's onchain validation passes
     const usdcDynamic = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
-    const approveTx = await usdcDynamic.approve(PERMIT2_ADDRESS, ethers.constants.MaxUint256);
-    await approveTx.wait(1);
+    const approveTx = await usdcDynamic.approve(PERMIT2_ADDRESS, ethers.constants.MaxUint256, fees);
+    await waitForTx(approveTx, 'Permit2 approve');
 
     const balance = await usdcDynamic.balanceOf(dynamicWallet.address);
     console.log(`Funded dynamic wallet (USDC balance: ${balance.toString()})`);
   });
 
-  after(async () => {
+  after(async function () {
+    this.timeout(180_000);
+    // Cleanup is best-effort: the dynamic wallet is a throwaway, so a failed
+    // refund must never fail the suite. Every RPC call and confirmation wait
+    // in here is bounded, so the hook itself cannot hit the mocha timeout.
     try {
+      const fees = await spikeResistantFees();
+
       // Return USDC balance to faucet
       const usdc = new ethers.Contract(TOKEN_IN, ERC20_ABI, dynamicSwapper);
       const usdcBalance: BigNumber = await usdc.balanceOf(dynamicWallet.address);
       if (usdcBalance.gt(0)) {
-        const usdcTx = await usdc.transfer(FAUCET_ADDRESS, usdcBalance);
-        await usdcTx.wait();
+        const usdcTx = await usdc.transfer(FAUCET_ADDRESS, usdcBalance, fees);
+        await waitForTx(usdcTx, 'USDC refund');
       }
 
-      // Return remaining ETH to faucet (minus gas for this tx)
+      // Return remaining ETH to faucet, reserving the most the refund tx
+      // itself can cost at the capped fee. An exact legacy-gasPrice reserve
+      // goes unmineable the moment the base fee rises above it.
       const ethBalance = await provider.getBalance(dynamicWallet.address);
-      const gasPrice = await provider.getGasPrice();
-      const gasCost = gasPrice.mul(21000);
+      const gasCost = fees.maxFeePerGas.mul(ETH_TRANSFER_GAS_LIMIT);
       const refundAmount = ethBalance.sub(gasCost);
       if (refundAmount.gt(0)) {
         const ethTx = await dynamicSwapper.sendTransaction({
           to: FAUCET_ADDRESS,
           value: refundAmount,
-          gasLimit: 21000,
-          gasPrice,
+          gasLimit: ETH_TRANSFER_GAS_LIMIT,
+          ...fees,
         });
-        await ethTx.wait();
+        await waitForTx(ethTx, 'ETH refund');
       }
       console.log('Refunded faucet wallet');
     } catch (e) {


### PR DESCRIPTION
## Problem

The hard-quote integ suite intermittently fails in the pipeline with:

```
1) Hard Quote endpoint integration test
     "after all" hook: Error: Timeout of 120000ms exceeded.
```

…and then the CodeBuild step hangs at that message until the build timeout (~60 min).

Beta passing while prod fails is coincidence, not config: both integ stages use the same faucet key, RPC secret, and chain — only `UNISWAP_API`/`COSIGNER_ADDR` differ, and the failing hook never touches the API.

## Root cause

Two layers:

1. **Hook hang** — the `after` refund hook used unbounded `tx.wait()` (ethers v5 polls forever) and priced the ETH refund with a one-shot legacy `getGasPrice()` + exact-balance math. The moment Sepolia's base fee rose above that price the tx became unmineable, nothing ever threw, and the hook sat until mocha's 120s timeout killed it. ethers' default HTTP timeout (120s) makes a single stalled RPC call fail identically.
2. **Process hang** — mocha 4+ doesn't force-exit while the event loop has live handles. The orphaned wait-poller kept polling after the report printed, so the Node process never exited and CodeBuild sat until its own timeout. (`test:unit` already guards this with `--forceExit`; `test:integ` didn't.)

## Changes

- Bound every confirmation wait (`provider.waitForTransaction(hash, 1, 30s)`) and every RPC call (15s HTTP timeout on the provider). Sepolia blocks are ~12s; a tx not mined within a few blocks is stuck and waiting longer won't help.
- Price all funding/refund txs as EIP-1559 with a 4x base-fee cap — they still pay only base + tip, but stay includable through fee spikes.
- Reserve the ETH refund's gas at the capped fee instead of the fragile exact legacy price.
- Label funding txs so a stuck one fails fast with `ETH funding tx 0x… not confirmed within 30s` instead of an opaque 120s timeout.
- Add `--exit` to `test:integ` so the process ends when the report does.

The cleanup hook is best-effort (all inside the existing try/catch): worst case it logs `Failed to refund faucet wallet` and the suite still passes. A failed refund also strands the run's 0.001 ETH in the throwaway wallet, so this stops a slow faucet drain too.

## Testing

- `tsc --noEmit -p tsconfig.cdk.json` clean for the changed file (remaining errors are the pre-existing `@types/mocha`/`@types/jest` globals clash)
- `prettier --check` / `eslint` pass
- Real verification is the pipeline integ stages themselves (no local `.env`)

## Residual flake sources (out of scope)

- Beta/prod and overlapping pipeline executions share one faucet key → possible nonce races in the funding hook; per-stage keys would eliminate this.
- `ETH_FUND_AMOUNT` (0.001 ETH) covers ~117k gas of wallet spend; sustained Sepolia base fees above ~8 gwei would break funding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)