### PR TITLE
chore: remove dead URA ingestion + v1 circuit breaker, fix dashboard and metric-namespace drift

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -137,7 +137,6 @@ export class APIPipeline extends Stack {
         ORDER_SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_BETA').toString(),
         FILL_LOG_SENDER_ACCOUNT: '321377678687',
         ORDER_LOG_SENDER_ACCOUNT: '321377678687',
-        URA_ACCOUNT: '665191769009',
         BOT_ACCOUNT: '800035746608',
       },
     });
@@ -158,7 +157,6 @@ export class APIPipeline extends Stack {
         ORDER_SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_PROD').toString(),
         FILL_LOG_SENDER_ACCOUNT: '316116520258',
         ORDER_LOG_SENDER_ACCOUNT: '316116520258',
-        URA_ACCOUNT: '652077092967',
         BOT_ACCOUNT: '456809954954',
       },
       stage: STAGE.PROD,
@@ -268,7 +266,6 @@ const app = new cdk.App();
 const envVars: { [key: string]: string } = {};
 
 envVars['FILL_LOG_SENDER_ACCOUNT'] = process.env['FILL_LOG_SENDER_ACCOUNT'] || '';
-envVars['URA_ACCOUNT'] = process.env['URA_ACCOUNT'] || '';
 envVars['BOT_ACCOUNT'] = process.env['BOT_ACCOUNT'] || '';
 envVars['UNISWAP_API'] = process.env['UNISWAP_API'] || '';
 envVars['ORDER_SERVICE_URL'] = process.env['ORDER_SERVICE_URL'] || '';

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -156,7 +156,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       aws_ec2.Port.tcp(rsCluster.clusterEndpoint.port)
     );
 
-    const uraRequestTable = new aws_rs.Table(this, 'UnifiedRoutingRequestTable', {
+    new aws_rs.Table(this, 'UnifiedRoutingRequestTable', {
       cluster: rsCluster,
       adminUser: creds,
       databaseName: RS_DATABASE_NAME,
@@ -218,7 +218,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       ],
     });
 
-    const uraResponseTable = new aws_rs.Table(this, 'UnifiedRoutingResponseTable', {
+    new aws_rs.Table(this, 'UnifiedRoutingResponseTable', {
       cluster: rsCluster,
       adminUser: creds,
       databaseName: RS_DATABASE_NAME,
@@ -351,11 +351,9 @@ export class AnalyticsStack extends cdk.NestedStack {
       managedPolicies: [aws_iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole')],
     });
     rfqRequestBucket.grantReadWrite(firehoseRole);
-    unifiedRoutingRequestBucket.grantReadWrite(firehoseRole);
     hardRequestBucket.grantReadWrite(firehoseRole);
     rfqResponseBucket.grantReadWrite(firehoseRole);
     hardResponseBucket.grantReadWrite(firehoseRole);
-    unifiedRoutingResponseBucket.grantReadWrite(firehoseRole);
     fillBucket.grantReadWrite(firehoseRole);
     ordersBucket.grantReadWrite(firehoseRole);
     botOrderLoaderBucket.grantReadWrite(firehoseRole);
@@ -537,39 +535,6 @@ export class AnalyticsStack extends cdk.NestedStack {
 
     // CDK doesn't have this implemented yet, so have to use the CloudFormation resource (lower level of abstraction)
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisfirehose-deliverystream.html
-    const uraRequestStream = new aws_firehose.CfnDeliveryStream(this, 'uraRequestStream', {
-      redshiftDestinationConfiguration: {
-        clusterJdbcurl: `jdbc:redshift://${rsCluster.clusterEndpoint.hostname}:${rsCluster.clusterEndpoint.port}/${RS_DATABASE_NAME}`,
-        username: 'admin',
-        password: creds.secretValueFromJson('password').toString(),
-        s3Configuration: {
-          bucketArn: unifiedRoutingRequestBucket.bucketArn,
-          roleArn: firehoseRole.roleArn,
-          compressionFormat: 'UNCOMPRESSED',
-        },
-        roleArn: firehoseRole.roleArn,
-        copyCommand: {
-          copyOptions: "JSON 'auto ignorecase'",
-          dataTableName: uraRequestTable.tableName,
-          dataTableColumns: uraRequestTable.tableColumns.map((column) => column.name).toString(),
-        },
-        processingConfiguration: {
-          enabled: true,
-          processors: [
-            {
-              type: 'Lambda',
-              parameters: [
-                {
-                  parameterName: 'LambdaArn',
-                  parameterValue: quoteProcessorLambda.functionArn,
-                },
-              ],
-            },
-          ],
-        },
-      },
-    });
-
     const rfqRequestFirehoseStream = new aws_firehose.CfnDeliveryStream(this, 'RfqRequestStream', {
       redshiftDestinationConfiguration: {
         clusterJdbcurl: `jdbc:redshift://${rsCluster.clusterEndpoint.hostname}:${rsCluster.clusterEndpoint.port}/${RS_DATABASE_NAME}`,
@@ -651,39 +616,6 @@ export class AnalyticsStack extends cdk.NestedStack {
           copyOptions: "JSON 'auto ignorecase'",
           dataTableName: hardResponseTable.tableName,
           dataTableColumns: hardResponseTable.tableColumns.map((column) => column.name).toString(),
-        },
-        processingConfiguration: {
-          enabled: true,
-          processors: [
-            {
-              type: 'Lambda',
-              parameters: [
-                {
-                  parameterName: 'LambdaArn',
-                  parameterValue: quoteProcessorLambda.functionArn,
-                },
-              ],
-            },
-          ],
-        },
-      },
-    });
-
-    const uraResponseStream = new aws_firehose.CfnDeliveryStream(this, 'UnifiedRoutingResponseStream', {
-      redshiftDestinationConfiguration: {
-        clusterJdbcurl: `jdbc:redshift://${rsCluster.clusterEndpoint.hostname}:${rsCluster.clusterEndpoint.port}/${RS_DATABASE_NAME}`,
-        username: 'admin',
-        password: creds.secretValueFromJson('password').toString(),
-        s3Configuration: {
-          bucketArn: unifiedRoutingResponseBucket.bucketArn,
-          roleArn: firehoseRole.roleArn,
-          compressionFormat: 'UNCOMPRESSED',
-        },
-        roleArn: firehoseRole.roleArn,
-        copyCommand: {
-          copyOptions: "JSON 'auto ignorecase'",
-          dataTableName: uraResponseTable.tableName,
-          dataTableColumns: uraResponseTable.tableColumns.map((column) => column.name).toString(),
         },
         processingConfiguration: {
           enabled: true,
@@ -858,41 +790,28 @@ export class AnalyticsStack extends cdk.NestedStack {
     });
 
     /* Firehose Alarms */
+    // hasRedshift gates the DeliveryToRedshift alarms: the S3-only streams never emit that
+    // metric, so alarming on it just creates alarms that sit in INSUFFICIENT_DATA forever.
     const allStreams = [
-      uraRequestStream,
-      rfqRequestFirehoseStream,
-      hardRequestFirehoseStream,
-      hardResponseFirehoseStream,
-      uraResponseStream,
-      rfqResponseFirehoseStream,
-      fillStream,
-      orderStream,
-      activeOrderStream,
-      unimindResponseStream,
-      unimindParameterUpdateStream,
+      { stream: rfqRequestFirehoseStream, hasRedshift: true },
+      { stream: hardRequestFirehoseStream, hasRedshift: true },
+      { stream: hardResponseFirehoseStream, hasRedshift: true },
+      { stream: rfqResponseFirehoseStream, hasRedshift: true },
+      { stream: fillStream, hasRedshift: true },
+      { stream: orderStream, hasRedshift: true },
+      { stream: activeOrderStream, hasRedshift: false },
+      { stream: unimindResponseStream, hasRedshift: false },
+      { stream: unimindParameterUpdateStream, hasRedshift: false },
     ];
 
-    allStreams.forEach((stream) => {
+    allStreams.forEach(({ stream, hasRedshift }) => {
       const s3DeliverySuccessSev3Name = `${stream.node.id}-SEV3-S3Delivery`;
       const s3DeliverySuccessSev2Name = `${stream.node.id}-SEV2-S3Delivery`;
       const missingRecordsName = `UniswapXParameterizationAPI-SEV3-MissingRecords-${stream.node.id}`;
 
-      const redshiftDeliverySuccessSev3Name = `${stream.node.id}-SEV3-RedshiftDelivery`;
-      const redshiftDeliverySuccessSev2Name = `${stream.node.id}-SEV2-RedshiftDelivery`;
-
       const deliveryToS3 = new cdk.aws_cloudwatch.Metric({
         namespace: 'AWS/Firehose',
         metricName: 'DeliveryToS3.Success',
-        dimensionsMap: {
-          DeliveryStreamName: stream.ref,
-        },
-        statistic: 'Average',
-        period: cdk.Duration.minutes(5),
-      });
-
-      const deliveryToRedshift = new cdk.aws_cloudwatch.Metric({
-        namespace: 'AWS/Firehose',
-        metricName: 'DeliveryToRedshift.Success',
         dimensionsMap: {
           DeliveryStreamName: stream.ref,
         },
@@ -940,29 +859,41 @@ export class AnalyticsStack extends cdk.NestedStack {
         actionsEnabled: true,
       });
 
-      const redshiftDeliverySev3 = new cdk.aws_cloudwatch.Alarm(this, redshiftDeliverySuccessSev3Name, {
-        metric: deliveryToRedshift,
-        threshold: 0.95,
-        evaluationPeriods: 3,
-        comparisonOperator: cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-        treatMissingData: cdk.aws_cloudwatch.TreatMissingData.NOT_BREACHING,
-        actionsEnabled: true,
-      });
+      const deliveryAlarms = [s3DeliverySev3, s3DeliverySev2];
 
-      const redshiftDeliverySev2 = new cdk.aws_cloudwatch.Alarm(this, redshiftDeliverySuccessSev2Name, {
-        metric: deliveryToRedshift,
-        threshold: 0.85,
-        evaluationPeriods: 3,
-        comparisonOperator: cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-        treatMissingData: cdk.aws_cloudwatch.TreatMissingData.NOT_BREACHING,
-        actionsEnabled: true,
-      });
+      if (hasRedshift) {
+        const deliveryToRedshift = new cdk.aws_cloudwatch.Metric({
+          namespace: 'AWS/Firehose',
+          metricName: 'DeliveryToRedshift.Success',
+          dimensionsMap: {
+            DeliveryStreamName: stream.ref,
+          },
+          statistic: 'Average',
+          period: cdk.Duration.minutes(5),
+        });
+
+        deliveryAlarms.push(
+          new cdk.aws_cloudwatch.Alarm(this, `${stream.node.id}-SEV3-RedshiftDelivery`, {
+            metric: deliveryToRedshift,
+            threshold: 0.95,
+            evaluationPeriods: 3,
+            comparisonOperator: cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+            treatMissingData: cdk.aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+            actionsEnabled: true,
+          }),
+          new cdk.aws_cloudwatch.Alarm(this, `${stream.node.id}-SEV2-RedshiftDelivery`, {
+            metric: deliveryToRedshift,
+            threshold: 0.85,
+            evaluationPeriods: 3,
+            comparisonOperator: cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+            treatMissingData: cdk.aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+            actionsEnabled: true,
+          })
+        );
+      }
 
       if (chatBotTopic) {
-        s3DeliverySev2.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
-        s3DeliverySev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
-        redshiftDeliverySev2.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
-        redshiftDeliverySev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
+        deliveryAlarms.forEach((alarm) => alarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic)));
       }
     });
 
@@ -999,18 +930,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       roleArn: subscriptionRole.roleArn,
       targetArn: orderStream.attrArn,
       destinationName: 'postedOrderDestination',
-    });
-
-    const uraRequestDestination = new aws_logs.CfnDestination(this, 'uraRequestDestination', {
-      roleArn: subscriptionRole.roleArn,
-      targetArn: uraRequestStream.attrArn,
-      destinationName: 'uraRequestDestination',
-    });
-
-    const uraResponseDestination = new aws_logs.CfnDestination(this, 'uraResponseDestination', {
-      roleArn: subscriptionRole.roleArn,
-      targetArn: uraResponseStream.attrArn,
-      destinationName: 'uraResponseDestination',
     });
 
     const unimindResponseDestination = new aws_logs.CfnDestination(this, 'UnimindResponseDestination', {
@@ -1067,37 +986,6 @@ export class AnalyticsStack extends cdk.NestedStack {
             Effect: 'Allow',
             Principal: {
               AWS: props.envVars['FILL_LOG_SENDER_ACCOUNT'],
-            },
-            Action: 'logs:PutSubscriptionFilter',
-            Resource: '*',
-          },
-        ],
-      });
-    }
-
-    if (props.envVars['URA_ACCOUNT']) {
-      uraRequestDestination.destinationPolicy = JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Sid: '',
-            Effect: 'Allow',
-            Principal: {
-              AWS: props.envVars['URA_ACCOUNT'],
-            },
-            Action: 'logs:PutSubscriptionFilter',
-            Resource: '*',
-          },
-        ],
-      });
-      uraResponseDestination.destinationPolicy = JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Sid: '',
-            Effect: 'Allow',
-            Principal: {
-              AWS: props.envVars['URA_ACCOUNT'],
             },
             Action: 'logs:PutSubscriptionFilter',
             Resource: '*',
@@ -1174,20 +1062,11 @@ export class AnalyticsStack extends cdk.NestedStack {
     new CfnOutput(this, 'postedOrderDestinationName', {
       value: postedOrderDestination.attrArn,
     });
-    new CfnOutput(this, 'uraRequestDestinationName', {
-      value: uraRequestDestination.attrArn,
-    });
-    new CfnOutput(this, 'uraResponseDestinationName', {
-      value: uraResponseDestination.attrArn,
-    });
     new CfnOutput(this, 'unimindResponseDestinationName', {
       value: unimindResponseDestination.attrArn,
     });
     new CfnOutput(this, 'unimindParameterUpdateDestinationName', {
       value: unimindParameterUpdateDestination.attrArn,
-    });
-    new CfnOutput(this, 'UraAccount', {
-      value: props.envVars['URA_ACCOUNT'],
     });
     new CfnOutput(this, 'BOT_ACCOUNT', {
       value: props.envVars['BOT_ACCOUNT'],

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -29,9 +29,7 @@ enum RS_DATA_TYPES {
   TERMINAL_STATUS = 'varchar(9)', // 'filled' || 'expired' || 'cancelled
   ALL_STATUS = 'text',
   TRADE_TYPE = 'varchar(12)', // 'EXACT_INPUT' || 'EXACT_OUTPUT'
-  ROUTING = 'text',
   CALL_DATA = 'varchar(5000)',
-  SLIPPAGE = 'float4',
   UnitInETH = 'float8',
   BOT_EVENT_TYPE = 'text', // 'fetch' || 'filter' || 'execution' || 'quote'
   ORDER_TYPE = 'text', // 'Limit' || 'Dutch'
@@ -741,7 +739,7 @@ export class AnalyticsStack extends cdk.NestedStack {
 
     /* Firehose Alarms */
     // hasRedshift gates the DeliveryToRedshift alarms: the S3-only streams never emit that
-    // metric, so alarming on it just creates alarms that sit in INSUFFICIENT_DATA forever.
+    // metric, and with treatMissingData NOT_BREACHING an alarm on it can never leave OK.
     const allStreams = [
       { stream: rfqRequestFirehoseStream, hasRedshift: true },
       { stream: hardRequestFirehoseStream, hasRedshift: true },

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -156,27 +156,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       aws_ec2.Port.tcp(rsCluster.clusterEndpoint.port)
     );
 
-    new aws_rs.Table(this, 'UnifiedRoutingRequestTable', {
-      cluster: rsCluster,
-      adminUser: creds,
-      databaseName: RS_DATABASE_NAME,
-      tableName: 'UnifiedRoutingRequests',
-      tableColumns: [
-        { name: 'requestId', dataType: RS_DATA_TYPES.UUID, distKey: true },
-        { name: 'offerer', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'tokenIn', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'tokenOut', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'amount', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'type', dataType: RS_DATA_TYPES.TRADE_TYPE },
-        { name: 'swapper', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'tokenInChainId', dataType: RS_DATA_TYPES.INTEGER },
-        { name: 'tokenOutChainId', dataType: RS_DATA_TYPES.INTEGER },
-        { name: 'configs', dataType: RS_DATA_TYPES.ROUTING }, // array as string, e.g. '[DUTCH_LIMIT,CLASSIC]'
-        { name: 'createdAt', dataType: RS_DATA_TYPES.TIMESTAMP },
-        { name: 'createdAtMs', dataType: RS_DATA_TYPES.TIMESTAMP_MS },
-      ],
-    });
-
     const rfqRequestTable = new aws_rs.Table(this, 'RfqRequestTable', {
       cluster: rsCluster,
       adminUser: creds,
@@ -213,35 +192,6 @@ export class AnalyticsStack extends cdk.NestedStack {
         { name: 'type', dataType: RS_DATA_TYPES.TRADE_TYPE },
         { name: 'numOutputs', dataType: RS_DATA_TYPES.INTEGER },
         { name: 'cosigner', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'createdAt', dataType: RS_DATA_TYPES.TIMESTAMP },
-        { name: 'createdAtMs', dataType: RS_DATA_TYPES.TIMESTAMP_MS },
-      ],
-    });
-
-    new aws_rs.Table(this, 'UnifiedRoutingResponseTable', {
-      cluster: rsCluster,
-      adminUser: creds,
-      databaseName: RS_DATABASE_NAME,
-      tableName: 'UnifiedRoutingResponses',
-      tableColumns: [
-        { name: 'quoteId', dataType: RS_DATA_TYPES.UUID },
-        { name: 'requestId', dataType: RS_DATA_TYPES.UUID, distKey: true },
-        { name: 'offerer', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'swapper', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'tokenIn', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'tokenOut', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'amountIn', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'amountOut', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'endAmountIn', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'endAmountOut', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'amountInGasAdjusted', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'amountOutGasAdjusted', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'tokenInChainId', dataType: RS_DATA_TYPES.INTEGER },
-        { name: 'tokenOutChainId', dataType: RS_DATA_TYPES.INTEGER },
-        { name: 'slippage', dataType: RS_DATA_TYPES.SLIPPAGE },
-        { name: 'gasPriceWei', dataType: RS_DATA_TYPES.UINT256 },
-        { name: 'filler', dataType: RS_DATA_TYPES.ADDRESS },
-        { name: 'routing', dataType: RS_DATA_TYPES.ROUTING },
         { name: 'createdAt', dataType: RS_DATA_TYPES.TIMESTAMP },
         { name: 'createdAtMs', dataType: RS_DATA_TYPES.TIMESTAMP_MS },
       ],

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -131,21 +131,7 @@ export class CronStack extends cdk.NestedStack {
       targets: [new aws_events_targets.LambdaFunction(this.redshiftReaperCronLambda)],
     });
 
-    const fillerCBTimestampsTable = new aws_dynamo.Table(this, `${SERVICE_NAME}FillerCBTimestampsTable`, {
-      tableName: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS,
-      partitionKey: {
-        name: 'hash',
-        type: aws_dynamo.AttributeType.STRING,
-      },
-      deletionProtection: true,
-      pointInTimeRecovery: true,
-      contributorInsightsEnabled: true,
-      ...PROD_TABLE_CAPACITY.timestamps,
-    });
-    this.alarmsPerTable(fillerCBTimestampsTable, DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS, chatbotTopic);
-
-    // V2 circuit-breaker state table, separate from the V1 table so the rate-based breaker's
-    // state is isolated for independent rollout/rollback. State is derived and starts empty.
+    // Circuit-breaker state table. State is derived (recomputed each cron run from Redshift).
     const fillerCBTimestampsV2Table = new aws_dynamo.Table(this, `${SERVICE_NAME}FillerCBTimestampsV2Table`, {
       tableName: DYNAMO_TABLE_NAME.FILLER_CB_TIMESTAMPS_V2,
       partitionKey: {

--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -79,24 +79,28 @@ const LatencyWidget = (region: string): LambdaWidget[] =>
     };
   });
 
-const RFQLatencyWidget = (region: string, rfqProviders: string[]): LambdaWidget[] =>
+// Per-filler response times, discovered via SEARCH rather than a hardcoded filler list: the
+// filler set lives in the S3 RFQ config and is only known at runtime, so any list baked in here
+// would be wrong. Series are named RFQ_RESPONSE_TIME_<filler name> (see WebhookQuoter).
+const RFQLatencyWidget = (region: string): LambdaWidget[] =>
   RFQ_SERVICES.map((service) => {
     return {
       height: 11,
       width: 13,
       type: 'metric',
       properties: {
-        metrics: rfqProviders.map((name) => [
-          'Uniswap',
-          `RFQ_RESPONSE_TIME_${name}`,
-          'Service',
-          service.Service,
-          { label: name },
-        ]),
+        metrics: [
+          [
+            {
+              expression: `SEARCH('{Uniswap,Service} Service="${service.Service}" ${Metric.RFQ_RESPONSE_TIME}_', 'p90', 300)`,
+              id: 'rfqResponseTimes',
+              region,
+            },
+          ],
+        ],
         view: 'timeSeries',
         stacked: false,
         region,
-        stat: 'p90',
         period: 300,
         title: `${service.Service} RFQ Response Times P90 | 5 minutes`,
       },
@@ -112,10 +116,7 @@ const QuotesRequestedWidget = (region: string): LambdaWidget[] =>
       x: 0,
       type: 'metric',
       properties: {
-        metrics: [
-          ['Uniswap', 'QUOTE_REQUESTED', 'Service', service.Service],
-          ['.', 'QUOTE_200', '.', '.', { visible: false }],
-        ],
+        metrics: [['Uniswap', Metric.QUOTE_REQUESTED, 'Service', service.Service]],
         view: 'timeSeries',
         region,
         stat: 'Sum',
@@ -307,7 +308,11 @@ const FailingRFQLogsWidget = (region: string, logGroup: string): LambdaWidget =>
     width: 24,
     height: 6,
     properties: {
-      query: `SOURCE '${logGroup}' | fields @timestamp, msg\n| filter quoter = 'WebhookQuoter' and msg like "Error fetching quote"\n| sort @timestamp desc\n| limit 20`,
+      // Insights treats "double quotes" as a field reference, so the old `msg like "..."` matched
+      // nothing at all. The regex needs an inline (?i) flag (Insights rejects a trailing /i) to
+      // catch both WebhookQuoter branches, which differ only in case: 'Error fetching quote from'
+      // and 'Axios error fetching quote from'.
+      query: `SOURCE '${logGroup}' | fields @timestamp, msg\n| filter quoter = 'WebhookQuoter' and msg like /(?i)error fetching quote from/\n| sort @timestamp desc\n| limit 20`,
       region,
       stacked: false,
       view: 'table',
@@ -316,7 +321,13 @@ const FailingRFQLogsWidget = (region: string, logGroup: string): LambdaWidget =>
   };
 };
 
-const RFQFailRatesWidget = (region: string, rfqProviders: string[]): LambdaWidget[] =>
+// Aggregate fail rate across all fillers. WebhookQuoter emits each of these metrics in both bare
+// and per-filler (`_<name>`) form on the same code path, so summing the per-filler series is
+// arithmetically identical to the bare series — using the bare ones keeps this to one expression
+// and, because the names come from the enum, it cannot drift from the emitter. Per-filler
+// breakdown is deliberately not charted here: pairing three metric families per filler is not
+// expressible via SEARCH, and per-filler latency is already visible in RFQLatencyWidget.
+const RFQFailRatesWidget = (region: string): LambdaWidget[] =>
   RFQ_SERVICES.map((service) => {
     return {
       height: 10,
@@ -325,42 +336,25 @@ const RFQFailRatesWidget = (region: string, rfqProviders: string[]): LambdaWidge
       x: 11,
       type: 'metric',
       properties: {
-        metrics: rfqProviders.flatMap((name, i) => {
-          const rfqRequested = i * 3;
-          const rfqFailError = i * 3 + 1;
-          const rfqFailValidation = i * 3 + 2;
-          return [
-            [
-              {
-                expression: `100*((m${rfqFailError}+m${rfqFailValidation})/m${rfqRequested})`,
-                label: name,
-                id: `e${i}`,
-                region,
-              },
-            ],
-            [
-              'Uniswap',
-              `RFQ_REQUESTED_${name}`,
-              'Service',
-              service.Service,
-              { id: `m${rfqRequested}`, visible: false },
-            ],
-            [
-              'Uniswap',
-              `RFQ_FAIl_ERROR_${name}`,
-              'Service',
-              service.Service,
-              { id: `m${rfqFailError}`, visible: false },
-            ],
-            [
-              'Uniswap',
-              `RFQ_FAIL_VALIDATION_${name}`,
-              'Service',
-              service.Service,
-              { id: `m${rfqFailValidation}`, visible: false },
-            ],
-          ];
-        }),
+        metrics: [
+          [
+            {
+              expression: '100*((mFailError+mFailValidation)/mRequested)',
+              label: 'fail rate',
+              id: 'failRate',
+              region,
+            },
+          ],
+          ['Uniswap', Metric.RFQ_REQUESTED, 'Service', service.Service, { id: 'mRequested', visible: false }],
+          ['Uniswap', Metric.RFQ_FAIL_ERROR, 'Service', service.Service, { id: 'mFailError', visible: false }],
+          [
+            'Uniswap',
+            Metric.RFQ_FAIL_VALIDATION,
+            'Service',
+            service.Service,
+            { id: 'mFailValidation', visible: false },
+          ],
+        ],
         view: 'timeSeries',
         stacked: false,
         region,
@@ -474,8 +468,6 @@ export interface DashboardProps extends cdk.NestedStackProps {
 }
 
 // TODO: fetch dynamically from s3?
-const RFQ_PROVIDERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'];
-
 export class ParamDashboardStack extends cdk.NestedStack {
   constructor(scope: Construct, name: string, props: DashboardProps) {
     super(scope, name, props);
@@ -488,15 +480,15 @@ export class ParamDashboardStack extends cdk.NestedStack {
         periodOverride: 'inherit',
         widgets: [
           LatencyWidget(region),
-          RFQLatencyWidget(region, RFQ_PROVIDERS),
+          RFQLatencyWidget(region),
           QuotesRequestedWidget(region),
           ErrorRatesWidget(region),
           LatencyByChainWidget(region),
           QuotesRequestedByChainWidget(region),
           ErrorRatesByChainWidget(region),
-          RFQFailRatesWidget(region, RFQ_PROVIDERS),
+          RFQFailRatesWidget(region),
           LambdaErrorRatesWidget(region, scope),
-          FailingRFQLogsWidget(region, props.quoteLambda.logGroup.logGroupArn),
+          FailingRFQLogsWidget(region, props.quoteLambda.logGroup.logGroupName),
           CircuitBreakerWidgets(region),
         ].flat(),
       }),

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -11,16 +11,6 @@ module.exports = {
       ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
     },
     {
-      TableName: 'FillerCBTimestamps',
-      KeySchema: [
-        { AttributeName: 'hash', KeyType: 'HASH' },
-      ],
-      AttributeDefinitions: [
-        { AttributeName: 'hash', AttributeType: 'S' },
-      ],
-      ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
-    },
-    {
       TableName: 'FillerCBTimestampsV2',
       KeySchema: [
         { AttributeName: 'hash', KeyType: 'HASH' },

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -11,10 +11,8 @@ export const BETA_COMPLIANCE_S3_KEY = 'beta.json';
 
 export const DYNAMO_TABLE_NAME = {
   FILLER_ADDRESS: 'FillerAddress',
-  FILLER_CB_TIMESTAMPS: 'FillerCBTimestamps',
-  // V2 circuit-breaker state table, separate from FILLER_CB_TIMESTAMPS so the rate-based
-  // breaker's state is isolated for independent rollout/rollback. State is derived
-  // (recomputed each cron run from Redshift), so it starts empty.
+  // Circuit-breaker state table for the rate-based breaker. State is derived (recomputed each
+  // cron run from Redshift). The name keeps its V2 suffix because it is the live table name.
   FILLER_CB_TIMESTAMPS_V2: 'FillerCBTimestampsV2',
 };
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,7 +20,6 @@ export const DYNAMO_TABLE_KEY = {
   BLOCK_UNTIL_TIMESTAMP: 'blockUntilTimestamp',
   LAST_EXAMINED_TIMESTAMP: 'lastExaminedTimestamp',
   FADE_WINDOW_START: 'fadeWindowStart',
-  FADED: 'faded',
   CONSECUTIVE_BLOCKS: 'consecutiveBlocks',
 };
 

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -120,7 +120,6 @@ async function main(metrics: MetricsLogger) {
     const now = Math.floor(Date.now() / 1000);
     const updatedTimestamps = calculateNewTimestamps(fillerTimestamps, fillerFadeStats, now, log, metrics);
     log.info({ updatedTimestamps }, 'filler for which to update timestamp');
-    metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_BLOCKED, updatedTimestamps.length, Unit.Count);
     metrics.putMetric(
       Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS,
       countActiveBlocks(fillerTimestamps, updatedTimestamps, now),

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -65,7 +65,6 @@ export enum Metric {
 
   // Metrics for circuit breaker
   CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS = 'CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS',
-  CIRCUIT_BREAKER_V2_BLOCKED = 'CIRCUIT_BREAKER_V2_BLOCKED',
   // Per-filler Laplace-smoothed fade rate over the post-block window (compare to FADE_RATE_BLOCK_THRESHOLD)
   CIRCUIT_BREAKER_V2_FADE_RATE = 'CIRCUIT_BREAKER_V2_FADE_RATE',
   // Per-filler Laplace-smoothed fade rate over the in-flight-during-block cohort, emitted while

--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -101,7 +101,10 @@ export abstract class APIGLambdaHandler<
           const response = await handler(event, context);
           const requestEnd = new Date().getTime();
 
-          // Track handler duration
+          // Track handler duration. metricScope creates a fresh logger per scope, so this one
+          // needs its own setNamespace — the inner handler's logger gets it from the injector.
+          // Without this the metric lands in the aws-embedded-metrics default namespace.
+          metric.setNamespace('Uniswap');
           metric.putDimensions({ [MetricDimension.METHOD]: this.handlerName });
           metric.putMetric(Metric.HANDLER_DURATION, requestEnd - requestStart, MetricLoggerUnit.Milliseconds);
 
@@ -129,6 +132,10 @@ export abstract class APIGLambdaHandler<
             level: process.env.NODE_ENV == 'test' ? bunyan.FATAL + 1 : bunyan.INFO,
             requestId: context.awsRequestId,
           });
+
+          // The injector sets this too, but validation can fail (and emit QUOTE_500) before the
+          // injector runs, so set it here to keep those puts out of the default namespace.
+          metric.setNamespace('Uniswap');
 
           let requestBody: ReqBody;
           let requestQueryParams: ReqQueryParams;

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -13,7 +13,7 @@ import {
   PostQuoteRequestBody,
   PostQuoteRequestBodyJoi,
   PostQuoteResponseWithAllQuotes,
-  URAResponseJoi,
+  PostQuoteResponseWithAllQuotesJoi,
 } from './schema';
 
 export class QuoteHandler extends APIGLambdaHandler<
@@ -83,6 +83,6 @@ export class QuoteHandler extends APIGLambdaHandler<
   }
 
   protected responseBodySchema(): Joi.ObjectSchema | null {
-    return URAResponseJoi;
+    return PostQuoteResponseWithAllQuotesJoi;
   }
 }

--- a/lib/handlers/quote/schema.ts
+++ b/lib/handlers/quote/schema.ts
@@ -57,7 +57,9 @@ export type PostQuoteResponseWithAllQuotes = PostQuoteResponse & {
   allQuotes?: PostQuoteResponse[];
 };
 
-export const URAResponseJoi = Joi.object({
+// The response body this service returns to whoever called POST /quote. Named for its shape, not
+// its consumer: it was URA, it is now the Trading API, and the name should not have to change again.
+export const PostQuoteResponseWithAllQuotesJoi = Joi.object({
   chainId: FieldValidator.chainId.required(),
   requestId: FieldValidator.uuid.required(),
   tokenIn: Joi.string().required(),

--- a/lib/handlers/quote/schema.ts
+++ b/lib/handlers/quote/schema.ts
@@ -57,8 +57,6 @@ export type PostQuoteResponseWithAllQuotes = PostQuoteResponse & {
   allQuotes?: PostQuoteResponse[];
 };
 
-// The response body this service returns to whoever called POST /quote. Named for its shape, not
-// its consumer: it was URA, it is now the Trading API, and the name should not have to change again.
 export const PostQuoteResponseWithAllQuotesJoi = Joi.object({
   chainId: FieldValidator.chainId.required(),
   requestId: FieldValidator.uuid.required(),


### PR DESCRIPTION
Follow-on cleanup after #471. **−206 lines, −31 CloudFormation resources** (22 alarms, 2 firehose streams, 2 log destinations, 1 DynamoDB table, 2 Redshift table custom resources + their 2 provider lambdas, 3 outputs), with no behavioural change to any live path.

Six items, grouped: two dead subsystems, one alarm-shape fix, and three dashboard widgets that were rendering nothing at all.

**URA is deprecated** and the Trading API is now the caller of `POST /quote`, so this removes the URA ingestion pipeline outright rather than leaving hooks for it to resume.

## Deletions

**1. Unified Routing API ingestion pipeline.** Both delivery streams had taken 0 records for ~148 days, and their last in-repo Redshift consumer left with the synthetic switch. Removes 2 streams, 2 cross-account `CfnDestination`s, the `URA_ACCOUNT` destination-policy block and env plumbing, 3 `CfnOutput`s, 2 `firehoseRole` write grants, and both Redshift table constructs.

The two Redshift tables are **orphaned, not dropped.** `@aws-cdk/aws-redshift-alpha` hardcodes `removalPolicy: RETAIN` before spreading props ([table.js:140](https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/aws-redshift-alpha/lib/table.ts)) and we never override it, so `UnifiedRoutingRequests` / `UnifiedRoutingResponses` survive the deploy, and `redshift-reaper` keeps pruning them by name. Two consequences of that worth being explicit about:

- The reaper prunes to a **2-week window**, so with ingestion gone the orphaned tables age to empty ~14 days after deploy. The durable URA history is the S3 buckets, not Redshift.
- If the tables are ever dropped, remove `unifiedroutingrequests`/`unifiedroutingresponses` from `TABLES_TO_CLEAN` in `lib/cron/redshift-reaper.ts` **in the same change**. They are first in a sequential fail-fast loop, so a missing table aborts the run and silently stops pruning `rfqrequests`/`rfqresponses`/`postedorders`.

Each Table owns its own custom-resource provider lambda — verified that every surviving table has a dedicated one, so only the two URA providers were removed and no shared provider was touched. Unlike the tables, the two `CfnDestination`s are genuinely **deleted** (the L1 construct has no RETAIN default) — intended, since the streams they target go too; the `URA_*_DESTINATION_*` Secrets Manager entries in the old URA accounts become stale pointers.

**Both S3 buckets stay.** They carry `grantRead(dsRole)`, so dropping them would revoke the data-science role's access to that same history. No `data-eng-workflows` change is needed before or after this deploy: its `unified_routing_*` load YAMLs read these retained buckets, and every URA consumer in that repo is BigQuery-side. Dropping those now-dead YAMLs is optional follow-up (precedent: data-eng `989fa33`). Retiring the buckets and the orphaned tables is a data decision, best done as its own PR with data-eng.

**2. v1 circuit-breaker table** `FillerCBTimestamps` + its 6 alarms. V2 cut over 2026-07-15 and writes daily; the surviving `TimestampRepository` reads only V2. The stronger fact: the v1 cron, injector, and S3 provider were deleted **2024-07-31** (`95c9452`), so the table has had zero readers or writers for two years — restoring a v1 breaker would mean resurrecting that code, not reading these 38 rows.

> The trap here: `PROD_TABLE_CAPACITY.timestamps` is **shared by both tables**. Removing it along with the v1 table would have silently changed V2's provisioned capacity, so it stays.

**5. Gate Redshift firehose alarms on having a Redshift destination.** `allStreams` now carries a `hasRedshift` flag, so the three S3-only streams (`activeOrder`, `unimindResponse`, `unimindParameterUpdate`) stop getting `DeliveryToRedshift` alarms that can never fire.

## Dashboard fixes

**7. `RFQ_PROVIDERS` was the literal letters `['A'…'L']`** — placeholders, so every per-filler series it built had no emitter and two widgets were permanently blank. The real filler set lives in the S3 RFQ config and is only known at runtime, so it *cannot* be listed at synth time. `RFQLatencyWidget` now discovers its series with a `SEARCH()` expression, mirroring the existing `CIRCUIT_BREAKER_V2_*` widgets.

`RFQFailRatesWidget` switches to the bare aggregate metrics. WebhookQuoter emits each of these in both bare and `_<filler>` form on adjacent lines in the same per-endpoint scope, so summing the per-filler series is arithmetically identical to the bare series — and taking the names from the `Metric` enum means it can't drift again. **Tradeoff:** per-filler fail-rate breakdown is lost, since pairing three metric families per filler isn't expressible via `SEARCH`. Per-filler latency is still charted. One thing to eyeball on the beta dashboard after deploy: `SEARCH` token-matches on `_`, so the bare aggregate `RFQ_RESPONSE_TIME` series may render as one extra line alongside the per-filler ones in the latency widget.

**8. Three more broken things.** The `RFQ_FAIl_ERROR` typo (lowercase L) disappears with the rewrite above. The *Failing RFQ Logs* widget had two independent bugs: its filter used `"double quotes"`, which Insights parses as a **field reference** rather than a string literal, and it was handed a log group **ARN** where `SOURCE` needs a **name**. The filter is now `like /(?i)error fetching quote from/` — the inline `(?i)` matters because Insights rejects a trailing `/i`, and the two WebhookQuoter branches (`Error fetching quote from…` / `Axios error fetching quote from…`) differ only in case. Also drops an invisible dead `QUOTE_200` series.

**9. Metric plumbing.** Deletes `CIRCUIT_BREAKER_V2_BLOCKED` — it counted fillers whose timestamps were updated, not blocks, and since every branch of `calculateNewTimestamps` pushes exactly one row it was numerically identical to `CIRCUIT_BREAKER_V2_FILLERS_EVALUATED`. Adds the missing `setNamespace('Uniswap')` in `api-handler.ts`: `metricScope` builds a fresh logger per scope, so `HANDLER_DURATION` and the pre-injector `QUOTE_500` puts were landing in the `aws-embedded-metrics` default namespace, invisible to every dashboard.

Two notes for whoever graphs these next: `Uniswap/HANDLER_DURATION` is keyed on a **`method`** dimension, not `Service`, and its history does not migrate — the old default-namespace series goes flat rather than moving.

## Also: `URAResponseJoi` renamed

It was never URA-specific — it is the response body `POST /quote` returns to its caller, which is now the Trading API. Renamed to `PostQuoteResponseWithAllQuotesJoi`, matching the existing `PostQuoteResponseWithAllQuotes` type, so it is named for its shape rather than a consumer that keeps changing.

## ⚠️ Contract mismatch found while confirming that (not fixed here)

Comparing our response schema against what TAPI actually validates, in `packages/services/trading/src/core/quoters/rfq/schema.ts`:

| Field | This service returns | TAPI's `RFQ_RESPONSE_SCHEMA` |
|---|---|---|
| `filler` | **optional** | **required** |
| `requestId` | required | optional |

If `POST /quote` ever returns a 200 without `filler`, TAPI rejects it as a validation error. It looks unreachable today — `RfqResponseJoi` now requires `filler` on the inbound MM side, so a winning quote always carries one — but the two schemas disagree, and tightening ours to `required` needs a check that no handler path omits it. Worth a follow-up rather than a blind change here.

## Verification

- `yarn build` clean; `yarn lint` 0 errors (76 pre-existing `no-explicit-any` warnings); `yarn test:unit` **236 passed / 27 suites**
- `cdk synth --all` semantic diff vs `main`, both sides synthed **twice from a shared converged `cdk.context.json`** (a cold AZ lookup otherwise makes the `maxAzs: 3` VPC emit dummy subnets and fills the diff with phantom EC2/NAT churn):
  - **341 → 310 resources**, no templates added or removed, **no resource changed type**
  - analytics stack: −16 alarms, −2 firehose streams, −2 log destinations, −2 `Custom::RedshiftDatabaseQuery`, −2 provider lambdas
  - cron stack: −6 alarms, −1 DynamoDB table
  - outputs: −`UraAccount`, −`uraRequestDestinationName`, −`uraResponseDestinationName`
  - Only additions are rev'd `Quote`/`HardQuote` lambda versions — expected, both bundle `api-handler.ts`
  - Verified `RfqRequests`/`RfqResponses` and the other Redshift tables are still synthesized; only the two URA ones left the template
  - Independently re-verified pre-merge with a second baseline/branch double-synth: net **−31 resources per deployed stack, identical in beta and prod**; the V2 circuit-breaker table is byte-identical including `ProvisionedThroughput {100, 10}`; the live `activeOrderStream` and FirehoseStack are untouched; the only IAM churn is the two URA-bucket grants leaving `FirehoseRoleDefaultPolicy`; the 3 removed outputs set no `exportName`, so nothing can `Fn::ImportValue` them

## Post-deploy

**Orphaned, with data *and bill* intact.** The v1 `FillerCBTimestamps` table (38 frozen rows) stays PROVISIONED at 100 RCU / 10 WCU with PITR + Contributor Insights in **both** beta `801328487475` and prod `830217277613` (~$14/mo per account), now unmanaged and with no remaining in-repo pointer. Deleting it later is a two-step: `aws dynamodb update-table --no-deletion-protection-enabled`, then `delete-table`. The two URA Redshift tables are likewise orphaned (see item 1 for how long their data actually lasts). Until deleted, the name `FillerCBTimestamps` cannot be reused by any CDK construct.

**On-call heads-up: 22 alarms disappear, two of them from the ALARM state.** `UniswapXParameterizationAPI-SEV3-MissingRecords-uraRequestStream` and `…-MissingRecords-UnifiedRoutingResponseStream` alarm on `IncomingRecords < 1` over 12h with `treatMissingData: BREACHING`, and the streams have taken 0 records for ~148 days — so both are expected to be in ALARM at deploy time. Their disappearance is the intended noise reduction, not a silenced signal. The other 20 are OK/INSUFFICIENT_DATA.

**Rollback:** a plain `git revert` of this PR is **not deployable**. Re-adding any of the three orphaned constructs fails on `CREATE` of an existing name — and while the DynamoDB table could be re-adopted via CFN import, a `Custom::RedshiftDatabaseQuery` cannot, so a full revert would need the orphans manually renamed or dropped first. In practice a full revert should never be needed: all runtime behaviour in this PR lives in `bin/stacks/param-dashboard-stack.ts` and `lib/handlers/base/api-handler.ts`, and a file-scoped revert of those two re-adds zero constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
