### PR TITLE
fix, test: stop writing client IPs to CloudWatch logs

### DIFF
--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -26,6 +26,32 @@ const INTERNAL_ERROR = (id?: string) => {
 
 export type APIGatewayProxyHandler = (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult>;
 
+/*
+ * The raw APIGatewayProxyEvent carries the client IP in several places: requestContext.identity.sourceIp
+ * and any of the forwarding headers (X-Forwarded-For, X-Real-IP, CF-Connecting-IP, ...). IP addresses are
+ * personal data, and our Lambda log groups have no retention policy set, so never log the raw event.
+ * This is an allowlist rather than a denylist so a new IP-bearing header can't leak in by default.
+ */
+export function redactEvent(event: APIGatewayProxyEvent) {
+  return {
+    resource: event.resource,
+    path: event.path,
+    httpMethod: event.httpMethod,
+    pathParameters: event.pathParameters,
+    queryStringParameters: event.queryStringParameters,
+    body: event.body,
+    isBase64Encoded: event.isBase64Encoded,
+    requestContext: {
+      requestId: event.requestContext?.requestId,
+      path: event.requestContext?.path,
+      stage: event.requestContext?.stage,
+      resourcePath: event.requestContext?.resourcePath,
+      httpMethod: event.requestContext?.httpMethod,
+      requestTimeEpoch: event.requestContext?.requestTimeEpoch,
+    },
+  };
+}
+
 export type ApiRInj = BaseRInj & { requestId: string };
 
 export type APIHandleRequestParams<CInj, RInj, ReqBody, ReqQueryParams> = BaseHandleRequestParams<
@@ -170,7 +196,7 @@ export abstract class APIGLambdaHandler<
               metric
             );
           } catch (err) {
-            log.error({ err, event }, 'Unexpected error building request injected.');
+            log.error({ err, event: redactEvent(event) }, 'Unexpected error building request injected.');
             metric.putMetric(Metric.QUOTE_500, 1, MetricLoggerUnit.Count);
             return INTERNAL_ERROR();
           }

--- a/test/handlers/base/redact-event.test.ts
+++ b/test/handlers/base/redact-event.test.ts
@@ -1,0 +1,79 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+
+import { redactEvent } from '../../../lib/handlers/base/api-handler';
+
+describe('redactEvent', () => {
+  const SOURCE_IP = '203.0.113.42';
+  const FORWARDED_IP = '198.51.100.7';
+
+  const event = {
+    resource: '/quote',
+    path: '/quote',
+    httpMethod: 'POST',
+    pathParameters: null,
+    queryStringParameters: null,
+    body: '{"tokenIn":"0xabc","tokenOut":"0xdef","amount":"1000"}',
+    isBase64Encoded: false,
+    headers: {
+      'X-Forwarded-For': FORWARDED_IP,
+      'x-real-ip': FORWARDED_IP,
+      'CF-Connecting-IP': FORWARDED_IP,
+      'User-Agent': 'Mozilla/5.0',
+      'x-api-key': 'super-secret-key',
+    },
+    multiValueHeaders: {
+      'X-Forwarded-For': [FORWARDED_IP],
+    },
+    requestContext: {
+      requestId: 'request-id-1',
+      path: '/prod/quote',
+      stage: 'prod',
+      resourcePath: '/quote',
+      httpMethod: 'POST',
+      requestTimeEpoch: 1700000000000,
+      identity: {
+        sourceIp: SOURCE_IP,
+        userAgent: 'Mozilla/5.0',
+        caller: 'caller-id',
+        user: 'user-id',
+      },
+    },
+  } as unknown as APIGatewayProxyEvent;
+
+  it('keeps the fields needed to debug a request', () => {
+    expect(redactEvent(event)).toEqual({
+      resource: '/quote',
+      path: '/quote',
+      httpMethod: 'POST',
+      pathParameters: null,
+      queryStringParameters: null,
+      body: '{"tokenIn":"0xabc","tokenOut":"0xdef","amount":"1000"}',
+      isBase64Encoded: false,
+      requestContext: {
+        requestId: 'request-id-1',
+        path: '/prod/quote',
+        stage: 'prod',
+        resourcePath: '/quote',
+        httpMethod: 'POST',
+        requestTimeEpoch: 1700000000000,
+      },
+    });
+  });
+
+  it('drops every client IP, headers, and requestContext.identity', () => {
+    const serialized = JSON.stringify(redactEvent(event));
+
+    expect(serialized).not.toContain(SOURCE_IP);
+    expect(serialized).not.toContain(FORWARDED_IP);
+    expect(serialized).not.toContain('super-secret-key');
+
+    const redacted = redactEvent(event) as Record<string, unknown>;
+    expect(redacted.headers).toBeUndefined();
+    expect(redacted.multiValueHeaders).toBeUndefined();
+    expect((redacted.requestContext as Record<string, unknown>).identity).toBeUndefined();
+  });
+
+  it('tolerates a missing requestContext', () => {
+    expect(() => redactEvent({} as APIGatewayProxyEvent)).not.toThrow();
+  });
+});

--- a/test/handlers/base/redact-event.test.ts
+++ b/test/handlers/base/redact-event.test.ts
@@ -40,8 +40,10 @@ describe('redactEvent', () => {
     },
   } as unknown as APIGatewayProxyEvent;
 
+  // toStrictEqual, not toEqual: toEqual ignores keys whose value is undefined, so a field
+  // added back to the allowlist but absent from this fixture would slip through.
   it('keeps the fields needed to debug a request', () => {
-    expect(redactEvent(event)).toEqual({
+    expect(redactEvent(event)).toStrictEqual({
       resource: '/quote',
       path: '/quote',
       httpMethod: 'POST',


### PR DESCRIPTION
## What

The API handler logged the raw `APIGatewayProxyEvent` when `getRequestInjected` threw. That event carries the client IP in several fields — `requestContext.identity.sourceIp` and the forwarding headers (`X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`) — so every hit of that path wrote an IP into CloudWatch.

```
lib/handlers/base/api-handler.ts:173  log.error({ err, event }, 'Unexpected error building request injected.')
```

Two things make this worth fixing here specifically:

- **No Lambda in this service sets `logRetention`** (zero hits across `bin/`), so those log groups take CloudWatch's default and **never expire**.
- The call is `error` level and the logger has no debug branch (`:132` is just `test ? FATAL+1 : INFO`), so it always fires in prod.

## How

Added `redactEvent()` and applied it at the call site. It's an **allowlist rather than a denylist**, so a new IP-bearing header can't leak in by default.

- **Kept:** `resource`, `path`, `httpMethod`, `pathParameters`, `queryStringParameters`, `body`, `isBase64Encoded`, and exactly six `requestContext` fields — `requestId`, `path`, `stage`, `resourcePath`, `httpMethod`, `requestTimeEpoch`.
- **Dropped:** `headers`, `multiValueHeaders`, and every other `requestContext` field. That includes `identity` (which carries `sourceIp`, `userAgent`, `caller`, `user`) and also `authorizer`, `apiId`, `extendedRequestId` and the domain fields. Dropping `authorizer` matters independently of IPs, since it can carry claims.

This brings the Lambda logs in line with the API Gateway access logs, which already set `ip: false` (`bin/stacks/api-stack.ts:71`).

## Context

Mirrors Uniswap/uniswapx-service#692 — same helper, same test, adapted to this repo's style. Came out of a review of the WAF IP rate limiting in `bin/stacks/api-stack.ts`, which is fine as-is: IP addresses are personal data under GDPR (Recital 30; CJEU *Breyer*, C-582/14), and rate limiting for abuse prevention is a standard legitimate-interest use. Indefinite IP retention in application logs is the harder part to justify, and it was inadvertent rather than deliberate.

Deliberately **out of scope**, flagged for follow-up:

- **Log retention.** No log group in this service has a retention policy. Adding `logRetention` across all 13 Lambdas is a larger infra change that deserves its own PR and its own review. The access log group at `api-stack.ts:61` also takes the CDK two-year default, though it holds no IPs given `ip: false`.
- `sampledRequestsEnabled: true` (×2) retains sampled requests including Source IP for 3 hours. Genuinely useful when debugging a misfiring WAF rule, so left on.
- **Request bodies are still logged.** For hard quotes that means `encodedInnerOrder` and `innerSig`, and since this error path fires inside `getRequestInjected` — before anything is persisted — the log entry can be the only copy of a signed order. Keeping the body still looks right for debuggability, but it's a deliberate call rather than a free one.

## Testing

New `test/handlers/base/redact-event.test.ts` asserts the exact output shape and serializes the result to confirm no IP (or `x-api-key`) survives — so it fails loudly if someone re-adds a field later.

Uses `toStrictEqual` rather than `toEqual`, since `toEqual` ignores keys whose value is `undefined` and would miss a re-added field absent from the fixture. Verified on the uniswapx-service twin: adding `multiValueQueryStringParameters` to `redactEvent` fails under `toStrictEqual` and passes under `toEqual`.

- `npx jest` (excluding `test/integ`) — 30 suites / 261 tests pass
- `npx tsc --noEmit` — clean
- `npx eslint` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
