### PR TITLE
feat, test: RFQ latency metrics

### DIFF
--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -63,6 +63,26 @@ export enum Metric {
   RFQ_COUNT_3 = 'RFQ_COUNT_3',
   RFQ_COUNT_4_PLUS = 'RFQ_COUNT_4_PLUS',
 
+  // Latency-attribution metrics.
+  // Time spent resolving webhook config + circuit-breaker state before fan-out.
+  RFQ_PHASE_ENDPOINT_STATUSES = 'RFQ_PHASE_ENDPOINT_STATUSES',
+  // Time spent resolving the compliance exclusion map before fan-out.
+  RFQ_PHASE_COMPLIANCE = 'RFQ_PHASE_COMPLIANCE',
+  // Wall time the request blocks on the webhook fan-out Promise.all.
+  RFQ_PHASE_FANOUT = 'RFQ_PHASE_FANOUT',
+  // Fan-out wall time minus the latency of the last response that produced a usable
+  // quote — the time every swapper waits for endpoints that contributed nothing. Equals
+  // the full fan-out wall when no endpoint produced a usable quote.
+  RFQ_WASTED_WAIT = 'RFQ_WASTED_WAIT',
+  // Emitted once per fan-out for the endpoint that finished last (set the wall).
+  RFQ_STRAGGLER = 'RFQ_STRAGGLER',
+  // Webhook attempts that hit the axios timeout (ECONNABORTED). A strict subset of
+  // RFQ_FAIL_ERROR, split out because timeouts are the wasted-wait driver.
+  RFQ_TIMEOUT = 'RFQ_TIMEOUT',
+  // End-to-end handler latency on every response path (200, 404, thrown errors), unlike
+  // QUOTE_LATENCY which fires only on 200s and is blind to slow 404s.
+  QUOTE_E2E_LATENCY = 'QUOTE_E2E_LATENCY',
+
   // Metrics for circuit breaker
   CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS = 'CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS',
   // Per-filler Laplace-smoothed fade rate over the post-block window (compare to FADE_RATE_BLOCK_THRESHOLD)
@@ -90,6 +110,8 @@ type MetricNeedingContext =
   | Metric.RFQ_FAIL_VALIDATION
   | Metric.RFQ_NON_QUOTE
   | Metric.RFQ_FAIL_ERROR
+  | Metric.RFQ_STRAGGLER
+  | Metric.RFQ_TIMEOUT
   | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS
   | Metric.CIRCUIT_BREAKER_V2_FADE_RATE
   | Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE;

--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -56,124 +56,131 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     metric.putMetric(Metric.QUOTE_REQUESTED, 1, MetricLoggerUnit.Count);
 
-    const provider = chainIdRpcMap.get(requestBody.tokenInChainId);
+    // QUOTE_LATENCY below fires only on successful order posts (and is alarmed on). The
+    // finally makes this metric cover every exit path — no-quote throws, cosigner
+    // mismatches, and order-service failures included.
+    try {
+      const provider = chainIdRpcMap.get(requestBody.tokenInChainId);
 
-    const orderParser = new UniswapXOrderParser();
-    const orderType: OrderType = orderParser.getOrderTypeFromEncoded(
-      requestBody.encodedInnerOrder,
-      requestBody.tokenInChainId
-    );
-    const request = HardQuoteRequest.fromHardRequestBody(requestBody, orderType);
-    // re-create KmsClient every call to avoid clock skew issue
-    // https://github.com/aws/aws-sdk-js-v3/issues/6400
-    const kmsKeyId = checkDefined(process.env.KMS_KEY_ID, 'KMS_KEY_ID is not defined');
-    const awsRegion = checkDefined(process.env.REGION, 'REGION is not defined');
-    const cosigner = new KmsSigner(new KMSClient({ region: awsRegion }), kmsKeyId);
-    const cosignerAddress = await cosigner.getAddress();
+      const orderParser = new UniswapXOrderParser();
+      const orderType: OrderType = orderParser.getOrderTypeFromEncoded(
+        requestBody.encodedInnerOrder,
+        requestBody.tokenInChainId
+      );
+      const request = HardQuoteRequest.fromHardRequestBody(requestBody, orderType);
+      // re-create KmsClient every call to avoid clock skew issue
+      // https://github.com/aws/aws-sdk-js-v3/issues/6400
+      const kmsKeyId = checkDefined(process.env.KMS_KEY_ID, 'KMS_KEY_ID is not defined');
+      const awsRegion = checkDefined(process.env.REGION, 'REGION is not defined');
+      const cosigner = new KmsSigner(new KMSClient({ region: awsRegion }), kmsKeyId);
+      const cosignerAddress = await cosigner.getAddress();
 
-    // we dont have access to the cosigner key, throw
-    if (request.order.info.cosigner !== cosignerAddress) {
-      log.error({ cosignerInReq: request.order.info.cosigner, expected: cosignerAddress }, 'Unknown cosigner');
-      throw new UnknownOrderCosignerError();
-    }
-    // Instead of decoding the order, we rely on frontend passing in the requestId
-    //   from indicative quote
-    log.info({
-      eventType: 'HardRequest',
-      body: {
-        requestId: request.requestId,
-        quoteId: request.quoteId,
-        tokenInChainId: request.tokenInChainId,
-        tokenOutChainId: request.tokenOutChainId,
-        tokenIn: request.tokenIn,
-        tokenOut: request.tokenOut,
-        offerer: request.swapper,
-        amount: request.amount.toString(),
-        type: TradeType[request.type],
-        numOutputs: request.numOutputs,
-        cosigner: request.order.info.cosigner,
-        createdAt: timestampInMstoSeconds(start),
-        createdAtMs: start.toString(),
-      },
-    });
+      // we dont have access to the cosigner key, throw
+      if (request.order.info.cosigner !== cosignerAddress) {
+        log.error({ cosignerInReq: request.order.info.cosigner, expected: cosignerAddress }, 'Unknown cosigner');
+        throw new UnknownOrderCosignerError();
+      }
+      // Instead of decoding the order, we rely on frontend passing in the requestId
+      //   from indicative quote
+      log.info({
+        eventType: 'HardRequest',
+        body: {
+          requestId: request.requestId,
+          quoteId: request.quoteId,
+          tokenInChainId: request.tokenInChainId,
+          tokenOutChainId: request.tokenOutChainId,
+          tokenIn: request.tokenIn,
+          tokenOut: request.tokenOut,
+          offerer: request.swapper,
+          amount: request.amount.toString(),
+          type: TradeType[request.type],
+          numOutputs: request.numOutputs,
+          cosigner: request.order.info.cosigner,
+          createdAt: timestampInMstoSeconds(start),
+          createdAtMs: start.toString(),
+        },
+      });
 
-    let bestQuote;
-    if (!requestBody.forceOpenOrder) {
-      const result = await getBestQuote(quoters, request.toQuoteRequest(), log, metric, provider, RESPONSE_LOG_TYPE);
-      bestQuote = result.bestQuote;
-      if (!bestQuote && !requestBody.allowNoQuote) {
-        if (!requestBody.allowNoQuote) {
-          throw new NoQuotesAvailable();
+      let bestQuote;
+      if (!requestBody.forceOpenOrder) {
+        const result = await getBestQuote(quoters, request.toQuoteRequest(), log, metric, provider, RESPONSE_LOG_TYPE);
+        bestQuote = result.bestQuote;
+        if (!bestQuote && !requestBody.allowNoQuote) {
+          if (!requestBody.allowNoQuote) {
+            throw new NoQuotesAvailable();
+          }
         }
       }
-    }
 
-    let cosignerData: CosignerData | V3CosignerData;
-    if (bestQuote) {
-      cosignerData = await getCosignerData(request, bestQuote, orderType, provider);
-      log.info({ bestQuote: bestQuote }, 'bestQuote');
-    } else {
-      cosignerData = await getDefaultCosignerData(request, orderType, provider);
-      log.info({ cosignerData: cosignerData }, 'open order with default cosignerData');
-    }
-
-    const cosignedOrder = await createCosignedOrder(cosigner, request, cosignerData);
-    try {
-      metric.putMetric(Metric.QUOTE_POST_ATTEMPT, 1, MetricLoggerUnit.Count);
-      // if no quote and creating open order, create random new quoteId
-      const response = await orderServiceProvider.postOrder({
-        order: cosignedOrder,
-        signature: request.innerSig,
-        quoteId: bestQuote?.quoteId ?? request.quoteId ?? request.requestId,
-        requestId: request.requestId,
-      });
-      if (response.statusCode == 200 || response.statusCode == 201) {
-        metric.putMetric(Metric.QUOTE_200, 1, MetricLoggerUnit.Count);
-        metric.putMetric(Metric.QUOTE_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
-        const hardResponse = createHardQuoteResponse(request, cosignedOrder);
-        if (!bestQuote) {
-          // The RFQ responses are logged in getBestQuote()
-          // we log the Open Orders here
-          log.info({
-            eventType: RESPONSE_LOG_TYPE,
-            body: {
-              ...hardResponse.toLog(),
-              offerer: request.swapper,
-            },
-          });
-        }
-        return {
-          statusCode: 200,
-          body: hardResponse.toResponseJSON(),
-        };
+      let cosignerData: CosignerData | V3CosignerData;
+      if (bestQuote) {
+        cosignerData = await getCosignerData(request, bestQuote, orderType, provider);
+        log.info({ bestQuote: bestQuote }, 'bestQuote');
       } else {
-        const error = response as ErrorResponse;
-        log.error({ error: error }, 'Error posting order');
+        cosignerData = await getDefaultCosignerData(request, orderType, provider);
+        log.info({ cosignerData: cosignerData }, 'open order with default cosignerData');
+      }
 
-        // user error should not be alerted on
-        if (error.detail != POST_ORDER_ERROR_REASON.INSUFFICIENT_FUNDS) {
-          metric.putMetric(Metric.QUOTE_POST_ERROR, 1, MetricLoggerUnit.Count);
-        }
-        // Only a 4xx from the order service is a genuine rejection of the
-        // order. Anything else (timeouts, 5xx) is indeterminate — the order
-        // service may have accepted the order after we stopped waiting — and
-        // rewriting it to 400 makes clients treat a live, fillable order as
-        // rejected (SWAP-2839).
-        if (error.statusCode >= 400 && error.statusCode < 500) {
-          metric.putMetric(Metric.QUOTE_400, 1, MetricLoggerUnit.Count);
+      const cosignedOrder = await createCosignedOrder(cosigner, request, cosignerData);
+      try {
+        metric.putMetric(Metric.QUOTE_POST_ATTEMPT, 1, MetricLoggerUnit.Count);
+        // if no quote and creating open order, create random new quoteId
+        const response = await orderServiceProvider.postOrder({
+          order: cosignedOrder,
+          signature: request.innerSig,
+          quoteId: bestQuote?.quoteId ?? request.quoteId ?? request.requestId,
+          requestId: request.requestId,
+        });
+        if (response.statusCode == 200 || response.statusCode == 201) {
+          metric.putMetric(Metric.QUOTE_200, 1, MetricLoggerUnit.Count);
+          metric.putMetric(Metric.QUOTE_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+          const hardResponse = createHardQuoteResponse(request, cosignedOrder);
+          if (!bestQuote) {
+            // The RFQ responses are logged in getBestQuote()
+            // we log the Open Orders here
+            log.info({
+              eventType: RESPONSE_LOG_TYPE,
+              body: {
+                ...hardResponse.toLog(),
+                offerer: request.swapper,
+              },
+            });
+          }
+          return {
+            statusCode: 200,
+            body: hardResponse.toResponseJSON(),
+          };
+        } else {
+          const error = response as ErrorResponse;
+          log.error({ error: error }, 'Error posting order');
+
+          // user error should not be alerted on
+          if (error.detail != POST_ORDER_ERROR_REASON.INSUFFICIENT_FUNDS) {
+            metric.putMetric(Metric.QUOTE_POST_ERROR, 1, MetricLoggerUnit.Count);
+          }
+          // Only a 4xx from the order service is a genuine rejection of the
+          // order. Anything else (timeouts, 5xx) is indeterminate — the order
+          // service may have accepted the order after we stopped waiting — and
+          // rewriting it to 400 makes clients treat a live, fillable order as
+          // rejected.
+          if (error.statusCode >= 400 && error.statusCode < 500) {
+            metric.putMetric(Metric.QUOTE_400, 1, MetricLoggerUnit.Count);
+            return {
+              ...error,
+              statusCode: 400,
+            };
+          }
+          metric.putMetric(Metric.QUOTE_500, 1, MetricLoggerUnit.Count);
           return {
             ...error,
-            statusCode: 400,
+            statusCode: 500,
           };
         }
-        metric.putMetric(Metric.QUOTE_500, 1, MetricLoggerUnit.Count);
-        return {
-          ...error,
-          statusCode: 500,
-        };
+      } catch (e) {
+        throw new OrderPostError((e as Error).message);
       }
-    } catch (e) {
-      throw new OrderPostError((e as Error).message);
+    } finally {
+      metric.putMetric(Metric.QUOTE_E2E_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
     }
   }
 

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -35,43 +35,50 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     metric.putMetric(Metric.QUOTE_REQUESTED, 1, MetricLoggerUnit.Count);
 
-    const provider = chainIdRpcMap.get(requestBody.tokenInChainId);
+    // QUOTE_LATENCY below fires only on 200s (and is alarmed on), so it cannot see slow
+    // 404s — which take the full webhook fan-out just like successes. The finally makes
+    // this metric cover every exit path, including the NoQuotesAvailable throw.
+    try {
+      const provider = chainIdRpcMap.get(requestBody.tokenInChainId);
 
-    const request = QuoteRequest.fromRequestBody(requestBody);
-    log.info({
-      eventType: 'QuoteRequest',
-      body: {
-        requestId: request.requestId,
-        tokenInChainId: request.tokenInChainId,
-        tokenOutChainId: request.tokenOutChainId,
-        offerer: request.swapper,
-        tokenIn: request.tokenIn,
-        tokenOut: request.tokenOut,
-        amount: request.amount.toString(),
-        type: TradeType[request.type],
-        createdAt: timestampInMstoSeconds(start),
-        createdAtMs: start.toString(),
-        numOutputs: request.numOutputs,
-      },
-    });
+      const request = QuoteRequest.fromRequestBody(requestBody);
+      log.info({
+        eventType: 'QuoteRequest',
+        body: {
+          requestId: request.requestId,
+          tokenInChainId: request.tokenInChainId,
+          tokenOutChainId: request.tokenOutChainId,
+          offerer: request.swapper,
+          tokenIn: request.tokenIn,
+          tokenOut: request.tokenOut,
+          amount: request.amount.toString(),
+          type: TradeType[request.type],
+          createdAt: timestampInMstoSeconds(start),
+          createdAtMs: start.toString(),
+          numOutputs: request.numOutputs,
+        },
+      });
 
-    const { bestQuote, allQuotes } = await getBestQuote(quoters, request, log, metric, provider);
-    if (!bestQuote) {
-      metric.putMetric(Metric.QUOTE_404, 1, MetricLoggerUnit.Count);
-      throw new NoQuotesAvailable();
+      const { bestQuote, allQuotes } = await getBestQuote(quoters, request, log, metric, provider);
+      if (!bestQuote) {
+        metric.putMetric(Metric.QUOTE_404, 1, MetricLoggerUnit.Count);
+        throw new NoQuotesAvailable();
+      }
+
+      log.info({ bestQuote: bestQuote }, 'bestQuote');
+
+      metric.putMetric(Metric.QUOTE_200, 1, MetricLoggerUnit.Count);
+      metric.putMetric(Metric.QUOTE_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+      return {
+        statusCode: 200,
+        body: {
+          ...bestQuote.toResponseJSON(),
+          allQuotes: allQuotes.map((q) => q.toResponseJSON()),
+        },
+      };
+    } finally {
+      metric.putMetric(Metric.QUOTE_E2E_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
     }
-
-    log.info({ bestQuote: bestQuote }, 'bestQuote');
-
-    metric.putMetric(Metric.QUOTE_200, 1, MetricLoggerUnit.Count);
-    metric.putMetric(Metric.QUOTE_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
-    return {
-      statusCode: 200,
-      body: {
-        ...bestQuote.toResponseJSON(),
-        allQuotes: allQuotes.map((q) => q.toResponseJSON()),
-      },
-    };
   }
 
   protected requestBodySchema(): Joi.ObjectSchema | null {

--- a/lib/handlers/shared/quote-injector.ts
+++ b/lib/handlers/shared/quote-injector.ts
@@ -147,6 +147,12 @@ export function buildQuoteRequestInjected<ReqBody extends { tokenInChainId: numb
     ...metricDimension,
     ChainId: requestBody.tokenInChainId.toString(),
   });
+  // Third, dimensionless rollup set (serializes as `[]` in the EMF Dimensions array).
+  // CloudWatch percentiles cannot be merged across dimension values post-hoc, and the
+  // latency dashboard's headline needs one combined all-services stream; because soft and
+  // hard emit the same metric names, their dimensionless streams merge into a single
+  // series per metric.
+  metricsLogger.putDimensions({});
   const metric = new AWSMetricsLogger(metricsLogger);
   setGlobalMetric(metric);
 

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -26,6 +26,36 @@ import { FillerAddressRepository } from '../repositories/filler-address-reposito
 import { RFQValidator } from '../util/rfqValidator';
 import { timestampInMstoISOString } from '../util/time';
 
+// Per-endpoint result of one webhook fan-out attempt. `response` is null when the endpoint
+// was tried but produced nothing usable (non-quote, validation failure, error, timeout);
+// attempts skipped before any request was sent (chain/protocol mismatch) yield no outcome.
+export interface FetchOutcome {
+  response: QuoteResponse | null;
+  name: string;
+  latencyMs: number;
+  timedOut: boolean;
+}
+
+// Derives the wasted-wait and straggler stats for one fan-out. Wasted wait is the time
+// between the last response that produced a usable quote and the fan-out returning — the
+// wait endpoints that contributed nothing cost every swapper. When nothing usable came
+// back the whole fan-out wall was wasted. The straggler is whichever endpoint finished
+// last, since it alone set the wall. Callers must pass a non-empty outcomes array.
+export function deriveFanoutStats(
+  outcomes: FetchOutcome[],
+  fanoutWallMs: number
+): { wastedWaitMs: number; stragglerName: string } {
+  const usable = outcomes.filter((o) => o.response !== null);
+  const lastUsefulMs = usable.length > 0 ? Math.max(...usable.map((o) => o.latencyMs)) : 0;
+  const stragglerName = outcomes.reduce((last, o) => (o.latencyMs > last.latencyMs ? o : last)).name;
+  return {
+    // The last usable response can land after Promise.all resolves its wall-clock
+    // measurement point; clamp instead of reporting negative waste.
+    wastedWaitMs: Math.max(0, fanoutWallMs - lastUsefulMs),
+    stragglerName,
+  };
+}
+
 // Quoter which fetches quotes from http endpoints
 // endpoints must return well-formed QuoteResponse JSON
 export class WebhookQuoter implements Quoter {
@@ -46,8 +76,13 @@ export class WebhookQuoter implements Quoter {
     request: QuoteRequest,
     provider?: ethers.providers.StaticJsonRpcProvider
   ): Promise<QuoteResponse[]> {
+    const beforeStatuses = Date.now();
     const statuses = await this.getEndpointStatuses();
+    metric.putMetric(Metric.RFQ_PHASE_ENDPOINT_STATUSES, Date.now() - beforeStatuses, MetricLoggerUnit.Milliseconds);
+
+    const beforeCompliance = Date.now();
     const endpointToAddrsMap = await this.complianceProvider.getEndpointToExcludedAddrsMap();
+    metric.putMetric(Metric.RFQ_PHASE_COMPLIANCE, Date.now() - beforeCompliance, MetricLoggerUnit.Milliseconds);
     // Ignore endpoint status if token is permissioned
     const isPermissionedToken =
       PermissionedTokenValidator.isPermissionedToken(request.tokenIn, request.tokenInChainId) ||
@@ -68,7 +103,19 @@ export class WebhookQuoter implements Quoter {
       `Fetching quotes from ${enabledEndpoints.length} endpoints and notifying disabled endpoints`
     );
 
-    const quotes = await Promise.all(enabledEndpoints.map((e) => this.fetchQuote(e, request, provider)));
+    const beforeFanout = Date.now();
+    const outcomes = (await Promise.all(enabledEndpoints.map((e) => this.fetchQuote(e, request, provider)))).filter(
+      (o): o is FetchOutcome => o !== null
+    );
+    const fanoutWallMs = Date.now() - beforeFanout;
+    metric.putMetric(Metric.RFQ_PHASE_FANOUT, fanoutWallMs, MetricLoggerUnit.Milliseconds);
+
+    if (outcomes.length > 0) {
+      const { wastedWaitMs, stragglerName } = deriveFanoutStats(outcomes, fanoutWallMs);
+      metric.putMetric(Metric.RFQ_WASTED_WAIT, wastedWaitMs, MetricLoggerUnit.Milliseconds);
+      metric.putMetric(Metric.RFQ_STRAGGLER, 1, MetricLoggerUnit.Count);
+      metric.putMetric(metricContext(Metric.RFQ_STRAGGLER, stragglerName), 1, MetricLoggerUnit.Count);
+    }
 
     // should not await and block
     if (!isPermissionedToken) {
@@ -77,7 +124,7 @@ export class WebhookQuoter implements Quoter {
       });
     }
 
-    return quotes.filter((q) => q !== null) as QuoteResponse[];
+    return outcomes.filter((o) => o.response !== null).map((o) => o.response) as QuoteResponse[];
   }
 
   public type(): QuoterType {
@@ -89,11 +136,14 @@ export class WebhookQuoter implements Quoter {
     return this.circuitBreakerProvider.getEndpointStatuses(endpoints);
   }
 
+  // Returns null only for attempts skipped before any request was sent (chain/protocol
+  // mismatch); once a webhook request goes out, every path returns a FetchOutcome so the
+  // caller can attribute fan-out wall time (response is null on non-quote/invalid/error).
   private async fetchQuote(
     config: WebhookConfiguration,
     request: QuoteRequest,
     provider?: ethers.providers.StaticJsonRpcProvider
-  ): Promise<QuoteResponse | null> {
+  ): Promise<FetchOutcome | null> {
     const { name, endpoint, headers } = config;
     // Child logger so every log line in this RFQ attempt carries the request id.
     // quoteId is added once it's generated below (it's per-RFQ, so it doesn't exist
@@ -228,7 +278,7 @@ export class WebhookQuoter implements Quoter {
             responseType: WebhookResponseType.NON_QUOTE,
           })
         );
-        return null;
+        return { response: null, name, latencyMs: rawResponse.latencyMs, timedOut: false };
       }
 
       // RFQ provider response failed validation
@@ -252,7 +302,7 @@ export class WebhookQuoter implements Quoter {
             validationError: error,
           })
         );
-        return null;
+        return { response: null, name, latencyMs: rawResponse.latencyMs, timedOut: false };
       }
 
       // Verify the market maker echoed back the obfuscated requestId we sent on the wire. The
@@ -278,7 +328,7 @@ export class WebhookQuoter implements Quoter {
             mismatchedRequestId: hookResponse.data?.requestId,
           })
         );
-        return null;
+        return { response: null, name, latencyMs: rawResponse.latencyMs, timedOut: false };
       }
 
       const quote = request.type === TradeType.EXACT_INPUT ? response.amountOut : response.amountIn;
@@ -336,7 +386,7 @@ export class WebhookQuoter implements Quoter {
         });
       }
 
-      return response;
+      return { response, name, latencyMs: rawResponse.latencyMs, timedOut: false };
     } catch (e) {
       metric.putMetric(Metric.RFQ_FAIL_ERROR, 1, MetricLoggerUnit.Count);
       metric.putMetric(metricContext(Metric.RFQ_FAIL_ERROR, name), 1, MetricLoggerUnit.Count);
@@ -344,13 +394,20 @@ export class WebhookQuoter implements Quoter {
         responseTime: timestampInMstoISOString(Date.now()),
         latencyMs: Date.now() - before,
       };
+      const timedOut = e instanceof AxiosError && e.code === 'ECONNABORTED';
+      // Timeouts are a strict subset of RFQ_FAIL_ERROR, split out because an endpoint that
+      // times out holds the fan-out open for the full timeout budget — it is the
+      // wasted-wait driver, while other errors typically fail fast.
+      if (timedOut) {
+        metric.putMetric(Metric.RFQ_TIMEOUT, 1, MetricLoggerUnit.Count);
+        metric.putMetric(metricContext(Metric.RFQ_TIMEOUT, name), 1, MetricLoggerUnit.Count);
+      }
       if (e instanceof AxiosError) {
         log.error(
           { endpoint, status: e.response?.status?.toString() },
           `Axios error fetching quote from ${endpoint}: ${e}`
         );
-        const axiosResponseType =
-          e.code === 'ECONNABORTED' ? WebhookResponseType.TIMEOUT : WebhookResponseType.HTTP_ERROR;
+        const axiosResponseType = timedOut ? WebhookResponseType.TIMEOUT : WebhookResponseType.HTTP_ERROR;
         this.firehose.sendAnalyticsEvent(
           new AnalyticsEvent(AnalyticsEventType.WEBHOOK_RESPONSE, {
             ...requestContext,
@@ -372,7 +429,7 @@ export class WebhookQuoter implements Quoter {
           })
         );
       }
-      return null;
+      return { response: null, name, latencyMs: errorLatency.latencyMs, timedOut };
     }
   }
 

--- a/test/handlers/hard-quote/handler.test.ts
+++ b/test/handlers/hard-quote/handler.test.ts
@@ -295,6 +295,25 @@ describe('Quote handler', () => {
     });
   });
 
+  it('emits QUOTE_E2E_LATENCY on both the 200 and the no-quote throw path', async () => {
+    const putMetricSpy = jest.spyOn(AWSMetricsLogger.prototype, 'putMetric');
+    const e2eCalls = () => putMetricSpy.mock.calls.filter((c) => c[0] === 'QUOTE_E2E_LATENCY');
+    const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
+
+    const ok = await getQuoteHandler([new MockQuoter(logger, 1, 1)]).handler(
+      getEvent(request),
+      {} as unknown as Context
+    );
+    expect(ok.statusCode).toEqual(200);
+    expect(e2eCalls()).toHaveLength(1);
+
+    const notFound = await getQuoteHandler([]).handler(getEvent(request), {} as unknown as Context);
+    expect(notFound.statusCode).toEqual(404);
+    expect(e2eCalls()).toHaveLength(2);
+
+    putMetricSpy.mockRestore();
+  });
+
   describe('getCosignerData', () => {
     const getQuoteResponse = (
       data: Partial<QuoteResponseData>,

--- a/test/handlers/quote/handler.test.ts
+++ b/test/handlers/quote/handler.test.ts
@@ -138,6 +138,33 @@ describe('Quote handler', () => {
     expect(responseFromRequest(request, {})).toMatchObject({ ...quoteResponse, quoteId: expect.any(String) });
   });
 
+  describe('QUOTE_E2E_LATENCY', () => {
+    const e2eCalls = (spy: jest.SpyInstance) => spy.mock.calls.filter((c) => c[0] === 'QUOTE_E2E_LATENCY');
+
+    it('is emitted on the 200 path', async () => {
+      const putMetricSpy = jest.spyOn(AWSMetricsLogger.prototype, 'putMetric');
+      const quoters = [new MockQuoter(logger, 1, 1)];
+      const request = getRequest(ethers.utils.parseEther('1').toString(), 'EXACT_INPUT', ProtocolVersion.V2);
+
+      const response = await getQuoteHandler(quoters).handler(getEvent(request), {} as unknown as Context);
+
+      expect(response.statusCode).toEqual(200);
+      expect(e2eCalls(putMetricSpy)).toHaveLength(1);
+    });
+
+    it('is emitted on the 404 (no quotes) path, which QUOTE_LATENCY misses', async () => {
+      const putMetricSpy = jest.spyOn(AWSMetricsLogger.prototype, 'putMetric');
+      const request = getRequest(ethers.utils.parseEther('1').toString(), 'EXACT_INPUT', ProtocolVersion.V2);
+
+      const response = await getQuoteHandler([]).handler(getEvent(request), {} as unknown as Context);
+
+      expect(response.statusCode).toEqual(404);
+      expect(e2eCalls(putMetricSpy)).toHaveLength(1);
+      const quoteLatencyCalls = putMetricSpy.mock.calls.filter((c) => c[0] === 'QUOTE_LATENCY');
+      expect(quoteLatencyCalls).toHaveLength(0);
+    });
+  });
+
   it('Handles hex amount', async () => {
     const quoters = [new MockQuoter(logger, 1, 1), new MockQuoter(logger, 1, 2)];
     const amountIn = ethers.utils.parseEther('1');

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -1,10 +1,11 @@
 import { TradeType } from '@uniswap/sdk-core';
-import axios from 'axios';
+import { metric, MetricLoggerUnit } from '@uniswap/smart-order-router';
+import axios, { AxiosError } from 'axios';
 import { BigNumber, ethers } from 'ethers';
 
 import { PERMISSIONED_TOKENS } from '@uniswap/uniswapx-sdk';
 import { NOTIFICATION_TIMEOUT_MS } from '../../../lib/constants';
-import { AnalyticsEventType, QuoteRequest, WebhookResponseType } from '../../../lib/entities';
+import { AnalyticsEventType, Metric, metricContext, QuoteRequest, WebhookResponseType } from '../../../lib/entities';
 import { MockWebhookConfigurationProvider, ProtocolVersion } from '../../../lib/providers';
 import { FirehoseLogger } from '../../../lib/providers/analytics';
 import { MockFillerComplianceConfigurationProvider } from '../../../lib/providers/compliance';
@@ -1048,5 +1049,114 @@ describe('WebhookQuoter tests', () => {
         },
       })
     );
+  });
+
+  describe('latency instrumentation', () => {
+    let putMetricSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      putMetricSpy = jest.spyOn(metric, 'putMetric');
+    });
+
+    const mockSimpleSuccess = () => {
+      mockedAxios.post
+        .mockImplementationOnce((_endpoint, _req, _options) => {
+          return Promise.resolve({ data: { ...quote, requestId: (_req as any).requestId } });
+        })
+        .mockImplementation((_endpoint, _req, _options) => {
+          return Promise.resolve({
+            data: { ...quote, tokenIn: request.tokenOut, tokenOut: request.tokenIn },
+          });
+        });
+    };
+
+    it('times the pre-fan-out phases', async () => {
+      mockSimpleSuccess();
+      await webhookQuoter.quote(request);
+
+      expect(putMetricSpy).toHaveBeenCalledWith(
+        Metric.RFQ_PHASE_ENDPOINT_STATUSES,
+        expect.any(Number),
+        MetricLoggerUnit.Milliseconds
+      );
+      expect(putMetricSpy).toHaveBeenCalledWith(
+        Metric.RFQ_PHASE_COMPLIANCE,
+        expect.any(Number),
+        MetricLoggerUnit.Milliseconds
+      );
+    });
+
+    it('emits fan-out wall time, wasted wait, and exactly one straggler', async () => {
+      mockSimpleSuccess();
+      await webhookQuoter.quote(request);
+
+      expect(putMetricSpy).toHaveBeenCalledWith(
+        Metric.RFQ_PHASE_FANOUT,
+        expect.any(Number),
+        MetricLoggerUnit.Milliseconds
+      );
+      expect(putMetricSpy).toHaveBeenCalledWith(
+        Metric.RFQ_WASTED_WAIT,
+        expect.any(Number),
+        MetricLoggerUnit.Milliseconds
+      );
+      expect(putMetricSpy).toHaveBeenCalledWith(Metric.RFQ_STRAGGLER, 1, MetricLoggerUnit.Count);
+      const perFillerStragglers = putMetricSpy.mock.calls.filter((c) =>
+        String(c[0]).startsWith(`${Metric.RFQ_STRAGGLER}_`)
+      );
+      expect(perFillerStragglers).toHaveLength(1);
+    });
+
+    it('emits RFQ_TIMEOUT (bare and per-filler) only for axios timeouts', async () => {
+      const timeoutError = new AxiosError('timeout of 500ms exceeded');
+      (timeoutError as any).code = 'ECONNABORTED';
+      mockedAxios.post.mockRejectedValue(timeoutError);
+
+      const response = await webhookQuoter.quote(request);
+
+      expect(response).toHaveLength(0);
+      expect(putMetricSpy).toHaveBeenCalledWith(Metric.RFQ_TIMEOUT, 1, MetricLoggerUnit.Count);
+      expect(putMetricSpy).toHaveBeenCalledWith(
+        metricContext(Metric.RFQ_TIMEOUT, 'uniswap'),
+        1,
+        MetricLoggerUnit.Count
+      );
+      // still counted under the umbrella error metric — RFQ_TIMEOUT is a subset, not a re-bucket
+      expect(putMetricSpy).toHaveBeenCalledWith(Metric.RFQ_FAIL_ERROR, 1, MetricLoggerUnit.Count);
+    });
+
+    it('does not emit RFQ_TIMEOUT for non-timeout errors', async () => {
+      const httpError = new AxiosError('Request failed with status code 500');
+      (httpError as any).code = 'ERR_BAD_RESPONSE';
+      mockedAxios.post.mockRejectedValue(httpError);
+
+      await webhookQuoter.quote(request);
+
+      const timeoutCalls = putMetricSpy.mock.calls.filter((c) => String(c[0]).startsWith(Metric.RFQ_TIMEOUT));
+      expect(timeoutCalls).toHaveLength(0);
+      expect(putMetricSpy).toHaveBeenCalledWith(Metric.RFQ_FAIL_ERROR, 1, MetricLoggerUnit.Count);
+    });
+
+    it('skips wasted-wait and straggler when no endpoint is eligible', async () => {
+      const v1OnlyProvider = new MockWebhookConfigurationProvider([
+        { name: 'v1only', endpoint: WEBHOOK_URL, headers: {}, hash: '0xv1', supportedVersions: [ProtocolVersion.V1] },
+      ]);
+      const quoter = new WebhookQuoter(
+        logger,
+        mockFirehoseLogger,
+        v1OnlyProvider,
+        MOCK_V2_CB_PROVIDER,
+        emptyMockComplianceProvider,
+        repository
+      );
+
+      const response = await quoter.quote(makeQuoteRequest({ protocol: ProtocolVersion.V2 }));
+
+      expect(response).toHaveLength(0);
+      const wastedOrStraggler = putMetricSpy.mock.calls.filter(
+        (c) => c[0] === Metric.RFQ_WASTED_WAIT || String(c[0]).startsWith(Metric.RFQ_STRAGGLER)
+      );
+      expect(wastedOrStraggler).toHaveLength(0);
+    });
   });
 });

--- a/test/providers/quoters/fanoutStats.test.ts
+++ b/test/providers/quoters/fanoutStats.test.ts
@@ -1,0 +1,48 @@
+import { deriveFanoutStats, FetchOutcome } from '../../../lib/quoters';
+
+const outcome = (overrides: Partial<FetchOutcome>): FetchOutcome => ({
+  response: null,
+  name: 'filler',
+  latencyMs: 0,
+  timedOut: false,
+  ...overrides,
+});
+
+// A truthy stand-in: deriveFanoutStats only checks `response !== null`.
+const USABLE = {} as FetchOutcome['response'];
+
+describe('deriveFanoutStats', () => {
+  it('charges the gap between the last usable quote and the wall as wasted wait', () => {
+    const outcomes = [
+      outcome({ name: 'fast-quoter', response: USABLE, latencyMs: 100 }),
+      outcome({ name: 'slow-failure', latencyMs: 500, timedOut: true }),
+    ];
+    expect(deriveFanoutStats(outcomes, 500)).toEqual({ wastedWaitMs: 400, stragglerName: 'slow-failure' });
+  });
+
+  it('counts the full wall as wasted when nothing usable came back (all timeouts)', () => {
+    const outcomes = [
+      outcome({ name: 'a', latencyMs: 500, timedOut: true }),
+      outcome({ name: 'b', latencyMs: 480, timedOut: true }),
+    ];
+    expect(deriveFanoutStats(outcomes, 505)).toEqual({ wastedWaitMs: 505, stragglerName: 'a' });
+  });
+
+  it('reports zero waste when the last usable quote set the wall', () => {
+    const outcomes = [
+      outcome({ name: 'fast-failure', latencyMs: 20 }),
+      outcome({ name: 'slow-quoter', response: USABLE, latencyMs: 300 }),
+    ];
+    expect(deriveFanoutStats(outcomes, 300)).toEqual({ wastedWaitMs: 0, stragglerName: 'slow-quoter' });
+  });
+
+  it('clamps to zero when the usable latency measurement lands past the wall measurement', () => {
+    const outcomes = [outcome({ name: 'only', response: USABLE, latencyMs: 310 })];
+    expect(deriveFanoutStats(outcomes, 305)).toEqual({ wastedWaitMs: 0, stragglerName: 'only' });
+  });
+
+  it('handles a single failed outcome', () => {
+    const outcomes = [outcome({ name: 'only', latencyMs: 500, timedOut: true })];
+    expect(deriveFanoutStats(outcomes, 500)).toEqual({ wastedWaitMs: 500, stragglerName: 'only' });
+  });
+});


### PR DESCRIPTION
Metric cost (measured 2026-08-04): ~785 new CloudWatch streams ≈ $236/mo upper bound — $45/mo of which is the dimensionless rollup applying to all 149 metric names on the request logger, not just the latency headliners — plus ~$90/mo of EMF log-byte ingestion (~775B/request at ~1.8 timeouts/request measured in prod). The rollup is logger-wide by EMF design, and the combined stream is what the dashboard headline requires. Note the dimensionless copy of count metrics (e.g. QUOTE_REQUESTED) sums soft+hard — use the Service-dimensioned streams when the split matters.