### PR TITLE
fix: circuit-breaker decay leak; cap block backoff; chronic-rate watchlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ data-eng-workflows/lib/spaces/uniswap_x/functions/uniswap_x_hourly_config/tables
 Table → YAML mapping (table names are lowercased in Redshift; YAML uses snake_case):
 
 | Redshift table   | Load schema YAML       |
-|------------------|------------------------|
+| ---------------- | ---------------------- |
 | `postedorders`   | `posted_orders.yaml`   |
 | `archivedorders` | `archived_orders.yaml` |
 | `rfqrequests`    | `rfq_requests.yaml`    |
@@ -26,7 +26,7 @@ Table → YAML mapping (table names are lowercased in Redshift; YAML uses snake_
 in the corresponding YAML.** The view/query column references are validated only at runtime
 against the live cluster — there is no compile-time or unit-test check — so a typo or a
 non-loaded column fails the cron in production (and a column that exists but is null for the
-relevant rows fails *silently*).
+relevant rows fails _silently_).
 
 ### The trap: "emitted" ≠ "loaded"
 
@@ -61,7 +61,11 @@ posted while a filler would have been benched as prevented (see PR #482 discussi
 full harness design, per-filler duty-cycle/allowed-fades metrics, and baseline numbers).
 
 Extract query (matches the breaker's fade semantics from `V2_FADE_RATE_SQL`, but with **no
-24h window, no latest-100 cap, and no row limit** — the replay applies windowing itself):
+24h window, no latest-100 cap, and no row limit** — the replay applies windowing itself).
+**Keep the `faded` CASE in sync with `V2_FADE_RATE_SQL`** — e.g. #461 changed Dutch_V3 to
+`fillTimeBlocks > 0` (a fill at the decay-start block is _not_ a fade); an extract using the
+old `>= 0` inflates V3 fade rates and mis-calibrates every knob. The raw columns are included
+so the replay can recompute `faded` locally if the semantics change again:
 
 ```sql
 SELECT
@@ -79,7 +83,7 @@ SELECT
     ao.tokenOut AS tokenOut,
     CASE
       WHEN ao.fillTimestamp IS NULL THEN 1
-      WHEN po.ordertype = 'Dutch_V3' AND ao.fillTimeBlocks >= 0 THEN 1
+      WHEN po.ordertype = 'Dutch_V3' AND ao.fillTimeBlocks > 0 THEN 1
       WHEN po.ordertype = 'Dutch_V2' AND po.starttime < ao.fillTimestamp THEN 1
       ELSE 0
     END AS faded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,58 @@ for the rows you care about.
    ```
 3. New columns must be added to the `data-eng-workflows` load YAML (and the table) **before**
    any SQL here references them.
+
+## Backtesting fade circuit-breaker changes against real order history
+
+Any change to the circuit-breaker knobs in `lib/cron/fade-rate-v2.ts` (threshold, Laplace
+prior, block backoff/cap, decay rules, windowing) should be replayed against real order data
+before shipping — the PR #482 backtest reversed two confidently-held design opinions, cheaply.
+Method: pull the extract below, then simulate 10-minute cron runs over it, treating orders
+posted while a filler would have been benched as prevented (see PR #482 discussion for the
+full harness design, per-filler duty-cycle/allowed-fades metrics, and baseline numbers).
+
+Extract query (matches the breaker's fade semantics from `V2_FADE_RATE_SQL`, but with **no
+24h window, no latest-100 cap, and no row limit** — the replay applies windowing itself):
+
+```sql
+SELECT
+    po.filler   AS rfqFiller,       -- quoted exclusive filler address
+    po.quoteid  AS quoteId,
+    po.chainid  AS chainId,
+    po.ordertype AS orderType,
+    po.createdat AS postTimestamp,  -- epoch secs
+    po.deadline AS deadline,        -- epoch secs, completion time
+    po.starttime AS decayStartTime,
+    ao.fillTimestamp AS fillTimestamp,
+    ao.fillTimeBlocks AS fillTimeBlocks,
+    ao.filler AS actualFiller,
+    ao.tokenIn AS tokenIn,
+    ao.tokenOut AS tokenOut,
+    CASE
+      WHEN ao.fillTimestamp IS NULL THEN 1
+      WHEN po.ordertype = 'Dutch_V3' AND ao.fillTimeBlocks >= 0 THEN 1
+      WHEN po.ordertype = 'Dutch_V2' AND po.starttime < ao.fillTimestamp THEN 1
+      ELSE 0
+    END AS faded
+FROM postedorders po
+LEFT OUTER JOIN archivedorders ao ON po.quoteid = ao.quoteid
+WHERE po.ordertype IN ('Dutch_V2', 'Dutch_V3')
+  AND po.quoteid IS NOT NULL
+  AND po.filler IS NOT NULL
+  AND po.filler != '0x0000000000000000000000000000000000000000'
+  AND po.chainid NOT IN (5, 8001, 420, 421613)
+  AND po.deadline < EXTRACT(EPOCH FROM GETDATE())                          -- completed only
+  AND po.deadline >= EXTRACT(EPOCH FROM (GETDATE() - INTERVAL '28 DAYS'))  -- replay window
+ORDER BY po.deadline ASC;
+```
+
+Post-processing the replay must do itself (deliberately not in the SQL):
+
+- **Filter permissioned-token orders** using `PERMISSIONED_TOKENS` from `@uniswap/uniswapx-sdk`
+  (the breaker excludes them); the SQL keeps `tokenIn`/`tokenOut` for this so the list can't
+  drift from the code.
+- **Aggregate addresses to fillers** with the `FillerAddress` DynamoDB table
+  (`aws dynamodb scan --table-name FillerAddress`) — the breaker scores per filler hash, not
+  per address. Per-address replay is a usable approximation but under-counts multi-address
+  fillers.
+- Dedupe on `quoteId` (the `archivedorders` join can rarely fan out).

--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -808,6 +808,16 @@ const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
         ['.', Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, '.', '.', { stat: 'Sum', label: 'extended blocks' }],
         ['.', Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS, '.', '.', { stat: 'Maximum', label: 'active blocks' }],
         ['.', Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, '.', '.', { stat: 'Maximum', label: 'fillers evaluated' }],
+        [
+          '.',
+          Metric.CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES,
+          '.',
+          '.',
+          // addresses whose latest-N window has outrun the streak finality horizon (rows
+          // evicted before classification): sustained nonzero = per-address volume has
+          // outgrown the window and decay fidelity degrades for those fillers
+          { stat: 'Maximum', label: 'window-saturated addresses' },
+        ],
       ],
       view: 'timeSeries',
       stacked: false,
@@ -879,8 +889,11 @@ const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
       title: 'Filler Consecutive Blocks (escalation)',
     },
   },
-  // Watchlist: per-filler RAW fade rate over the whole 24h window, no clean-slate amnesty and
-  // no smoothing. The breaker deliberately tolerates low-volume fillers up to ~0.12n + 1.4
+  // Watchlist: per-filler RAW fade rate over the query window's final rows — no clean-slate
+  // amnesty, no smoothing. The window is adaptive (24h for low-volume fillers, the latest-100
+  // per address for high-volume ones — see SATURATED_ADDRESSES when the cap binds). Series
+  // exist only for fillers over the emission floor, so an empty chart means nobody is
+  // watch-worthy. The breaker deliberately tolerates low-volume fillers up to ~0.12n + 1.4
   // fades/day (e.g. ~20% raw at 15 orders/day) — anyone hugging or exceeding the threshold
   // line here for days while never showing up in the blocks widgets is inside that envelope
   // and needs a human conversation, not a threshold change (see PR #482 backtest).
@@ -902,7 +915,7 @@ const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
       stacked: false,
       region,
       period: 600,
-      title: 'Filler Chronic Fade Rate (raw, 24h, no amnesty) — watchlist',
+      title: 'Filler Chronic Fade Rate (raw, no amnesty, adaptive window) — watchlist',
       yAxis: {
         left: {
           label: 'raw fade rate',

--- a/bin/stacks/param-dashboard-stack.ts
+++ b/bin/stacks/param-dashboard-stack.ts
@@ -879,6 +879,41 @@ const CircuitBreakerWidgets = (region: string): LambdaWidget[] => [
       title: 'Filler Consecutive Blocks (escalation)',
     },
   },
+  // Watchlist: per-filler RAW fade rate over the whole 24h window, no clean-slate amnesty and
+  // no smoothing. The breaker deliberately tolerates low-volume fillers up to ~0.12n + 1.4
+  // fades/day (e.g. ~20% raw at 15 orders/day) — anyone hugging or exceeding the threshold
+  // line here for days while never showing up in the blocks widgets is inside that envelope
+  // and needs a human conversation, not a threshold change (see PR #482 backtest).
+  {
+    height: 8,
+    width: 12,
+    type: 'metric',
+    properties: {
+      metrics: [
+        [
+          {
+            expression: `SEARCH('{Uniswap,Service} Service="${CircuitBreakerMetricDimension.Service}" ${Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE}_', 'Average', 600)`,
+            id: 'chronicRates',
+            region,
+          },
+        ],
+      ],
+      view: 'timeSeries',
+      stacked: false,
+      region,
+      period: 600,
+      title: 'Filler Chronic Fade Rate (raw, 24h, no amnesty) — watchlist',
+      yAxis: {
+        left: {
+          label: 'raw fade rate',
+          showUnits: false,
+        },
+      },
+      annotations: {
+        horizontal: [{ label: 'block threshold (smoothed)', value: FADE_RATE_BLOCK_THRESHOLD }],
+      },
+    },
+  },
 ];
 
 export interface DashboardProps extends cdk.NestedStackProps {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,6 +21,7 @@ export const DYNAMO_TABLE_KEY = {
   LAST_EXAMINED_TIMESTAMP: 'lastExaminedTimestamp',
   FADE_WINDOW_START: 'fadeWindowStart',
   CONSECUTIVE_BLOCKS: 'consecutiveBlocks',
+  CONSECUTIVE_CLEAN_RUNS: 'consecutiveCleanRuns',
 };
 
 export const POST_ORDER_ERROR_REASON = {

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -41,6 +41,9 @@ export type FillerFadeStats = {
   // working off escalation requires demonstrated activity, not just going idle while stale
   // rows linger in the 24h view.
   newCompletions: number;
+  // Fades among newCompletions. A run with any new fade is not a clean run: it cannot build
+  // the decay streak (and resets it), so a sub-threshold fade never counts as recovery.
+  newFades: number;
 };
 export type FillerFadeStatsMap = Record<string, FillerFadeStats>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
@@ -57,6 +60,14 @@ export const LAPLACE_BETA = 19;
 // a sustained ~14%+ raw fade rate (e.g. ~3 fades in 10, ~14 in 100), or ~2 fades at very low
 // volume.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
+// Escalation (consecutiveBlocks) decays one level only after this many consecutive clean
+// runs — cron runs with at least one new completion and zero new fades. A run with any new
+// fade resets the streak; an idle run freezes it. At the 10-minute cron cadence this makes
+// recovery cost >=1 hour of demonstrated clean activity per level, so decay is structurally
+// slower than escalation (+1 per block event). Without the streak, a chronic low-volume
+// fader whose fades land in separate cron runs (fade #1 under threshold -> "activity" decay,
+// fade #2 -> block) nets zero escalation per cycle and stays on 15-30 minute blocks forever.
+export const CLEAN_RUNS_PER_DECAY = 6;
 
 const log = Logger.createLogger({
   name: 'FadeRate',
@@ -153,9 +164,11 @@ function newConsecutiveBlocks(consecutiveBlocks?: number): number {
     - Post-block fade rate over threshold — or the during-block cohort over threshold
       (late in-flight fades from a block that expired between cron runs): block,
       increment consecutiveBlocks
-    - Otherwise: reset blockUntilTimestamp to unblocked and decay consecutiveBlocks by 1 —
-      but only if the filler completed new orders since the last run (idling must not work
-      off escalation). fadeWindowStart is left untouched so the clean-slate floor persists.
+    - Otherwise: reset blockUntilTimestamp to unblocked. consecutiveBlocks decays one level
+      per CLEAN_RUNS_PER_DECAY consecutive clean runs (>=1 new completion, 0 new fades);
+      a new fade resets the streak, idling freezes it — working off escalation requires
+      sustained demonstrated clean activity. fadeWindowStart is left untouched so the
+      clean-slate floor persists.
 
   blockUntilTimestamp is the block expiry (used for the is-blocked check). fadeWindowStart is
   the clean-slate floor for the fade-rate window; a block/extension sets both to the block end,
@@ -173,10 +186,11 @@ export function calculateNewTimestamps(
   let newBlocks = 0;
   let extendedBlocks = 0;
   Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
-    const { fadeRate, duringBlockRate, newCompletions } = stats;
+    const { fadeRate, duringBlockRate, newCompletions, newFades } = stats;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
     const previousBlocks = fillerTimestamp?.consecutiveBlocks || 0;
+    const previousCleanRuns = fillerTimestamp?.consecutiveCleanRuns || 0;
 
     // Per-filler rate so the distribution can be charted against FADE_RATE_BLOCK_THRESHOLD. While
     // blocked, fadeRate sits at the prior (post-block window is empty), so also emit the
@@ -213,9 +227,12 @@ export function calculateNewTimestamps(
         blockUntilTimestamp: extendedBlockUntil,
         fadeWindowStart: extendedBlockUntil, // clean slate resumes when the extended block ends
         consecutiveBlocks,
+        consecutiveCleanRuns: 0, // faded while blocked: recovery streak restarts
       });
     } else if (isCurrentlyBlocked) {
-      // Blocked but no new fades - keep existing block and floor, don't decay
+      // Blocked with the in-flight cohort under threshold - keep existing block and floor,
+      // don't decay. Serving a bench is not recovery, so clean in-flight fills don't build
+      // the decay streak either — but a sub-threshold in-flight fade still resets it.
       consecutiveBlocks = fillerTimestamp.consecutiveBlocks;
       updatedTimestamps.push({
         hash,
@@ -223,6 +240,7 @@ export function calculateNewTimestamps(
         blockUntilTimestamp: fillerTimestamp.blockUntilTimestamp,
         fadeWindowStart: fillerTimestamp.fadeWindowStart,
         consecutiveBlocks,
+        consecutiveCleanRuns: newFades > 0 ? 0 : previousCleanRuns,
       });
     } else if (fadeRate > FADE_RATE_BLOCK_THRESHOLD || duringBlockRate > FADE_RATE_BLOCK_THRESHOLD) {
       // duringBlockRate covers in-flight fades that landed near the end of a block that
@@ -245,21 +263,38 @@ export function calculateNewTimestamps(
         blockUntilTimestamp,
         fadeWindowStart: blockUntilTimestamp, // clean slate resumes when the block ends
         consecutiveBlocks,
+        consecutiveCleanRuns: 0, // blocked: recovery streak restarts
       });
     } else {
-      // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked and decay
-      // consecutiveBlocks by 1 (gradual decay resists gaming via alternating fade/clean
-      // cycles). Decay only when the filler completed new orders this run, so working off
-      // escalation requires demonstrated clean activity rather than idling. fadeWindowStart
-      // is left as-is: it holds the last block end as the clean-slate floor, so a returning
-      // filler is scored only on orders completed after their block ended.
-      consecutiveBlocks = newCompletions > 0 ? Math.max(0, previousBlocks - 1) : previousBlocks;
+      // Under threshold: not blocked. Reset blockUntilTimestamp to unblocked. Escalation
+      // decays one level only after CLEAN_RUNS_PER_DECAY consecutive clean runs (>=1 new
+      // completion, 0 new fades): a new fade resets the streak — a sub-threshold fade is
+      // not recovery — and an idle run freezes it (idling must not work off escalation).
+      // fadeWindowStart is left as-is: it holds the last block end as the clean-slate
+      // floor, so a returning filler is scored only on orders completed after their block
+      // ended.
+      let consecutiveCleanRuns: number;
+      consecutiveBlocks = previousBlocks;
+      if (previousBlocks === 0) {
+        consecutiveCleanRuns = 0; // nothing to work off; don't accumulate a stale streak
+      } else if (newFades > 0) {
+        consecutiveCleanRuns = 0;
+      } else if (newCompletions > 0) {
+        consecutiveCleanRuns = previousCleanRuns + 1;
+        if (consecutiveCleanRuns >= CLEAN_RUNS_PER_DECAY) {
+          consecutiveBlocks = previousBlocks - 1;
+          consecutiveCleanRuns = 0; // streak restarts for the next level
+        }
+      } else {
+        consecutiveCleanRuns = previousCleanRuns; // idle: frozen
+      }
       updatedTimestamps.push({
         hash,
         lastExaminedTimestamp: newPostTimestamp,
         blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         fadeWindowStart: fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         consecutiveBlocks,
+        consecutiveCleanRuns,
       });
     }
 
@@ -343,7 +378,14 @@ export function getFillersFadeStats(
   // filler hash -> tallies used to derive the stats below
   const tallies: Record<
     string,
-    { windowFades: number; windowTotal: number; blockFades: number; blockTotal: number; newCompletions: number }
+    {
+      windowFades: number;
+      windowTotal: number;
+      blockFades: number;
+      blockTotal: number;
+      newCompletions: number;
+      newFades: number;
+    }
   > = {};
   rows.forEach((row) => {
     const fillerAddr = ethers.utils.getAddress(row.fillerAddress);
@@ -354,12 +396,20 @@ export function getFillersFadeStats(
     }
     const fillerTimestamp = fillerTimestamps.get(fillerHash);
     if (!tallies[fillerHash]) {
-      tallies[fillerHash] = { windowFades: 0, windowTotal: 0, blockFades: 0, blockTotal: 0, newCompletions: 0 };
+      tallies[fillerHash] = {
+        windowFades: 0,
+        windowTotal: 0,
+        blockFades: 0,
+        blockTotal: 0,
+        newCompletions: 0,
+        newFades: 0,
+      };
     }
     const windowStart = fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP;
     const lastExaminedTimestamp = fillerTimestamp?.lastExaminedTimestamp ?? 0;
     if (row.deadline > lastExaminedTimestamp) {
       tallies[fillerHash].newCompletions += 1;
+      tallies[fillerHash].newFades += row.faded;
     }
     if (row.deadline > windowStart) {
       // Rate window: orders completed after the filler's last block ended (clean slate).
@@ -380,6 +430,7 @@ export function getFillersFadeStats(
       fadeRate: laplaceSmoothedFadeRate(t.windowFades, t.windowTotal),
       duringBlockRate: laplaceSmoothedFadeRate(t.blockFades, t.blockTotal),
       newCompletions: t.newCompletions,
+      newFades: t.newFades,
     };
   });
   log?.info({ tallies, stats }, 'fade stats by filler');

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -44,6 +44,14 @@ export type FillerFadeStats = {
   // Fades among newCompletions. A run with any new fade is not a clean run: it cannot build
   // the decay streak (and resets it), so a sub-threshold fade never counts as recovery.
   newFades: number;
+  // Raw (unsmoothed) fade rate over the filler's ENTIRE query window (24h / latest-100 per
+  // address), ignoring the clean-slate floor — the no-amnesty "chronic" view. Never used for
+  // blocking: emitted as a watchlist metric so persistent moderate faders who live inside the
+  // block threshold's envelope (~0.12n + 1.4 fades per day, e.g. ~20% raw at 15 orders/day)
+  // stay visible to humans even though the breaker correctly never trips on them.
+  chronicRate: number;
+  // Sample size behind chronicRate; the metric is only emitted at CHRONIC_RATE_MIN_SAMPLE+.
+  chronicTotal: number;
 };
 export type FillerFadeStatsMap = Record<string, FillerFadeStats>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
@@ -68,6 +76,15 @@ export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 // fader whose fades land in separate cron runs (fade #1 under threshold -> "activity" decay,
 // fade #2 -> block) nets zero escalation per cycle and stays on 15-30 minute blocks forever.
 export const CLEAN_RUNS_PER_DECAY = 6;
+// Cap on the block-backoff exponent: a single block/extension increment is at most
+// BASE_BLOCK_SECS * 2^7 = 32 hours (extensions stack, so the worst continuous bench seen in
+// the 2-week backtest under the cap was ~64h). Uncapped, the same replay produced a 152h
+// (6.3-day) block. The cap costs ~12% of worst-offender fade containment in exchange for a
+// bounded worst-case sentence and automatic recovery from pathological stored state.
+export const MAX_BLOCK_BACKOFF_EXPONENT = 7;
+// Minimum sample size before the chronic-rate watchlist metric is emitted, so one or two
+// orders don't chart as a 0%/100% swing.
+export const CHRONIC_RATE_MIN_SAMPLE = 10;
 
 const log = Logger.createLogger({
   name: 'FadeRate',
@@ -199,6 +216,14 @@ export function calculateNewTimestamps(
     metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_FADE_RATE, hash), fadeRate, Unit.None);
     if (isCurrentlyBlocked) {
       metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, hash), duringBlockRate, Unit.None);
+    }
+    // Watchlist, not a trigger: the raw no-amnesty rate over the whole query window. Backtests
+    // show a low-volume filler can sustain ~20% raw inside the block threshold's envelope and
+    // that no trigger calibration catches them without unacceptable collateral — this metric
+    // keeps them visible for human follow-up instead. Gated on sample size to avoid charting
+    // 0%/100% single-order noise.
+    if (stats.chronicTotal >= CHRONIC_RATE_MIN_SAMPLE) {
+      metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE, hash), stats.chronicRate, Unit.None);
     }
 
     // Resulting escalation level for this filler, emitted once below so the dashboard can chart
@@ -385,6 +410,8 @@ export function getFillersFadeStats(
       blockTotal: number;
       newCompletions: number;
       newFades: number;
+      chronicFades: number;
+      chronicTotal: number;
     }
   > = {};
   rows.forEach((row) => {
@@ -403,10 +430,15 @@ export function getFillersFadeStats(
         blockTotal: 0,
         newCompletions: 0,
         newFades: 0,
+        chronicFades: 0,
+        chronicTotal: 0,
       };
     }
     const windowStart = fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP;
     const lastExaminedTimestamp = fillerTimestamp?.lastExaminedTimestamp ?? 0;
+    // Chronic (no-amnesty) view: every row in the query window, regardless of cohort.
+    tallies[fillerHash].chronicTotal += 1;
+    tallies[fillerHash].chronicFades += row.faded;
     if (row.deadline > lastExaminedTimestamp) {
       tallies[fillerHash].newCompletions += 1;
       tallies[fillerHash].newFades += row.faded;
@@ -431,6 +463,8 @@ export function getFillersFadeStats(
       duringBlockRate: laplaceSmoothedFadeRate(t.blockFades, t.blockTotal),
       newCompletions: t.newCompletions,
       newFades: t.newFades,
+      chronicRate: t.chronicTotal > 0 ? t.chronicFades / t.chronicTotal : 0,
+      chronicTotal: t.chronicTotal,
     };
   });
   log?.info({ tallies, stats }, 'fade stats by filler');
@@ -447,8 +481,9 @@ export function getFillersFadeStats(
     - 1 consecutive block:  15 * 2^1 = 30 minutes
     - 2 consecutive blocks: 15 * 2^2 = 60 minutes
     - 3 consecutive blocks: 15 * 2^3 = 120 minutes
+    - 7+ consecutive blocks: capped at 15 * 2^7 = 32 hours per increment
 */
 export function calculateBlockUntilTimestamp(fromTimestamp: number, consecutiveBlocks: number | undefined): number {
-  const blocks = consecutiveBlocks || 0;
+  const blocks = Math.min(consecutiveBlocks || 0, MAX_BLOCK_BACKOFF_EXPONENT);
   return Math.floor(fromTimestamp + BASE_BLOCK_SECS * Math.pow(2, blocks));
 }

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -37,12 +37,14 @@ export type FillerFadeStats = {
   // in-flight fills offset stray fades: extending a block is volume-neutral, just like
   // tripping one.
   duringBlockRate: number;
-  // Orders completed since the last cron run (any cohort). Gates consecutiveBlocks decay:
-  // working off escalation requires demonstrated activity, not just going idle while stale
-  // rows linger in the 24h view.
+  // Completions newly classified this run (see the finality-lagged slice in
+  // getFillersFadeStats) whose deadline is past the clean-slate floor. Gates consecutiveBlocks
+  // decay: working off escalation requires demonstrated post-block activity — idling doesn't
+  // count, and neither do fills that were merely in flight while serving a bench.
   newCompletions: number;
-  // Fades among newCompletions. A run with any new fade is not a clean run: it cannot build
-  // the decay streak (and resets it), so a sub-threshold fade never counts as recovery.
+  // Fades newly classified this run, from ANY cohort (a during-bench fade is still a fade).
+  // A run with any new fade is not a clean run: it cannot build the decay streak (and resets
+  // it), so a sub-threshold fade never counts as recovery.
   newFades: number;
   // Raw (unsmoothed) fade rate over the filler's ENTIRE query window (24h / latest-100 per
   // address), ignoring the clean-slate floor — the no-amnesty "chronic" view. Never used for
@@ -69,18 +71,30 @@ export const LAPLACE_BETA = 19;
 // volume.
 export const FADE_RATE_BLOCK_THRESHOLD = 0.12;
 // Escalation (consecutiveBlocks) decays one level only after this many consecutive clean
-// runs — cron runs with at least one new completion and zero new fades. A run with any new
-// fade resets the streak; an idle run freezes it. At the 10-minute cron cadence this makes
-// recovery cost >=1 hour of demonstrated clean activity per level, so decay is structurally
-// slower than escalation (+1 per block event). Without the streak, a chronic low-volume
-// fader whose fades land in separate cron runs (fade #1 under threshold -> "activity" decay,
-// fade #2 -> block) nets zero escalation per cycle and stays on 15-30 minute blocks forever.
+// runs — cron runs whose newly classified slice has at least one post-floor completion and
+// zero new fades. A run with any new fade resets the streak; an idle run freezes it. At the
+// 10-minute cron cadence this makes recovery cost >=1 hour of demonstrated clean activity
+// per level, so decay is structurally slower than escalation (+1 per block event). Without
+// the streak, a chronic low-volume fader whose fades land in separate cron runs (fade #1
+// under threshold -> "activity" decay, fade #2 -> block) nets zero escalation per cycle and
+// stays on 15-30 minute blocks forever.
 export const CLEAN_RUNS_PER_DECAY = 6;
-// Cap on the block-backoff exponent: a single block/extension increment is at most
-// BASE_BLOCK_SECS * 2^7 = 32 hours (extensions stack, so the worst continuous bench seen in
-// the 2-week backtest under the cap was ~64h). Uncapped, the same replay produced a 152h
-// (6.3-day) block. The cap costs ~12% of worst-offender fade containment in exchange for a
-// bounded worst-case sentence and automatic recovery from pathological stored state.
+// The streak classifies rows as "new" against a horizon that trails wall clock by this lag,
+// because postedorders/archivedorders are batch-loaded (hourly) while the cron runs every 10
+// minutes. Without the lag, streak classification is wrong in both directions: a fade whose
+// row loads late (deadline already behind the watermark) never resets the streak, and an
+// order whose fill row hasn't loaded yet reads as a transient fade (LEFT JOIN fillTimestamp
+// NULL) exactly when it counts as new — resetting an honest filler's streak with no later
+// correction. Rows older than the lag have final load state, so classification is exact.
+// 2h = hourly load cadence + headroom for cross-table skew and job runtime.
+export const STREAK_FINALITY_LAG_SECS = 2 * 60 * 60;
+// Cap on the block backoff: both the stored consecutiveBlocks counter and the duration
+// exponent stop growing here, so a single block/extension increment is at most
+// BASE_BLOCK_SECS * 2^7 = 32 hours (extensions stack: worst continuous bench in the 2-week
+// backtest under the cap was ~64h, vs a 128h single block uncapped), and full recovery is
+// bounded at MAX_BLOCK_BACKOFF_EXPONENT * CLEAN_RUNS_PER_DECAY clean runs rather than
+// growing with block history. Costs ~20% of worst-offender fade containment in exchange for
+// a bounded worst-case sentence and automatic recovery from pathological stored state.
 export const MAX_BLOCK_BACKOFF_EXPONENT = 7;
 // Minimum sample size before the chronic-rate watchlist metric is emitted, so one or two
 // orders don't chart as a 0%/100% swing.
@@ -136,16 +150,17 @@ async function main(metrics: MetricsLogger) {
     const addressToFillerMap = await fillerAddressRepo.getAddressToFillerMap(fillerEndpoints);
     const fillerTimestamps = await timestampDB.getFillerTimestampsMap(fillerEndpoints);
 
+    const now = Math.floor(Date.now() / 1000);
+
     // compute each filler's Laplace-smoothed fade rates (post-block window + during-block cohort):
     //  | hash     |  fadeRate  |  duringBlockRate  |
     //  |---- foo -|---- 0.18 --|------ 0.05 -------|
     //  |---- bar -|---- 0.05 --|------ 0.20 -------|
-    const fillerFadeStats = getFillersFadeStats(result, addressToFillerMap, fillerTimestamps, log);
+    const fillerFadeStats = getFillersFadeStats(result, addressToFillerMap, fillerTimestamps, now, log);
 
     //  | hash        |lastExaminedTimestamp|blockUntilTimestamp|fadeWindowStart|
     //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
     //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
-    const now = Math.floor(Date.now() / 1000);
     const updatedTimestamps = calculateNewTimestamps(fillerTimestamps, fillerFadeStats, now, log, metrics);
     log.info({ updatedTimestamps }, 'filler for which to update timestamp');
     metrics.putMetric(
@@ -169,7 +184,10 @@ function newConsecutiveBlocks(consecutiveBlocks?: number): number {
   if (Number.isNaN(consecutiveBlocks)) {
     return 1;
   }
-  return consecutiveBlocks + 1;
+  // Cap the stored counter, not just the duration exponent: full recovery costs
+  // consecutiveBlocks * CLEAN_RUNS_PER_DECAY clean runs, so an uncapped counter would leave a
+  // long-reformed filler one sub-threshold fade away from a max-length block indefinitely.
+  return Math.min(consecutiveBlocks + 1, MAX_BLOCK_BACKOFF_EXPONENT);
 }
 
 /* compute blockUntil timestamp for each filler
@@ -382,6 +400,14 @@ export function laplaceSmoothedFadeRate(fades: number, total: number): number {
      trickling isolated fades (each slice under threshold) won't extend the block, but those
      orders never enter the post-block window either — they still serve the full bench.
 
+   - newCompletions / newFades (streak inputs): rows classified as new against a horizon that
+     trails wall clock by STREAK_FINALITY_LAG_SECS. Each run classifies deadlines in
+     (lastExaminedTimestamp - LAG, now - LAG] — lastExaminedTimestamp advances to `now` every
+     run, so consecutive runs' slices partition time and each row is classified exactly once,
+     after its load state is final. newCompletions additionally requires deadline past the
+     clean-slate floor (fills served while benched are not recovery); newFades counts any
+     cohort (a during-bench fade still resets the streak).
+
    NOTE: cohort membership uses `deadline` (order completion time) instead of `postTimestamp`.
    This ensures orders posted before the last cron run but completed after are still counted,
    preventing the "in-flight orders" exploit.
@@ -390,6 +416,7 @@ export function getFillersFadeStats(
   rows: V2FadesRowType[],
   addressToFillerMap: Map<string, string>,
   fillerTimestamps: FillerTimestamps,
+  now: number,
   log?: Logger
 ): FillerFadeStatsMap {
   log?.info(
@@ -439,8 +466,17 @@ export function getFillersFadeStats(
     // Chronic (no-amnesty) view: every row in the query window, regardless of cohort.
     tallies[fillerHash].chronicTotal += 1;
     tallies[fillerHash].chronicFades += row.faded;
-    if (row.deadline > lastExaminedTimestamp) {
-      tallies[fillerHash].newCompletions += 1;
+    // Streak inputs, classified against the finality-lagged horizon so hourly-batch load lag
+    // can't miss a late fade or count a not-yet-loaded fill as a transient fade. The slices
+    // partition time across runs because lastExaminedTimestamp advances to `now` each run.
+    if (
+      row.deadline > lastExaminedTimestamp - STREAK_FINALITY_LAG_SECS &&
+      row.deadline <= now - STREAK_FINALITY_LAG_SECS
+    ) {
+      if (row.deadline > windowStart) {
+        // Bench fills (deadline on/before the floor) earn nothing toward recovery.
+        tallies[fillerHash].newCompletions += 1;
+      }
       tallies[fillerHash].newFades += row.faded;
     }
     if (row.deadline > windowStart) {

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -11,6 +11,7 @@ import { CircuitBreakerMetricDimension, Metric, metricContext } from '../entitie
 import { checkDefined } from '../preconditions/preconditions';
 import { S3WebhookConfigurationProvider } from '../providers';
 import {
+  ORDERS_PER_FILLER_LIMIT,
   SharedConfigs,
   TimestampRepoRow,
   ToUpdateTimestampRow,
@@ -46,14 +47,24 @@ export type FillerFadeStats = {
   // A run with any new fade is not a clean run: it cannot build the decay streak (and resets
   // it), so a sub-threshold fade never counts as recovery.
   newFades: number;
-  // Raw (unsmoothed) fade rate over the filler's ENTIRE query window (24h / latest-100 per
-  // address), ignoring the clean-slate floor — the no-amnesty "chronic" view. Never used for
-  // blocking: emitted as a watchlist metric so persistent moderate faders who live inside the
-  // block threshold's envelope (~0.12n + 1.4 fades per day, e.g. ~20% raw at 15 orders/day)
-  // stay visible to humans even though the breaker correctly never trips on them.
+  // Raw (unsmoothed) fade rate over the FINAL rows of the filler's query window (24h /
+  // latest-100 per address, deadline past the finality horizon), ignoring the clean-slate
+  // floor — the no-amnesty "chronic" view. Final rows only, so not-yet-loaded fills can't
+  // inflate the rate with transient fades. Never used for blocking: emitted as a watchlist
+  // metric so persistent moderate faders who live inside the block threshold's envelope
+  // (~0.12n + 1.4 fades per day, e.g. ~20% raw at 15 orders/day) stay visible to humans even
+  // though the breaker correctly never trips on them.
   chronicRate: number;
   // Sample size behind chronicRate; the metric is only emitted at CHRONIC_RATE_MIN_SAMPLE+.
   chronicTotal: number;
+  // How many of this filler's addresses have a query window that no longer reaches back to
+  // the streak finality horizon: the address returned the full latest-N cap AND its oldest
+  // returned row is fresher than STREAK_FINALITY_LAG_SECS. Rows for such an address are
+  // being evicted before they can ever be streak-classified, thinning decay credit. (Merely
+  // being at the latest-N cap is the designed adaptive window and is NOT flagged — big
+  // fillers sit at the cap constantly.) Surfaced as an aggregate metric so per-address
+  // volume outgrowing the window shows on the dashboard instead of as a stuck recovery.
+  saturatedAddresses: number;
 };
 export type FillerFadeStatsMap = Record<string, FillerFadeStats>;
 export type FillerTimestamps = Map<string, Omit<TimestampRepoRow, 'hash'>>;
@@ -87,6 +98,17 @@ export const CLEAN_RUNS_PER_DECAY = 6;
 // NULL) exactly when it counts as new — resetting an honest filler's streak with no later
 // correction. Rows older than the lag have final load state, so classification is exact.
 // 2h = hourly load cadence + headroom for cross-table skew and job runtime.
+//
+// Known boundary (by design): a row is only classifiable while it survives in the query's
+// latest-ORDERS_PER_FILLER_LIMIT window per address, so streak classification degrades for
+// an address completing more than ORDERS_PER_FILLER_LIMIT orders per lag period (~50/hour
+// sustained) — evicted rows are never classified, thinning streak credit (and, in the
+// extreme, freezing decay). The 2-week backtest showed only the two busiest, never-escalated
+// addresses touch this (peak 2h bursts at 104-123% of the cap; 0.6% of all rows evicted
+// pre-classification, zero behavioral impact on escalated fillers).
+// CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES fires when an address's window no longer reaches
+// back to this horizon, so volume growth surfaces on the dashboard rather than as a stuck
+// recovery.
 export const STREAK_FINALITY_LAG_SECS = 2 * 60 * 60;
 // Cap on the block backoff: both the stored consecutiveBlocks counter and the duration
 // exponent stop growing here, so a single block/extension increment is at most
@@ -99,6 +121,12 @@ export const MAX_BLOCK_BACKOFF_EXPONENT = 7;
 // Minimum sample size before the chronic-rate watchlist metric is emitted, so one or two
 // orders don't chart as a 0%/100% swing.
 export const CHRONIC_RATE_MIN_SAMPLE = 10;
+// Rate floor for emitting the chronic-rate watchlist metric. Without it, every filler at
+// >= CHRONIC_RATE_MIN_SAMPLE orders/day gets a permanent per-filler CloudWatch series that
+// sits flat near 0 and is never consulted; a series should start exactly when a filler
+// becomes watch-worthy. Half the block threshold leaves generous headroom below the
+// enforcement line while still charting anyone trending toward it.
+export const CHRONIC_RATE_EMISSION_FLOOR = FADE_RATE_BLOCK_THRESHOLD / 2;
 
 const log = Logger.createLogger({
   name: 'FadeRate',
@@ -220,11 +248,19 @@ export function calculateNewTimestamps(
   const updatedTimestamps: ToUpdateTimestampRow[] = [];
   let newBlocks = 0;
   let extendedBlocks = 0;
+  let saturatedAddresses = 0;
   Object.entries(fillerFadeStats).forEach(([hash, stats]) => {
     const { fadeRate, duringBlockRate, newCompletions, newFades } = stats;
+    saturatedAddresses += stats.saturatedAddresses;
     const fillerTimestamp = fillerTimestamps.get(hash);
     const isCurrentlyBlocked = fillerTimestamp && fillerTimestamp.blockUntilTimestamp > newPostTimestamp;
-    const previousBlocks = fillerTimestamp?.consecutiveBlocks || 0;
+    // previousBlocks is the single clamped read of stored escalation: legacy rows predate the
+    // backoff cap (values > MAX would extend recovery beyond the documented bound and chart
+    // impossible levels), and corrupted rows could be negative (decay would drive them lower
+    // and 2^negative yields sub-base fractional blocks). Clamping once here covers every
+    // branch below — extend, keep, re-block, and decay — so pathological stored state
+    // normalizes on the next run regardless of which path the filler takes.
+    const previousBlocks = Math.min(Math.max(fillerTimestamp?.consecutiveBlocks || 0, 0), MAX_BLOCK_BACKOFF_EXPONENT);
     const previousCleanRuns = fillerTimestamp?.consecutiveCleanRuns || 0;
 
     // Per-filler rate so the distribution can be charted against FADE_RATE_BLOCK_THRESHOLD. While
@@ -235,12 +271,13 @@ export function calculateNewTimestamps(
     if (isCurrentlyBlocked) {
       metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE, hash), duringBlockRate, Unit.None);
     }
-    // Watchlist, not a trigger: the raw no-amnesty rate over the whole query window. Backtests
-    // show a low-volume filler can sustain ~20% raw inside the block threshold's envelope and
-    // that no trigger calibration catches them without unacceptable collateral — this metric
-    // keeps them visible for human follow-up instead. Gated on sample size to avoid charting
-    // 0%/100% single-order noise.
-    if (stats.chronicTotal >= CHRONIC_RATE_MIN_SAMPLE) {
+    // Watchlist, not a trigger: the raw no-amnesty rate over the query window's final rows.
+    // Backtests show a low-volume filler can sustain ~20% raw inside the block threshold's
+    // envelope and that no trigger calibration catches them without unacceptable collateral —
+    // this metric keeps them visible for human follow-up instead. Gated on sample size (so one
+    // or two orders don't chart as a 0%/100% swing) and a rate floor (so a per-filler series
+    // starts only when a filler becomes watch-worthy, not for every healthy filler forever).
+    if (stats.chronicTotal >= CHRONIC_RATE_MIN_SAMPLE && stats.chronicRate >= CHRONIC_RATE_EMISSION_FLOOR) {
       metrics?.putMetric(metricContext(Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE, hash), stats.chronicRate, Unit.None);
     }
 
@@ -254,9 +291,9 @@ export function calculateNewTimestamps(
       // in-flight fade offset by clean in-flight fills does not extend the block.
       const extendedBlockUntil = calculateBlockUntilTimestamp(
         fillerTimestamp.blockUntilTimestamp, // Extend from when current block ends
-        fillerTimestamp.consecutiveBlocks
+        previousBlocks
       );
-      consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp.consecutiveBlocks);
+      consecutiveBlocks = newConsecutiveBlocks(previousBlocks);
 
       extendedBlocks++;
       log?.info(
@@ -276,7 +313,7 @@ export function calculateNewTimestamps(
       // Blocked with the in-flight cohort under threshold - keep existing block and floor,
       // don't decay. Serving a bench is not recovery, so clean in-flight fills don't build
       // the decay streak either — but a sub-threshold in-flight fade still resets it.
-      consecutiveBlocks = fillerTimestamp.consecutiveBlocks;
+      consecutiveBlocks = previousBlocks;
       updatedTimestamps.push({
         hash,
         lastExaminedTimestamp: newPostTimestamp,
@@ -291,8 +328,8 @@ export function calculateNewTimestamps(
       // path that scores them. Over the rolling 24h window a filler can also cross the
       // threshold on a run with no new completions ("blocked while idle") as clean orders age
       // out; that is accepted behavior.
-      const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, fillerTimestamp?.consecutiveBlocks);
-      consecutiveBlocks = newConsecutiveBlocks(fillerTimestamp?.consecutiveBlocks);
+      const blockUntilTimestamp = calculateBlockUntilTimestamp(newPostTimestamp, previousBlocks);
+      consecutiveBlocks = newConsecutiveBlocks(previousBlocks);
 
       newBlocks++;
       log?.info(
@@ -354,7 +391,8 @@ export function calculateNewTimestamps(
   });
   metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS, newBlocks, Unit.Count);
   metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_EXTENDED_BLOCKS, extendedBlocks, Unit.Count);
-  log?.info({ updatedTimestamps, newBlocks, extendedBlocks }, 'updated timestamps');
+  metrics?.putMetric(Metric.CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES, saturatedAddresses, Unit.Count);
+  log?.info({ updatedTimestamps, newBlocks, extendedBlocks, saturatedAddresses }, 'updated timestamps');
   return updatedTimestamps;
 }
 
@@ -441,6 +479,11 @@ export function getFillersFadeStats(
       chronicTotal: number;
     }
   > = {};
+  // per-address row count and oldest deadline, to detect addresses whose latest-N window has
+  // outrun the streak finality horizon (rows evicted before they can be classified)
+  const addressRowCounts = new Map<string, number>();
+  const addressOldestDeadline = new Map<string, number>();
+  const addressHash = new Map<string, string>();
   rows.forEach((row) => {
     const fillerAddr = ethers.utils.getAddress(row.fillerAddress);
     const fillerHash = addressToFillerMap.get(fillerAddr);
@@ -448,6 +491,9 @@ export function getFillersFadeStats(
       log?.info({ fillerAddr }, 'filler address not found dynamo mapping');
       return;
     }
+    addressRowCounts.set(fillerAddr, (addressRowCounts.get(fillerAddr) ?? 0) + 1);
+    addressOldestDeadline.set(fillerAddr, Math.min(addressOldestDeadline.get(fillerAddr) ?? Infinity, row.deadline));
+    addressHash.set(fillerAddr, fillerHash);
     const fillerTimestamp = fillerTimestamps.get(fillerHash);
     if (!tallies[fillerHash]) {
       tallies[fillerHash] = {
@@ -463,9 +509,13 @@ export function getFillersFadeStats(
     }
     const windowStart = fillerTimestamp?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP;
     const lastExaminedTimestamp = fillerTimestamp?.lastExaminedTimestamp ?? 0;
-    // Chronic (no-amnesty) view: every row in the query window, regardless of cohort.
-    tallies[fillerHash].chronicTotal += 1;
-    tallies[fillerHash].chronicFades += row.faded;
+    // Chronic (no-amnesty) view: every FINAL row in the query window, regardless of cohort.
+    // Fresher rows are excluded for the same reason the streak defers them: a not-yet-loaded
+    // fill reads as a transient fade and would sawtooth the watchlist metric every load cycle.
+    if (row.deadline <= now - STREAK_FINALITY_LAG_SECS) {
+      tallies[fillerHash].chronicTotal += 1;
+      tallies[fillerHash].chronicFades += row.faded;
+    }
     // Streak inputs, classified against the finality-lagged horizon so hourly-batch load lag
     // can't miss a late fade or count a not-yet-loaded fill as a transient fade. The slices
     // partition time across runs because lastExaminedTimestamp advances to `now` each run.
@@ -492,6 +542,20 @@ export function getFillersFadeStats(
     }
   });
 
+  // An address is streak-degraded when it fills the latest-N cap AND its oldest returned row
+  // is fresher than the finality horizon: rows are then evicted from the window before they
+  // can ever be streak-classified. (Being at the cap alone is the designed adaptive window —
+  // high-volume addresses sit there constantly — so it is deliberately not flagged.)
+  const saturatedByHash: Record<string, number> = {};
+  addressRowCounts.forEach((count, addr) => {
+    const oldestDeadline = addressOldestDeadline.get(addr) ?? 0;
+    if (count >= ORDERS_PER_FILLER_LIMIT && oldestDeadline > now - STREAK_FINALITY_LAG_SECS) {
+      const hash = addressHash.get(addr)!;
+      saturatedByHash[hash] = (saturatedByHash[hash] ?? 0) + 1;
+      log?.info({ addr, hash, count, oldestDeadline }, 'filler address window has outrun the streak finality horizon');
+    }
+  });
+
   const stats: FillerFadeStatsMap = {};
   Object.entries(tallies).forEach(([hash, t]) => {
     stats[hash] = {
@@ -501,6 +565,7 @@ export function getFillersFadeStats(
       newFades: t.newFades,
       chronicRate: t.chronicTotal > 0 ? t.chronicFades / t.chronicTotal : 0,
       chronicTotal: t.chronicTotal,
+      saturatedAddresses: saturatedByHash[hash] ?? 0,
     };
   });
   log?.info({ tallies, stats }, 'fade stats by filler');

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -92,12 +92,20 @@ export enum Metric {
   // post-block FADE_RATE, which sits at the prior while blocked) is what shows a benched filler
   // above the threshold. Compare to FADE_RATE_BLOCK_THRESHOLD.
   CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE = 'CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE',
-  // Per-filler RAW (unsmoothed) fade rate over the entire query window, ignoring the
-  // clean-slate floor — the no-amnesty "chronic" view. Watchlist only, never a block trigger:
-  // it exists to surface persistent moderate faders who live inside the block threshold's
-  // small-sample envelope (e.g. ~20% raw at ~15 orders/day). Emitted only at a minimum sample
-  // size (CHRONIC_RATE_MIN_SAMPLE).
+  // Per-filler RAW (unsmoothed) fade rate over the query window's FINAL rows (past the
+  // streak finality horizon, so not-yet-loaded fills can't chart as transient fades),
+  // ignoring the clean-slate floor — the no-amnesty "chronic" view. Watchlist only, never a
+  // block trigger: it exists to surface persistent moderate faders who live inside the block
+  // threshold's small-sample envelope (e.g. ~20% raw at ~15 orders/day). Emitted only at a
+  // minimum sample size (CHRONIC_RATE_MIN_SAMPLE) and rate floor (CHRONIC_RATE_EMISSION_FLOOR)
+  // so per-filler series exist only for watch-worthy fillers.
   CIRCUIT_BREAKER_V2_CHRONIC_RATE = 'CIRCUIT_BREAKER_V2_CHRONIC_RATE',
+  // Filler addresses whose latest-N query window has outrun the streak finality horizon this
+  // run (window full AND its oldest row fresher than STREAK_FINALITY_LAG_SECS): rows for
+  // these addresses are evicted before they can be streak-classified, thinning decay credit.
+  // Merely sitting at the latest-N cap is the designed adaptive window and does not count.
+  // Sustained nonzero values mean per-address volume has outgrown the window parameters.
+  CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES = 'CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES',
   // Fillers newly blocked in a cron run (unblocked -> blocked)
   CIRCUIT_BREAKER_V2_NEW_BLOCKS = 'CIRCUIT_BREAKER_V2_NEW_BLOCKS',
   // Active blocks extended in a cron run (in-flight cohort faded over threshold while blocked)

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -92,6 +92,12 @@ export enum Metric {
   // post-block FADE_RATE, which sits at the prior while blocked) is what shows a benched filler
   // above the threshold. Compare to FADE_RATE_BLOCK_THRESHOLD.
   CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE = 'CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE',
+  // Per-filler RAW (unsmoothed) fade rate over the entire query window, ignoring the
+  // clean-slate floor — the no-amnesty "chronic" view. Watchlist only, never a block trigger:
+  // it exists to surface persistent moderate faders who live inside the block threshold's
+  // small-sample envelope (e.g. ~20% raw at ~15 orders/day). Emitted only at a minimum sample
+  // size (CHRONIC_RATE_MIN_SAMPLE).
+  CIRCUIT_BREAKER_V2_CHRONIC_RATE = 'CIRCUIT_BREAKER_V2_CHRONIC_RATE',
   // Fillers newly blocked in a cron run (unblocked -> blocked)
   CIRCUIT_BREAKER_V2_NEW_BLOCKS = 'CIRCUIT_BREAKER_V2_NEW_BLOCKS',
   // Active blocks extended in a cron run (in-flight cohort faded over threshold while blocked)
@@ -114,7 +120,8 @@ type MetricNeedingContext =
   | Metric.RFQ_TIMEOUT
   | Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS
   | Metric.CIRCUIT_BREAKER_V2_FADE_RATE
-  | Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE;
+  | Metric.CIRCUIT_BREAKER_V2_DURING_BLOCK_RATE
+  | Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE;
 
 export function metricContext(metric: MetricNeedingContext, context: string): string {
   return `${metric}_${context}`;

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -44,13 +44,12 @@ export type TimestampRepoRow = {
 // client), so the raw shape matches TimestampRepoRow — no string parsing.
 export type DynamoTimestampRepoRow = TimestampRepoRow;
 
-export type ToUpdateTimestampRow = Omit<
-  TimestampRepoRow,
-  'blockUntilTimestamp' | 'fadeWindowStart' | 'consecutiveCleanRuns'
-> & {
+// consecutiveCleanRuns stays required here: updateTimestampsBatch does a full-item put, so an
+// optional field a caller forgets to set would silently wipe the stored streak (reads default
+// missing attributes to 0).
+export type ToUpdateTimestampRow = Omit<TimestampRepoRow, 'blockUntilTimestamp' | 'fadeWindowStart'> & {
   blockUntilTimestamp?: number;
   fadeWindowStart?: number;
-  consecutiveCleanRuns?: number;
 };
 
 /*

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -34,15 +34,23 @@ export type TimestampRepoRow = {
   // Set to the block end whenever a block is applied/extended; 0 if the filler was never blocked.
   fadeWindowStart: number;
   consecutiveBlocks: number;
+  // Streak of consecutive clean runs (cron runs with >=1 new completion and 0 new fades)
+  // while unblocked and escalated. consecutiveBlocks decays one level per
+  // CLEAN_RUNS_PER_DECAY of these; any new fade resets the streak, idle runs freeze it.
+  consecutiveCleanRuns: number;
 };
 
 // Rows round-trip as native numbers now (number-typed attributes read via a wrapNumbers:false
 // client), so the raw shape matches TimestampRepoRow — no string parsing.
 export type DynamoTimestampRepoRow = TimestampRepoRow;
 
-export type ToUpdateTimestampRow = Omit<TimestampRepoRow, 'blockUntilTimestamp' | 'fadeWindowStart'> & {
+export type ToUpdateTimestampRow = Omit<
+  TimestampRepoRow,
+  'blockUntilTimestamp' | 'fadeWindowStart' | 'consecutiveCleanRuns'
+> & {
   blockUntilTimestamp?: number;
   fadeWindowStart?: number;
+  consecutiveCleanRuns?: number;
 };
 
 /*

--- a/lib/repositories/timestamp-repository.ts
+++ b/lib/repositories/timestamp-repository.ts
@@ -49,6 +49,7 @@ export class TimestampRepository implements BaseTimestampRepository {
         [`${DYNAMO_TABLE_KEY.BLOCK_UNTIL_TIMESTAMP}`]: { type: 'number' },
         [`${DYNAMO_TABLE_KEY.FADE_WINDOW_START}`]: { type: 'number' },
         [`${DYNAMO_TABLE_KEY.CONSECUTIVE_BLOCKS}`]: { type: 'number' },
+        [`${DYNAMO_TABLE_KEY.CONSECUTIVE_CLEAN_RUNS}`]: { type: 'number' },
       },
       table: table,
       autoExecute: true,
@@ -72,6 +73,7 @@ export class TimestampRepository implements BaseTimestampRepository {
           [`${DYNAMO_TABLE_KEY.BLOCK_UNTIL_TIMESTAMP}`]: row.blockUntilTimestamp,
           [`${DYNAMO_TABLE_KEY.FADE_WINDOW_START}`]: row.fadeWindowStart,
           [`${DYNAMO_TABLE_KEY.CONSECUTIVE_BLOCKS}`]: row.consecutiveBlocks,
+          [`${DYNAMO_TABLE_KEY.CONSECUTIVE_CLEAN_RUNS}`]: row.consecutiveCleanRuns,
         });
       }),
       {
@@ -93,6 +95,7 @@ export class TimestampRepository implements BaseTimestampRepository {
       blockUntilTimestamp: Item?.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
       fadeWindowStart: Item?.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
       consecutiveBlocks: Item?.consecutiveBlocks ?? 0,
+      consecutiveCleanRuns: Item?.consecutiveCleanRuns ?? 0,
     };
   }
 
@@ -115,6 +118,7 @@ export class TimestampRepository implements BaseTimestampRepository {
         blockUntilTimestamp: row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         fadeWindowStart: row.fadeWindowStart ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
         consecutiveBlocks: row.consecutiveBlocks ?? 0,
+        consecutiveCleanRuns: row.consecutiveCleanRuns ?? 0,
       };
     });
   }
@@ -128,6 +132,7 @@ export class TimestampRepository implements BaseTimestampRepository {
         blockUntilTimestamp: row.blockUntilTimestamp,
         fadeWindowStart: row.fadeWindowStart,
         consecutiveBlocks: row.consecutiveBlocks,
+        consecutiveCleanRuns: row.consecutiveCleanRuns,
       });
     });
     return res;

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -8,6 +8,7 @@ import {
   CLEAN_RUNS_PER_DECAY,
   countActiveBlocks,
   FADE_RATE_BLOCK_THRESHOLD,
+  FillerFadeStats,
   FillerFadeStatsMap,
   FillerTimestamps,
   getFillersFadeStats,
@@ -15,12 +16,15 @@ import {
   LAPLACE_ALPHA,
   LAPLACE_BETA,
   MAX_BLOCK_BACKOFF_EXPONENT,
+  STREAK_FINALITY_LAG_SECS,
   UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
 } from '../../lib/cron/fade-rate-v2';
 import { Metric, metricContext } from '../../lib/entities';
-import { ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
+import { TimestampRepoRow, ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
 
 const now = Math.floor(Date.now() / 1000);
+// deadlines at least this old are past the streak's finality horizon (load state final)
+const FINAL = STREAK_FINALITY_LAG_SECS + 100;
 
 // silent logger in tests
 const logger = Logger.createLogger({ name: 'test' });
@@ -32,6 +36,26 @@ const order = (fillerAddress: string, faded: 0 | 1, deadline: number): V2FadesRo
   faded,
   postTimestamp: deadline - 20,
   deadline,
+});
+
+// factories so tests spell out only the fields they exercise; defaults are a quiet,
+// under-threshold filler with no stored circuit-breaker history
+const fadeStats = (overrides: Partial<FillerFadeStats> = {}): FillerFadeStats => ({
+  fadeRate: 0.05,
+  duringBlockRate: 0.05,
+  newCompletions: 1,
+  newFades: 0,
+  chronicRate: 0,
+  chronicTotal: 0,
+  ...overrides,
+});
+const cbState = (overrides: Partial<Omit<TimestampRepoRow, 'hash'>> = {}): Omit<TimestampRepoRow, 'hash'> => ({
+  lastExaminedTimestamp: now - 100,
+  blockUntilTimestamp: 0,
+  fadeWindowStart: now - 50,
+  consecutiveBlocks: 0,
+  consecutiveCleanRuns: 0,
+  ...overrides,
 });
 
 describe('FadeRateV2 cron', () => {
@@ -88,17 +112,17 @@ describe('FadeRateV2 cron', () => {
       const rows: V2FadesRowType[] = [
         ...Array(3)
           .fill(0)
-          .map(() => order('0x0000000000000000000000000000000000000001', 1, now - 50)),
+          .map(() => order('0x0000000000000000000000000000000000000001', 1, now - FINAL)),
         ...Array(7)
           .fill(0)
-          .map(() => order('0x0000000000000000000000000000000000000001', 0, now - 50)),
+          .map(() => order('0x0000000000000000000000000000000000000001', 0, now - FINAL)),
       ];
-      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), now, logger);
       // window = all 10 orders (no prior block), rate = (3+1)/(10+20) = 4/30
       expect(stats['fillerA'].fadeRate).toBeCloseTo(4 / 30, 6);
       // never blocked => empty during-block cohort => prior mean
       expect(stats['fillerA'].duringBlockRate).toBeCloseTo(0.05, 6);
-      // no prior timestamp => every completion is new
+      // no prior timestamp => every final completion is new
       expect(stats['fillerA'].newCompletions).toEqual(10);
       expect(stats['fillerA'].newFades).toEqual(3);
       // chronic view: raw rate over all rows, no smoothing
@@ -106,37 +130,53 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerA'].chronicTotal).toEqual(10);
     });
 
+    it('defers streak classification until rows are final (batch load lag)', () => {
+      // A fade fresher than STREAK_FINALITY_LAG_SECS scores in the rate window immediately,
+      // but is not classified for the streak yet: its load state may still change (a fill row
+      // that lands next batch would flip it to faded=0), so counting it now could reset an
+      // honest filler's streak on a transient. It is classified once it ages past the horizon.
+      const fresh = order('0x0000000000000000000000000000000000000001', 1, now - 100);
+      const stats = getFillersFadeStats([fresh], ADDRESS_TO_FILLER, new Map(), now, logger);
+      expect(stats['fillerA'].fadeRate).toBeCloseTo(2 / 21, 6); // scored for blocking
+      expect(stats['fillerA'].newCompletions).toEqual(0); // not yet streak-classified
+      expect(stats['fillerA'].newFades).toEqual(0);
+
+      // next run after the row ages past the horizon: classified exactly once
+      const later = now + STREAK_FINALITY_LAG_SECS;
+      const timestamps: FillerTimestamps = new Map([
+        ['fillerA', cbState({ lastExaminedTimestamp: now, fadeWindowStart: 0 })],
+      ]);
+      const statsLater = getFillersFadeStats([fresh], ADDRESS_TO_FILLER, timestamps, later, logger);
+      expect(statsLater['fillerA'].newCompletions).toEqual(1);
+      expect(statsLater['fillerA'].newFades).toEqual(1);
+    });
+
     it('excludes pre-block orders from the rate window', () => {
       const fillerTimestamps: FillerTimestamps = new Map([
-        // fadeWindowStart (the clean-slate floor) is the last block end at now-200
+        // fadeWindowStart (the clean-slate floor) is the last block end at now-20000
         [
           'fillerB',
-          {
-            lastExaminedTimestamp: now - 150,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 200,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
+          cbState({ lastExaminedTimestamp: now - 15000, fadeWindowStart: now - 20000, consecutiveBlocks: 1 }),
         ],
       ]);
       const rows: V2FadesRowType[] = [
-        // pre-block fades (deadline now-300, before block end now-200): excluded from window;
-        // also before lastExaminedTimestamp (now-150) so not part of the during-block cohort
-        order('0x0000000000000000000000000000000000000002', 1, now - 300),
-        order('0x0000000000000000000000000000000000000002', 1, now - 300),
-        // post-block orders (deadline now-100): 1 faded + 4 clean
-        order('0x0000000000000000000000000000000000000002', 1, now - 100),
+        // pre-block fades (deadline now-30000, before block end now-20000): excluded from
+        // window; also before lastExaminedTimestamp (now-15000) so already streak-classified
+        // by an earlier run and not part of the during-block cohort
+        order('0x0000000000000000000000000000000000000002', 1, now - 30000),
+        order('0x0000000000000000000000000000000000000002', 1, now - 30000),
+        // post-block orders (deadline now-10000, past the finality horizon): 1 faded + 4 clean
+        order('0x0000000000000000000000000000000000000002', 1, now - 10000),
         ...Array(4)
           .fill(0)
-          .map(() => order('0x0000000000000000000000000000000000000002', 0, now - 100)),
+          .map(() => order('0x0000000000000000000000000000000000000002', 0, now - 10000)),
       ];
-      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, now, logger);
       // window = 5 post-block orders, 1 faded => (1+1)/(5+20) = 2/25
       expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 25, 6);
       // stale pre-block fades don't resurrect as a during-block cohort
       expect(stats['fillerB'].duringBlockRate).toBeCloseTo(0.05, 6);
-      // only the 5 post-lastPost orders are new completions, 1 of them faded
+      // only the 5 final post-block orders are newly streak-classified, 1 of them faded
       expect(stats['fillerB'].newCompletions).toEqual(5);
       expect(stats['fillerB'].newFades).toEqual(1);
       // chronic view has NO amnesty: the pre-block fades excluded from the rate window still
@@ -146,50 +186,45 @@ describe('FadeRateV2 cron', () => {
     });
 
     it('scores in-flight orders that completed during a block, even after it expired', () => {
-      // Block ran until now-100 and has expired; the last cron run was at now-400 (while
-      // blocked). Orders completed in between (deadline in (now-400, now-100]) were in
-      // flight during the block: below the clean-slate floor, so they never enter the
-      // post-block window — the during-block cohort is the only path that scores them.
+      // Block ran until now-10000 and has expired; the last cron run was at now-40000 (while
+      // blocked). Orders completed in between were in flight during the block: below the
+      // clean-slate floor, so they never enter the post-block window — the during-block
+      // cohort is the only path that scores them.
       const fillerTimestamps: FillerTimestamps = new Map([
-        // block ended at now-100 => fadeWindowStart is now-100; last cron run at now-400
         [
           'fillerB',
-          {
-            lastExaminedTimestamp: now - 400,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 100,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
+          cbState({ lastExaminedTimestamp: now - 40000, fadeWindowStart: now - 10000, consecutiveBlocks: 1 }),
         ],
       ]);
       const rows: V2FadesRowType[] = [
         // during-block cohort: 2 faded + 1 clean
-        order('0x0000000000000000000000000000000000000002', 1, now - 200),
-        order('0x0000000000000000000000000000000000000002', 1, now - 200),
-        order('0x0000000000000000000000000000000000000002', 0, now - 200),
-        // post-block window: 1 clean
-        order('0x0000000000000000000000000000000000000002', 0, now - 50),
+        order('0x0000000000000000000000000000000000000002', 1, now - 20000),
+        order('0x0000000000000000000000000000000000000002', 1, now - 20000),
+        order('0x0000000000000000000000000000000000000002', 0, now - 20000),
+        // post-block window: 1 clean (past the finality horizon)
+        order('0x0000000000000000000000000000000000000002', 0, now - FINAL),
       ];
-      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, logger);
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, fillerTimestamps, now, logger);
       // cohort = (2+1)/(3+20) = 3/23 ≈ 13.0% > threshold => calculateNewTimestamps re-blocks
       expect(stats['fillerB'].duringBlockRate).toBeCloseTo(3 / 23, 6);
       expect(stats['fillerB'].duringBlockRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
       // window = 1 clean post-block order
       expect(stats['fillerB'].fadeRate).toBeCloseTo(1 / 21, 6);
-      expect(stats['fillerB'].newCompletions).toEqual(4);
-      // during-block fades still count as new fades (they break the decay streak)
+      // only the post-floor clean fill earns streak credit: fills served while benched are
+      // not recovery, so the 3 during-block completions don't count...
+      expect(stats['fillerB'].newCompletions).toEqual(1);
+      // ...but during-block FADES still count against the streak (a fade is a fade)
       expect(stats['fillerB'].newFades).toEqual(2);
     });
 
     it('aggregates multiple addresses belonging to the same filler', () => {
       const rows: V2FadesRowType[] = [
-        order('0x0000000000000000000000000000000000000003', 1, now - 40),
-        order('0x0000000000000000000000000000000000000004', 1, now - 40),
-        order('0x0000000000000000000000000000000000000004', 0, now - 40),
-        order('0x0000000000000000000000000000000000000004', 0, now - 40),
+        order('0x0000000000000000000000000000000000000003', 1, now - FINAL),
+        order('0x0000000000000000000000000000000000000004', 1, now - FINAL),
+        order('0x0000000000000000000000000000000000000004', 0, now - FINAL),
+        order('0x0000000000000000000000000000000000000004', 0, now - FINAL),
       ];
-      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), logger);
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), now, logger);
       // combined: 2 faded / 4 total => (2+1)/(4+20) = 3/24 = 0.125
       expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 24, 6);
       expect(stats['fillerC'].duringBlockRate).toBeCloseTo(0.05, 6);
@@ -216,16 +251,7 @@ describe('FadeRateV2 cron', () => {
   describe('calculateNewTimestamps', () => {
     it('blocks a filler whose fade rate exceeds the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = {
-        newBad: {
-          fadeRate: 0.2,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { newBad: fadeStats({ fadeRate: 0.2, newFades: 1 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row).toEqual({
         hash: 'newBad',
@@ -239,9 +265,7 @@ describe('FadeRateV2 cron', () => {
 
     it('does not block a filler under the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = {
-        ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0, chronicRate: 0, chronicTotal: 0 },
-      };
+      const stats: FillerFadeStatsMap = { ok: fadeStats() };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
       expect(row.fadeWindowStart).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // never blocked
@@ -252,56 +276,40 @@ describe('FadeRateV2 cron', () => {
     it('uses consecutiveBlocks for backoff when re-blocking', () => {
       // previously blocked twice, block now expired (past), breaches again
       const timestamps: FillerTimestamps = new Map([
-        [
-          'repeat',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 10,
-            consecutiveBlocks: 2,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['repeat', cbState({ fadeWindowStart: now - 10, consecutiveBlocks: 2 })],
       ]);
-      const stats: FillerFadeStatsMap = {
-        repeat: {
-          fadeRate: 0.3,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { repeat: fadeStats({ fadeRate: 0.3, newFades: 1 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
       expect(row.fadeWindowStart).toEqual(now + BASE_BLOCK_SECS * 4);
       expect(row.consecutiveBlocks).toEqual(3);
     });
 
+    it('caps consecutiveBlocks so recovery time is bounded along with block duration', () => {
+      // A filler with a long block history: the stored counter must not keep growing past the
+      // backoff cap, else full recovery (consecutiveBlocks * CLEAN_RUNS_PER_DECAY clean runs)
+      // grows with history and a long-reformed filler stays one fade from a max-length block.
+      const timestamps: FillerTimestamps = new Map([
+        ['maxed', cbState({ fadeWindowStart: now - 10, consecutiveBlocks: MAX_BLOCK_BACKOFF_EXPONENT })],
+      ]);
+      const stats: FillerFadeStatsMap = { maxed: fadeStats({ fadeRate: 0.3, newFades: 1 }) };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2 ** MAX_BLOCK_BACKOFF_EXPONENT);
+      expect(row.consecutiveBlocks).toEqual(MAX_BLOCK_BACKOFF_EXPONENT); // counter capped too
+    });
+
     it('resets blockUntilTimestamp but preserves fadeWindowStart when the decay streak completes', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'recovering',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
+          cbState({
             fadeWindowStart: now - 500,
             consecutiveBlocks: 2,
             consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1, // this clean run completes the streak
-          },
+          }),
         ],
       ]);
-      const stats: FillerFadeStatsMap = {
-        recovering: {
-          fadeRate: 0.05,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { recovering: fadeStats() };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // not blocked
       expect(row.fadeWindowStart).toEqual(now - 500); // clean-slate floor preserved independently
@@ -314,27 +322,9 @@ describe('FadeRateV2 cron', () => {
       // the newCompletions gate, escalation would decay every 10-minute cron run while they
       // simply idle — resetting 3 -> 0 in ~30 minutes with zero demonstrated clean fills.
       const timestamps: FillerTimestamps = new Map([
-        [
-          'idler',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 50,
-            consecutiveBlocks: 3,
-            consecutiveCleanRuns: 2,
-          },
-        ],
+        ['idler', cbState({ consecutiveBlocks: 3, consecutiveCleanRuns: 2 })],
       ]);
-      const stats: FillerFadeStatsMap = {
-        idler: {
-          fadeRate: 0.05,
-          duringBlockRate: 0.05,
-          newCompletions: 0,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { idler: fadeStats({ newCompletions: 0 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.consecutiveBlocks).toEqual(3); // frozen, not decayed
       expect(row.consecutiveCleanRuns).toEqual(2); // idle doesn't build the streak, but doesn't break it either
@@ -343,29 +333,11 @@ describe('FadeRateV2 cron', () => {
 
     it('extends the block when in-flight orders fade at over the threshold rate while blocked', () => {
       const timestamps: FillerTimestamps = new Map([
-        [
-          'blockedFader',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: now + 500,
-            fadeWindowStart: now + 500,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['blockedFader', cbState({ blockUntilTimestamp: now + 500, fadeWindowStart: now + 500, consecutiveBlocks: 1 })],
       ]);
       // post-block rate sits at the prior (blocked => empty window), but the in-flight
       // cohort faded at over the threshold rate
-      const stats: FillerFadeStatsMap = {
-        blockedFader: {
-          fadeRate: 0.05,
-          duringBlockRate: 0.2,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { blockedFader: fadeStats({ duringBlockRate: 0.2, newFades: 1 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
       expect(row.fadeWindowStart).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // floor tracks the extended end
@@ -377,27 +349,19 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'blockedBusy',
-          {
-            lastExaminedTimestamp: now - 100,
+          cbState({
             blockUntilTimestamp: now + 500,
             fadeWindowStart: now + 500,
             consecutiveBlocks: 1,
             consecutiveCleanRuns: 3,
-          },
+          }),
         ],
       ]);
       // 1 fade among 19 clean in-flight fills: (1+1)/(20+20) = 5% <= threshold.
       // Under the old count-based rule (newFades > 0) this high-volume filler's block
       // would have been extended by a single statistical fade.
       const stats: FillerFadeStatsMap = {
-        blockedBusy: {
-          fadeRate: 0.05,
-          duringBlockRate: laplaceSmoothedFadeRate(1, 20),
-          newCompletions: 20,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
+        blockedBusy: fadeStats({ duringBlockRate: laplaceSmoothedFadeRate(1, 20), newCompletions: 20, newFades: 1 }),
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500); // kept, not extended
@@ -409,27 +373,9 @@ describe('FadeRateV2 cron', () => {
       // The block expired between cron runs; the fades landed while it was active, so they
       // sit below the clean-slate floor (fadeRate at prior) — duringBlockRate catches them.
       const timestamps: FillerTimestamps = new Map([
-        [
-          'lateFader',
-          {
-            lastExaminedTimestamp: now - 400,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 10,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['lateFader', cbState({ lastExaminedTimestamp: now - 400, fadeWindowStart: now - 10, consecutiveBlocks: 1 })],
       ]);
-      const stats: FillerFadeStatsMap = {
-        lateFader: {
-          fadeRate: 0.05,
-          duringBlockRate: 0.14,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { lateFader: fadeStats({ duringBlockRate: 0.14, newFades: 1 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2); // 2^1 backoff
       expect(row.consecutiveBlocks).toEqual(2);
@@ -439,26 +385,16 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'blockedClean',
-          {
-            lastExaminedTimestamp: now - 100,
+          cbState({
             blockUntilTimestamp: now + 300,
             fadeWindowStart: now + 300,
             consecutiveBlocks: 1,
             consecutiveCleanRuns: 2,
-          },
+          }),
         ],
       ]);
       // even a high (stale) window rate must not extend an active block by itself
-      const stats: FillerFadeStatsMap = {
-        blockedClean: {
-          fadeRate: 0.9,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { blockedClean: fadeStats({ fadeRate: 0.9 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 300);
       expect(row.fadeWindowStart).toEqual(now + 300);
@@ -470,27 +406,9 @@ describe('FadeRateV2 cron', () => {
     it('decays one escalation level only after CLEAN_RUNS_PER_DECAY consecutive clean runs', () => {
       const state = (consecutiveBlocks: number, consecutiveCleanRuns: number, lastExaminedTimestamp: number) =>
         new Map([
-          [
-            'gamer',
-            {
-              lastExaminedTimestamp,
-              blockUntilTimestamp: 0,
-              fadeWindowStart: now - 50,
-              consecutiveBlocks,
-              consecutiveCleanRuns,
-            },
-          ],
+          ['gamer', cbState({ lastExaminedTimestamp, consecutiveBlocks, consecutiveCleanRuns })],
         ]) as FillerTimestamps;
-      const clean: FillerFadeStatsMap = {
-        gamer: {
-          fadeRate: 0.04,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const clean: FillerFadeStatsMap = { gamer: fadeStats({ fadeRate: 0.04 }) };
 
       // clean runs build the streak without decaying until the streak completes
       let timestamps = state(3, 0, now - 100);
@@ -498,7 +416,7 @@ describe('FadeRateV2 cron', () => {
         const [row] = calculateNewTimestamps(timestamps, clean, now + run * 600, logger);
         expect(row.consecutiveBlocks).toEqual(3); // not yet
         expect(row.consecutiveCleanRuns).toEqual(run);
-        timestamps = state(row.consecutiveBlocks, row.consecutiveCleanRuns ?? 0, row.lastExaminedTimestamp);
+        timestamps = state(row.consecutiveBlocks, row.consecutiveCleanRuns, row.lastExaminedTimestamp);
       }
       // the CLEAN_RUNS_PER_DECAY-th clean run decays one level and restarts the streak
       const [row] = calculateNewTimestamps(timestamps, clean, now + CLEAN_RUNS_PER_DECAY * 600, logger);
@@ -511,26 +429,11 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'almostRecovered',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 50,
-            consecutiveBlocks: 2,
-            consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1, // one clean run away from a decay
-          },
+          cbState({ consecutiveBlocks: 2, consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1 }), // one clean run from a decay
         ],
       ]);
       // under threshold, but the run's one new completion faded
-      const stats: FillerFadeStatsMap = {
-        almostRecovered: {
-          fadeRate: 0.09,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-      };
+      const stats: FillerFadeStatsMap = { almostRecovered: fadeStats({ fadeRate: 0.09, newFades: 1 }) };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // still not blocked
       expect(row.consecutiveBlocks).toEqual(2); // and not decayed
@@ -539,42 +442,12 @@ describe('FadeRateV2 cron', () => {
 
     it('processes a mix of fillers in one pass', () => {
       const timestamps: FillerTimestamps = new Map([
-        [
-          'blocked',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: now + 500,
-            fadeWindowStart: now + 500,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['blocked', cbState({ blockUntilTimestamp: now + 500, fadeWindowStart: now + 500, consecutiveBlocks: 1 })],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: {
-          fadeRate: 0.25,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-        clean: {
-          fadeRate: 0.03,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-        blocked: {
-          fadeRate: 0.05,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
+        breach: fadeStats({ fadeRate: 0.25, newFades: 1 }),
+        clean: fadeStats({ fadeRate: 0.03 }),
+        blocked: fadeStats(),
       };
       const rows: ToUpdateTimestampRow[] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(rows).toHaveLength(3);
@@ -587,42 +460,12 @@ describe('FadeRateV2 cron', () => {
     it('emits per-filler fade rates and new/extended block counters', () => {
       const metrics = { putMetric: jest.fn() } as any;
       const timestamps: FillerTimestamps = new Map([
-        [
-          'extendMe',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: now + 500,
-            fadeWindowStart: now + 500,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['extendMe', cbState({ blockUntilTimestamp: now + 500, fadeWindowStart: now + 500, consecutiveBlocks: 1 })],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: {
-          fadeRate: 0.25,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        }, // trips a new block
-        clean: {
-          fadeRate: 0.03,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        },
-        extendMe: {
-          fadeRate: 0.05,
-          duringBlockRate: 0.2,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 0,
-          chronicTotal: 0,
-        }, // extends an active block
+        breach: fadeStats({ fadeRate: 0.25, newFades: 1 }), // trips a new block
+        clean: fadeStats({ fadeRate: 0.03 }),
+        extendMe: fadeStats({ duringBlockRate: 0.2, newFades: 1 }), // extends an active block
       };
       calculateNewTimestamps(timestamps, stats, now, logger, metrics);
 
@@ -676,24 +519,11 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'recovering',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 50,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1, // this clean run completes the streak
-          },
+          cbState({ consecutiveBlocks: 1, consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1 }), // streak completes
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        recovering: {
-          fadeRate: 0.03,
-          duringBlockRate: 0.05,
-          newCompletions: 5,
-          newFades: 0,
-          chronicRate: 0,
-          chronicTotal: 0,
-        }, // decays 1 -> 0
+        recovering: fadeStats({ fadeRate: 0.03, newCompletions: 5 }), // decays 1 -> 0
       };
       calculateNewTimestamps(timestamps, stats, now, logger, metrics);
 
@@ -710,23 +540,9 @@ describe('FadeRateV2 cron', () => {
       const stats: FillerFadeStatsMap = {
         // a low-volume ~20% fader living inside the block threshold's envelope: never blocked,
         // but the watchlist metric keeps them visible
-        watchme: {
-          fadeRate: 0.11,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 0,
-          chronicRate: 0.2,
-          chronicTotal: CHRONIC_RATE_MIN_SAMPLE,
-        },
+        watchme: fadeStats({ fadeRate: 0.11, chronicRate: 0.2, chronicTotal: CHRONIC_RATE_MIN_SAMPLE }),
         // below the sample gate: a single faded order must not chart as a 100% swing
-        tiny: {
-          fadeRate: 0.09,
-          duringBlockRate: 0.05,
-          newCompletions: 1,
-          newFades: 1,
-          chronicRate: 1,
-          chronicTotal: CHRONIC_RATE_MIN_SAMPLE - 1,
-        },
+        tiny: fadeStats({ fadeRate: 0.09, newFades: 1, chronicRate: 1, chronicTotal: CHRONIC_RATE_MIN_SAMPLE - 1 }),
       };
       calculateNewTimestamps(new Map(), stats, now, logger, metrics);
       expect(metrics.putMetric).toHaveBeenCalledWith(
@@ -753,28 +569,21 @@ describe('FadeRateV2 cron', () => {
     // a week of ~94% fading with consecutiveBlocks sitting at 2.
     const ELK_ADDR = '0x0000000000000000000000000000000000000005';
     const ELK_MAP = new Map<string, string>([[ELK_ADDR, 'elk']]);
-    const floor = now - 7200; // last block ended 2h ago (clean-slate floor)
+    const floor = now - 20000; // last block ended ~5.5h ago (clean-slate floor)
 
     const elkState = (consecutiveBlocks: number, lastExaminedTimestamp: number) =>
       new Map([
-        [
-          'elk',
-          {
-            lastExaminedTimestamp,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: floor,
-            consecutiveBlocks,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['elk', cbState({ lastExaminedTimestamp, fadeWindowStart: floor, consecutiveBlocks })],
       ]) as FillerTimestamps;
 
     it('does not decay consecutiveBlocks on a run whose only new completion is a fade', () => {
       const t1 = now - 600;
       const fillerTimestamps = elkState(2, t1 - 600);
-      // one faded order completed since the last run; window rate (1+1)/(1+20) is under threshold
-      const stats = getFillersFadeStats([order(ELK_ADDR, 1, t1 - 100)], ELK_MAP, fillerTimestamps, logger);
+      // one faded order past the finality horizon (visible in this batch, streak-classified
+      // this run); window rate (1+1)/(1+20) is under threshold
+      const stats = getFillersFadeStats([order(ELK_ADDR, 1, t1 - FINAL)], ELK_MAP, fillerTimestamps, t1, logger);
       expect(stats['elk'].fadeRate).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
+      expect(stats['elk'].newFades).toEqual(1);
 
       const [row] = calculateNewTimestamps(fillerTimestamps, stats, t1, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // correctly not blocked yet
@@ -784,28 +593,29 @@ describe('FadeRateV2 cron', () => {
     it('keeps full exponential backoff across a lone-fade -> trip cycle', () => {
       const t1 = now - 600;
       const t2 = now;
-      const fade1 = order(ELK_ADDR, 1, t1 - 100);
-      const fade2 = order(ELK_ADDR, 1, t2 - 100);
+      // each fade ages past the finality horizon in time for the corresponding run's slice
+      const fade1 = order(ELK_ADDR, 1, t1 - FINAL);
+      const fade2 = order(ELK_ADDR, 1, t2 - FINAL);
 
       // run 1: lone sub-threshold fade
       const state1 = elkState(2, t1 - 600);
-      const stats1 = getFillersFadeStats([fade1], ELK_MAP, state1, logger);
+      const stats1 = getFillersFadeStats([fade1], ELK_MAP, state1, t1, logger);
       const [row1] = calculateNewTimestamps(state1, stats1, t1, logger);
 
-      // run 2: second fade puts the window at 3/22 > threshold -> block
+      // run 2: second fade (loaded in the next batch) puts the window at 3/22 > threshold -> block
       const state2 = new Map([
         [
           'elk',
-          {
+          cbState({
             lastExaminedTimestamp: row1.lastExaminedTimestamp,
             blockUntilTimestamp: row1.blockUntilTimestamp ?? 0,
             fadeWindowStart: row1.fadeWindowStart ?? 0,
             consecutiveBlocks: row1.consecutiveBlocks,
-            consecutiveCleanRuns: row1.consecutiveCleanRuns ?? 0,
-          },
+            consecutiveCleanRuns: row1.consecutiveCleanRuns,
+          }),
         ],
       ]) as FillerTimestamps;
-      const stats2 = getFillersFadeStats([fade1, fade2], ELK_MAP, state2, logger);
+      const stats2 = getFillersFadeStats([fade1, fade2], ELK_MAP, state2, t2, logger);
       expect(stats2['elk'].fadeRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
 
       const [row2] = calculateNewTimestamps(state2, stats2, t2, logger);
@@ -820,38 +630,11 @@ describe('FadeRateV2 cron', () => {
     it('counts benched fillers across stored and updated state, updates taking precedence', () => {
       const timestamps: FillerTimestamps = new Map([
         // benched with no completions this run: no update row, still active
-        [
-          'benchedIdle',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: now + 500,
-            fadeWindowStart: now + 500,
-            consecutiveBlocks: 1,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['benchedIdle', cbState({ blockUntilTimestamp: now + 500, fadeWindowStart: now + 500, consecutiveBlocks: 1 })],
         // recovered: past block, no update
-        [
-          'recovered',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 50,
-            consecutiveBlocks: 0,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['recovered', cbState()],
         // stored state says unblocked, but this run blocks them
-        [
-          'justBlocked',
-          {
-            lastExaminedTimestamp: now - 100,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: now - 50,
-            consecutiveBlocks: 0,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['justBlocked', cbState()],
       ]);
       const updated: ToUpdateTimestampRow[] = [
         {
@@ -860,6 +643,7 @@ describe('FadeRateV2 cron', () => {
           blockUntilTimestamp: now + 900,
           fadeWindowStart: now + 900,
           consecutiveBlocks: 1,
+          consecutiveCleanRuns: 0,
         },
         {
           hash: 'newClean',
@@ -867,6 +651,7 @@ describe('FadeRateV2 cron', () => {
           blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
           fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
           consecutiveBlocks: 0,
+          consecutiveCleanRuns: 0,
         },
       ];
       expect(countActiveBlocks(timestamps, updated, now)).toEqual(2); // benchedIdle + justBlocked
@@ -874,19 +659,16 @@ describe('FadeRateV2 cron', () => {
 
     it('treats an unset (0 / undefined) blockUntilTimestamp as unblocked', () => {
       const timestamps: FillerTimestamps = new Map([
-        [
-          'unsetRow',
-          {
-            lastExaminedTimestamp: 1,
-            blockUntilTimestamp: 0,
-            fadeWindowStart: 0,
-            consecutiveBlocks: 0,
-            consecutiveCleanRuns: 0,
-          },
-        ],
+        ['unsetRow', cbState({ lastExaminedTimestamp: 1, fadeWindowStart: 0 })],
       ]);
       const updated: ToUpdateTimestampRow[] = [
-        { hash: 'undefRow', lastExaminedTimestamp: now, blockUntilTimestamp: undefined, consecutiveBlocks: 0 },
+        {
+          hash: 'undefRow',
+          lastExaminedTimestamp: now,
+          blockUntilTimestamp: undefined,
+          consecutiveBlocks: 0,
+          consecutiveCleanRuns: 0,
+        },
       ];
       expect(countActiveBlocks(timestamps, updated, now)).toEqual(0);
     });

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -4,6 +4,7 @@ import {
   BASE_BLOCK_SECS,
   calculateBlockUntilTimestamp,
   calculateNewTimestamps,
+  CHRONIC_RATE_MIN_SAMPLE,
   CLEAN_RUNS_PER_DECAY,
   countActiveBlocks,
   FADE_RATE_BLOCK_THRESHOLD,
@@ -13,6 +14,7 @@ import {
   laplaceSmoothedFadeRate,
   LAPLACE_ALPHA,
   LAPLACE_BETA,
+  MAX_BLOCK_BACKOFF_EXPONENT,
   UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
 } from '../../lib/cron/fade-rate-v2';
 import { Metric, metricContext } from '../../lib/entities';
@@ -99,6 +101,9 @@ describe('FadeRateV2 cron', () => {
       // no prior timestamp => every completion is new
       expect(stats['fillerA'].newCompletions).toEqual(10);
       expect(stats['fillerA'].newFades).toEqual(3);
+      // chronic view: raw rate over all rows, no smoothing
+      expect(stats['fillerA'].chronicRate).toBeCloseTo(3 / 10, 6);
+      expect(stats['fillerA'].chronicTotal).toEqual(10);
     });
 
     it('excludes pre-block orders from the rate window', () => {
@@ -134,6 +139,10 @@ describe('FadeRateV2 cron', () => {
       // only the 5 post-lastPost orders are new completions, 1 of them faded
       expect(stats['fillerB'].newCompletions).toEqual(5);
       expect(stats['fillerB'].newFades).toEqual(1);
+      // chronic view has NO amnesty: the pre-block fades excluded from the rate window still
+      // count here (3 fades over all 7 rows)
+      expect(stats['fillerB'].chronicRate).toBeCloseTo(3 / 7, 6);
+      expect(stats['fillerB'].chronicTotal).toEqual(7);
     });
 
     it('scores in-flight orders that completed during a block, even after it expired', () => {
@@ -194,13 +203,28 @@ describe('FadeRateV2 cron', () => {
       expect(calculateBlockUntilTimestamp(now, 2)).toEqual(now + BASE_BLOCK_SECS * 4);
       expect(calculateBlockUntilTimestamp(now, undefined)).toEqual(now + BASE_BLOCK_SECS);
     });
+
+    it('caps the backoff exponent so a single increment never exceeds 32 hours', () => {
+      const capped = now + BASE_BLOCK_SECS * 2 ** MAX_BLOCK_BACKOFF_EXPONENT;
+      expect(calculateBlockUntilTimestamp(now, MAX_BLOCK_BACKOFF_EXPONENT)).toEqual(capped);
+      expect(calculateBlockUntilTimestamp(now, MAX_BLOCK_BACKOFF_EXPONENT + 1)).toEqual(capped);
+      expect(calculateBlockUntilTimestamp(now, 50)).toEqual(capped);
+      expect(capped - now).toEqual(32 * 3600); // pin the intended ceiling in wall-clock terms
+    });
   });
 
   describe('calculateNewTimestamps', () => {
     it('blocks a filler whose fade rate exceeds the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
       const stats: FillerFadeStatsMap = {
-        newBad: { fadeRate: 0.2, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+        newBad: {
+          fadeRate: 0.2,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row).toEqual({
@@ -216,7 +240,7 @@ describe('FadeRateV2 cron', () => {
     it('does not block a filler under the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
       const stats: FillerFadeStatsMap = {
-        ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0, chronicRate: 0, chronicTotal: 0 },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
@@ -240,7 +264,14 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        repeat: { fadeRate: 0.3, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+        repeat: {
+          fadeRate: 0.3,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
@@ -262,7 +293,14 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        recovering: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        recovering: {
+          fadeRate: 0.05,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // not blocked
@@ -288,7 +326,14 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        idler: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 0, newFades: 0 },
+        idler: {
+          fadeRate: 0.05,
+          duringBlockRate: 0.05,
+          newCompletions: 0,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.consecutiveBlocks).toEqual(3); // frozen, not decayed
@@ -312,7 +357,14 @@ describe('FadeRateV2 cron', () => {
       // post-block rate sits at the prior (blocked => empty window), but the in-flight
       // cohort faded at over the threshold rate
       const stats: FillerFadeStatsMap = {
-        blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1, newFades: 1 },
+        blockedFader: {
+          fadeRate: 0.05,
+          duringBlockRate: 0.2,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
@@ -343,6 +395,8 @@ describe('FadeRateV2 cron', () => {
           duringBlockRate: laplaceSmoothedFadeRate(1, 20),
           newCompletions: 20,
           newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
         },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
@@ -367,7 +421,14 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        lateFader: { fadeRate: 0.05, duringBlockRate: 0.14, newCompletions: 1, newFades: 1 },
+        lateFader: {
+          fadeRate: 0.05,
+          duringBlockRate: 0.14,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2); // 2^1 backoff
@@ -389,7 +450,14 @@ describe('FadeRateV2 cron', () => {
       ]);
       // even a high (stale) window rate must not extend an active block by itself
       const stats: FillerFadeStatsMap = {
-        blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        blockedClean: {
+          fadeRate: 0.9,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 300);
@@ -414,7 +482,14 @@ describe('FadeRateV2 cron', () => {
           ],
         ]) as FillerTimestamps;
       const clean: FillerFadeStatsMap = {
-        gamer: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        gamer: {
+          fadeRate: 0.04,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
 
       // clean runs build the streak without decaying until the streak completes
@@ -447,7 +522,14 @@ describe('FadeRateV2 cron', () => {
       ]);
       // under threshold, but the run's one new completion faded
       const stats: FillerFadeStatsMap = {
-        almostRecovered: { fadeRate: 0.09, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+        almostRecovered: {
+          fadeRate: 0.09,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // still not blocked
@@ -469,9 +551,30 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
-        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
-        blocked: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        breach: {
+          fadeRate: 0.25,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
+        clean: {
+          fadeRate: 0.03,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
+        blocked: {
+          fadeRate: 0.05,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
       };
       const rows: ToUpdateTimestampRow[] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(rows).toHaveLength(3);
@@ -496,9 +599,30 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 }, // trips a new block
-        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
-        extendMe: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1, newFades: 1 }, // extends an active block
+        breach: {
+          fadeRate: 0.25,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        }, // trips a new block
+        clean: {
+          fadeRate: 0.03,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        },
+        extendMe: {
+          fadeRate: 0.05,
+          duringBlockRate: 0.2,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 0,
+          chronicTotal: 0,
+        }, // extends an active block
       };
       calculateNewTimestamps(timestamps, stats, now, logger, metrics);
 
@@ -562,7 +686,14 @@ describe('FadeRateV2 cron', () => {
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        recovering: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 5, newFades: 0 }, // decays 1 -> 0
+        recovering: {
+          fadeRate: 0.03,
+          duringBlockRate: 0.05,
+          newCompletions: 5,
+          newFades: 0,
+          chronicRate: 0,
+          chronicTotal: 0,
+        }, // decays 1 -> 0
       };
       calculateNewTimestamps(timestamps, stats, now, logger, metrics);
 
@@ -570,6 +701,42 @@ describe('FadeRateV2 cron', () => {
       expect(metrics.putMetric).toHaveBeenCalledWith(
         metricContext(Metric.CIRCUIT_BREAKER_V2_CONSECUTIVE_BLOCKS, 'recovering'),
         0,
+        expect.anything()
+      );
+    });
+
+    it('emits the chronic (no-amnesty) watchlist rate only at sufficient sample size', () => {
+      const metrics = { putMetric: jest.fn() } as any;
+      const stats: FillerFadeStatsMap = {
+        // a low-volume ~20% fader living inside the block threshold's envelope: never blocked,
+        // but the watchlist metric keeps them visible
+        watchme: {
+          fadeRate: 0.11,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 0,
+          chronicRate: 0.2,
+          chronicTotal: CHRONIC_RATE_MIN_SAMPLE,
+        },
+        // below the sample gate: a single faded order must not chart as a 100% swing
+        tiny: {
+          fadeRate: 0.09,
+          duringBlockRate: 0.05,
+          newCompletions: 1,
+          newFades: 1,
+          chronicRate: 1,
+          chronicTotal: CHRONIC_RATE_MIN_SAMPLE - 1,
+        },
+      };
+      calculateNewTimestamps(new Map(), stats, now, logger, metrics);
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE, 'watchme'),
+        0.2,
+        expect.anything()
+      );
+      expect(metrics.putMetric).not.toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE, 'tiny'),
+        expect.anything(),
         expect.anything()
       );
     });

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -4,6 +4,7 @@ import {
   BASE_BLOCK_SECS,
   calculateBlockUntilTimestamp,
   calculateNewTimestamps,
+  CLEAN_RUNS_PER_DECAY,
   countActiveBlocks,
   FADE_RATE_BLOCK_THRESHOLD,
   FillerFadeStatsMap,
@@ -97,6 +98,7 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerA'].duringBlockRate).toBeCloseTo(0.05, 6);
       // no prior timestamp => every completion is new
       expect(stats['fillerA'].newCompletions).toEqual(10);
+      expect(stats['fillerA'].newFades).toEqual(3);
     });
 
     it('excludes pre-block orders from the rate window', () => {
@@ -109,6 +111,7 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: 0,
             fadeWindowStart: now - 200,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
           },
         ],
       ]);
@@ -128,8 +131,9 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerB'].fadeRate).toBeCloseTo(2 / 25, 6);
       // stale pre-block fades don't resurrect as a during-block cohort
       expect(stats['fillerB'].duringBlockRate).toBeCloseTo(0.05, 6);
-      // only the 5 post-lastPost orders are new completions
+      // only the 5 post-lastPost orders are new completions, 1 of them faded
       expect(stats['fillerB'].newCompletions).toEqual(5);
+      expect(stats['fillerB'].newFades).toEqual(1);
     });
 
     it('scores in-flight orders that completed during a block, even after it expired', () => {
@@ -146,6 +150,7 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: 0,
             fadeWindowStart: now - 100,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
           },
         ],
       ]);
@@ -164,6 +169,8 @@ describe('FadeRateV2 cron', () => {
       // window = 1 clean post-block order
       expect(stats['fillerB'].fadeRate).toBeCloseTo(1 / 21, 6);
       expect(stats['fillerB'].newCompletions).toEqual(4);
+      // during-block fades still count as new fades (they break the decay streak)
+      expect(stats['fillerB'].newFades).toEqual(2);
     });
 
     it('aggregates multiple addresses belonging to the same filler', () => {
@@ -192,7 +199,9 @@ describe('FadeRateV2 cron', () => {
   describe('calculateNewTimestamps', () => {
     it('blocks a filler whose fade rate exceeds the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = { newBad: { fadeRate: 0.2, duringBlockRate: 0.05, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        newBad: { fadeRate: 0.2, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row).toEqual({
         hash: 'newBad',
@@ -200,16 +209,20 @@ describe('FadeRateV2 cron', () => {
         blockUntilTimestamp: now + BASE_BLOCK_SECS, // 2^0
         fadeWindowStart: now + BASE_BLOCK_SECS, // floor = block end
         consecutiveBlocks: 1,
+        consecutiveCleanRuns: 0, // blocked: recovery streak restarts
       });
     });
 
     it('does not block a filler under the threshold', () => {
       const timestamps: FillerTimestamps = new Map();
-      const stats: FillerFadeStatsMap = { ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        ok: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
       expect(row.fadeWindowStart).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // never blocked
       expect(row.consecutiveBlocks).toEqual(0);
+      expect(row.consecutiveCleanRuns).toEqual(0); // no escalation to work off: no streak accumulates
     });
 
     it('uses consecutiveBlocks for backoff when re-blocking', () => {
@@ -217,17 +230,25 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'repeat',
-          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 10, consecutiveBlocks: 2 },
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 10,
+            consecutiveBlocks: 2,
+            consecutiveCleanRuns: 0,
+          },
         ],
       ]);
-      const stats: FillerFadeStatsMap = { repeat: { fadeRate: 0.3, duringBlockRate: 0.05, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        repeat: { fadeRate: 0.3, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 4); // 2^2 (old consecutive)
       expect(row.fadeWindowStart).toEqual(now + BASE_BLOCK_SECS * 4);
       expect(row.consecutiveBlocks).toEqual(3);
     });
 
-    it('resets blockUntilTimestamp but preserves fadeWindowStart while decaying', () => {
+    it('resets blockUntilTimestamp but preserves fadeWindowStart when the decay streak completes', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'recovering',
@@ -236,29 +257,42 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: 0,
             fadeWindowStart: now - 500,
             consecutiveBlocks: 2,
+            consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1, // this clean run completes the streak
           },
         ],
       ]);
-      const stats: FillerFadeStatsMap = { recovering: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        recovering: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // not blocked
       expect(row.fadeWindowStart).toEqual(now - 500); // clean-slate floor preserved independently
       expect(row.consecutiveBlocks).toEqual(1); // decayed 2 -> 1
+      expect(row.consecutiveCleanRuns).toEqual(0); // streak restarts for the next level
     });
 
-    it('freezes consecutiveBlocks while idle: no new completions means no decay', () => {
+    it('freezes consecutiveBlocks and the clean-run streak while idle', () => {
       // A filler's stale rows can sit in the 24h view long after their block expired. Without
       // the newCompletions gate, escalation would decay every 10-minute cron run while they
       // simply idle — resetting 3 -> 0 in ~30 minutes with zero demonstrated clean fills.
       const timestamps: FillerTimestamps = new Map([
         [
           'idler',
-          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 3 },
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 50,
+            consecutiveBlocks: 3,
+            consecutiveCleanRuns: 2,
+          },
         ],
       ]);
-      const stats: FillerFadeStatsMap = { idler: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 0 } };
+      const stats: FillerFadeStatsMap = {
+        idler: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 0, newFades: 0 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.consecutiveBlocks).toEqual(3); // frozen, not decayed
+      expect(row.consecutiveCleanRuns).toEqual(2); // idle doesn't build the streak, but doesn't break it either
       expect(row.fadeWindowStart).toEqual(now - 50); // clean-slate floor preserved
     });
 
@@ -271,16 +305,20 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: now + 500,
             fadeWindowStart: now + 500,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
           },
         ],
       ]);
       // post-block rate sits at the prior (blocked => empty window), but the in-flight
       // cohort faded at over the threshold rate
-      const stats: FillerFadeStatsMap = { blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        blockedFader: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1, newFades: 1 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // extend from current end, 2^1
       expect(row.fadeWindowStart).toEqual(now + 500 + BASE_BLOCK_SECS * 2); // floor tracks the extended end
       expect(row.consecutiveBlocks).toEqual(2);
+      expect(row.consecutiveCleanRuns).toEqual(0);
     });
 
     it("does not extend when a blocked filler's stray in-flight fade is offset by clean fills", () => {
@@ -292,6 +330,7 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: now + 500,
             fadeWindowStart: now + 500,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 3,
           },
         ],
       ]);
@@ -299,11 +338,17 @@ describe('FadeRateV2 cron', () => {
       // Under the old count-based rule (newFades > 0) this high-volume filler's block
       // would have been extended by a single statistical fade.
       const stats: FillerFadeStatsMap = {
-        blockedBusy: { fadeRate: 0.05, duringBlockRate: laplaceSmoothedFadeRate(1, 20), newCompletions: 1 },
+        blockedBusy: {
+          fadeRate: 0.05,
+          duringBlockRate: laplaceSmoothedFadeRate(1, 20),
+          newCompletions: 20,
+          newFades: 1,
+        },
       };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 500); // kept, not extended
       expect(row.consecutiveBlocks).toEqual(1);
+      expect(row.consecutiveCleanRuns).toEqual(0); // but the in-flight fade still breaks the decay streak
     });
 
     it('re-blocks after expiry when in-flight orders faded during the block (slip-through fix)', () => {
@@ -312,10 +357,18 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'lateFader',
-          { lastExaminedTimestamp: now - 400, blockUntilTimestamp: 0, fadeWindowStart: now - 10, consecutiveBlocks: 1 },
+          {
+            lastExaminedTimestamp: now - 400,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 10,
+            consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
+          },
         ],
       ]);
-      const stats: FillerFadeStatsMap = { lateFader: { fadeRate: 0.05, duringBlockRate: 0.14, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        lateFader: { fadeRate: 0.05, duringBlockRate: 0.14, newCompletions: 1, newFades: 1 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2); // 2^1 backoff
       expect(row.consecutiveBlocks).toEqual(2);
@@ -330,46 +383,76 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: now + 300,
             fadeWindowStart: now + 300,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 2,
           },
         ],
       ]);
       // even a high (stale) window rate must not extend an active block by itself
-      const stats: FillerFadeStatsMap = { blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05, newCompletions: 1 } };
+      const stats: FillerFadeStatsMap = {
+        blockedClean: { fadeRate: 0.9, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+      };
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + 300);
       expect(row.fadeWindowStart).toEqual(now + 300);
       expect(row.consecutiveBlocks).toEqual(1);
+      // serving a bench is not recovery: clean in-flight fills don't build the decay streak
+      expect(row.consecutiveCleanRuns).toEqual(2);
     });
 
-    it('requires multiple clean cycles to fully decay consecutiveBlocks (anti-gaming)', () => {
+    it('decays one escalation level only after CLEAN_RUNS_PER_DECAY consecutive clean runs', () => {
+      const state = (consecutiveBlocks: number, consecutiveCleanRuns: number, lastExaminedTimestamp: number) =>
+        new Map([
+          [
+            'gamer',
+            {
+              lastExaminedTimestamp,
+              blockUntilTimestamp: 0,
+              fadeWindowStart: now - 50,
+              consecutiveBlocks,
+              consecutiveCleanRuns,
+            },
+          ],
+        ]) as FillerTimestamps;
+      const clean: FillerFadeStatsMap = {
+        gamer: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+      };
+
+      // clean runs build the streak without decaying until the streak completes
+      let timestamps = state(3, 0, now - 100);
+      for (let run = 1; run < CLEAN_RUNS_PER_DECAY; run++) {
+        const [row] = calculateNewTimestamps(timestamps, clean, now + run * 600, logger);
+        expect(row.consecutiveBlocks).toEqual(3); // not yet
+        expect(row.consecutiveCleanRuns).toEqual(run);
+        timestamps = state(row.consecutiveBlocks, row.consecutiveCleanRuns ?? 0, row.lastExaminedTimestamp);
+      }
+      // the CLEAN_RUNS_PER_DECAY-th clean run decays one level and restarts the streak
+      const [row] = calculateNewTimestamps(timestamps, clean, now + CLEAN_RUNS_PER_DECAY * 600, logger);
+      expect(row.consecutiveBlocks).toEqual(2);
+      expect(row.consecutiveCleanRuns).toEqual(0);
+      // full recovery from 3 levels therefore costs 3 * CLEAN_RUNS_PER_DECAY clean runs
+    });
+
+    it('resets the clean-run streak on a sub-threshold fade (a fade is not recovery)', () => {
       const timestamps: FillerTimestamps = new Map([
         [
-          'gamer',
-          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 3 },
+          'almostRecovered',
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 50,
+            consecutiveBlocks: 2,
+            consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1, // one clean run away from a decay
+          },
         ],
       ]);
-      const clean: FillerFadeStatsMap = { gamer: { fadeRate: 0.04, duringBlockRate: 0.05, newCompletions: 1 } };
-
-      let row = calculateNewTimestamps(timestamps, clean, now, logger)[0];
-      expect(row.consecutiveBlocks).toEqual(2);
-
-      timestamps.set('gamer', {
-        lastExaminedTimestamp: row.lastExaminedTimestamp,
-        blockUntilTimestamp: row.blockUntilTimestamp ?? 0,
-        fadeWindowStart: row.fadeWindowStart ?? 0,
-        consecutiveBlocks: row.consecutiveBlocks,
-      });
-      row = calculateNewTimestamps(timestamps, clean, now + 300, logger)[0];
-      expect(row.consecutiveBlocks).toEqual(1);
-
-      timestamps.set('gamer', {
-        lastExaminedTimestamp: row.lastExaminedTimestamp,
-        blockUntilTimestamp: row.blockUntilTimestamp ?? 0,
-        fadeWindowStart: row.fadeWindowStart ?? 0,
-        consecutiveBlocks: row.consecutiveBlocks,
-      });
-      row = calculateNewTimestamps(timestamps, clean, now + 600, logger)[0];
-      expect(row.consecutiveBlocks).toEqual(0);
+      // under threshold, but the run's one new completion faded
+      const stats: FillerFadeStatsMap = {
+        almostRecovered: { fadeRate: 0.09, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+      };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // still not blocked
+      expect(row.consecutiveBlocks).toEqual(2); // and not decayed
+      expect(row.consecutiveCleanRuns).toEqual(0); // streak restarts from scratch
     });
 
     it('processes a mix of fillers in one pass', () => {
@@ -381,13 +464,14 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: now + 500,
             fadeWindowStart: now + 500,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
           },
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1 },
-        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1 },
-        blocked: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1 },
+        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 },
+        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        blocked: { fadeRate: 0.05, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
       };
       const rows: ToUpdateTimestampRow[] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(rows).toHaveLength(3);
@@ -407,13 +491,14 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: now + 500,
             fadeWindowStart: now + 500,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
           },
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1 }, // trips a new block
-        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1 }, // decays
-        extendMe: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1 }, // extends an active block
+        breach: { fadeRate: 0.25, duringBlockRate: 0.05, newCompletions: 1, newFades: 1 }, // trips a new block
+        clean: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 1, newFades: 0 },
+        extendMe: { fadeRate: 0.05, duringBlockRate: 0.2, newCompletions: 1, newFades: 1 }, // extends an active block
       };
       calculateNewTimestamps(timestamps, stats, now, logger, metrics);
 
@@ -467,11 +552,17 @@ describe('FadeRateV2 cron', () => {
       const timestamps: FillerTimestamps = new Map([
         [
           'recovering',
-          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 1 },
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 50,
+            consecutiveBlocks: 1,
+            consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1, // this clean run completes the streak
+          },
         ],
       ]);
       const stats: FillerFadeStatsMap = {
-        recovering: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 5 }, // clean run, decays 1 -> 0
+        recovering: { fadeRate: 0.03, duringBlockRate: 0.05, newCompletions: 5, newFades: 0 }, // decays 1 -> 0
       };
       calculateNewTimestamps(timestamps, stats, now, logger, metrics);
 
@@ -481,6 +572,80 @@ describe('FadeRateV2 cron', () => {
         0,
         expect.anything()
       );
+    });
+  });
+
+  describe('escalation decay requires demonstrated clean activity', () => {
+    // Repro of the production "Elk" profile: a chronic ~94% fader at ~1 order per 2 hours.
+    // Their fades land in separate cron runs, so every post-block cycle looks like:
+    //   fade #1 (window = 1 fade -> 2/21 = 9.5%, under threshold)  -> run must NOT decay
+    //   fade #2 (window = 2 fades -> 3/22 = 13.6%, over threshold) -> block, +1 escalation
+    // If the first (sub-threshold, faded) completion counts as recovery activity and decays
+    // escalation, each cycle nets zero and consecutiveBlocks stays pinned at ~0-2 forever —
+    // 15-30 minute blocks that cost a 1-order-per-2h filler nothing. Observed in prod:
+    // a week of ~94% fading with consecutiveBlocks sitting at 2.
+    const ELK_ADDR = '0x0000000000000000000000000000000000000005';
+    const ELK_MAP = new Map<string, string>([[ELK_ADDR, 'elk']]);
+    const floor = now - 7200; // last block ended 2h ago (clean-slate floor)
+
+    const elkState = (consecutiveBlocks: number, lastExaminedTimestamp: number) =>
+      new Map([
+        [
+          'elk',
+          {
+            lastExaminedTimestamp,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: floor,
+            consecutiveBlocks,
+            consecutiveCleanRuns: 0,
+          },
+        ],
+      ]) as FillerTimestamps;
+
+    it('does not decay consecutiveBlocks on a run whose only new completion is a fade', () => {
+      const t1 = now - 600;
+      const fillerTimestamps = elkState(2, t1 - 600);
+      // one faded order completed since the last run; window rate (1+1)/(1+20) is under threshold
+      const stats = getFillersFadeStats([order(ELK_ADDR, 1, t1 - 100)], ELK_MAP, fillerTimestamps, logger);
+      expect(stats['elk'].fadeRate).toBeLessThan(FADE_RATE_BLOCK_THRESHOLD);
+
+      const [row] = calculateNewTimestamps(fillerTimestamps, stats, t1, logger);
+      expect(row.blockUntilTimestamp).toEqual(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP); // correctly not blocked yet
+      expect(row.consecutiveBlocks).toEqual(2); // a faded completion is not recovery activity
+    });
+
+    it('keeps full exponential backoff across a lone-fade -> trip cycle', () => {
+      const t1 = now - 600;
+      const t2 = now;
+      const fade1 = order(ELK_ADDR, 1, t1 - 100);
+      const fade2 = order(ELK_ADDR, 1, t2 - 100);
+
+      // run 1: lone sub-threshold fade
+      const state1 = elkState(2, t1 - 600);
+      const stats1 = getFillersFadeStats([fade1], ELK_MAP, state1, logger);
+      const [row1] = calculateNewTimestamps(state1, stats1, t1, logger);
+
+      // run 2: second fade puts the window at 3/22 > threshold -> block
+      const state2 = new Map([
+        [
+          'elk',
+          {
+            lastExaminedTimestamp: row1.lastExaminedTimestamp,
+            blockUntilTimestamp: row1.blockUntilTimestamp ?? 0,
+            fadeWindowStart: row1.fadeWindowStart ?? 0,
+            consecutiveBlocks: row1.consecutiveBlocks,
+            consecutiveCleanRuns: row1.consecutiveCleanRuns ?? 0,
+          },
+        ],
+      ]) as FillerTimestamps;
+      const stats2 = getFillersFadeStats([fade1, fade2], ELK_MAP, state2, logger);
+      expect(stats2['elk'].fadeRate).toBeGreaterThan(FADE_RATE_BLOCK_THRESHOLD);
+
+      const [row2] = calculateNewTimestamps(state2, stats2, t2, logger);
+      // escalation must ratchet: block computed off the preserved consecutiveBlocks=2 (2^2),
+      // not a flattened level worked off by the cycle's own first fade
+      expect(row2.blockUntilTimestamp).toEqual(t2 + BASE_BLOCK_SECS * 4);
+      expect(row2.consecutiveBlocks).toEqual(3);
     });
   });
 
@@ -495,17 +660,30 @@ describe('FadeRateV2 cron', () => {
             blockUntilTimestamp: now + 500,
             fadeWindowStart: now + 500,
             consecutiveBlocks: 1,
+            consecutiveCleanRuns: 0,
           },
         ],
         // recovered: past block, no update
         [
           'recovered',
-          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 50,
+            consecutiveBlocks: 0,
+            consecutiveCleanRuns: 0,
+          },
         ],
         // stored state says unblocked, but this run blocks them
         [
           'justBlocked',
-          { lastExaminedTimestamp: now - 100, blockUntilTimestamp: 0, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+          {
+            lastExaminedTimestamp: now - 100,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: now - 50,
+            consecutiveBlocks: 0,
+            consecutiveCleanRuns: 0,
+          },
         ],
       ]);
       const updated: ToUpdateTimestampRow[] = [
@@ -529,7 +707,16 @@ describe('FadeRateV2 cron', () => {
 
     it('treats an unset (0 / undefined) blockUntilTimestamp as unblocked', () => {
       const timestamps: FillerTimestamps = new Map([
-        ['unsetRow', { lastExaminedTimestamp: 1, blockUntilTimestamp: 0, fadeWindowStart: 0, consecutiveBlocks: 0 }],
+        [
+          'unsetRow',
+          {
+            lastExaminedTimestamp: 1,
+            blockUntilTimestamp: 0,
+            fadeWindowStart: 0,
+            consecutiveBlocks: 0,
+            consecutiveCleanRuns: 0,
+          },
+        ],
       ]);
       const updated: ToUpdateTimestampRow[] = [
         { hash: 'undefRow', lastExaminedTimestamp: now, blockUntilTimestamp: undefined, consecutiveBlocks: 0 },

--- a/test/crons/fade-rate-v2.test.ts
+++ b/test/crons/fade-rate-v2.test.ts
@@ -4,6 +4,7 @@ import {
   BASE_BLOCK_SECS,
   calculateBlockUntilTimestamp,
   calculateNewTimestamps,
+  CHRONIC_RATE_EMISSION_FLOOR,
   CHRONIC_RATE_MIN_SAMPLE,
   CLEAN_RUNS_PER_DECAY,
   countActiveBlocks,
@@ -20,7 +21,12 @@ import {
   UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
 } from '../../lib/cron/fade-rate-v2';
 import { Metric, metricContext } from '../../lib/entities';
-import { TimestampRepoRow, ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
+import {
+  ORDERS_PER_FILLER_LIMIT,
+  TimestampRepoRow,
+  ToUpdateTimestampRow,
+  V2FadesRowType,
+} from '../../lib/repositories';
 
 const now = Math.floor(Date.now() / 1000);
 // deadlines at least this old are past the streak's finality horizon (load state final)
@@ -47,6 +53,7 @@ const fadeStats = (overrides: Partial<FillerFadeStats> = {}): FillerFadeStats =>
   newFades: 0,
   chronicRate: 0,
   chronicTotal: 0,
+  saturatedAddresses: 0,
   ...overrides,
 });
 const cbState = (overrides: Partial<Omit<TimestampRepoRow, 'hash'>> = {}): Omit<TimestampRepoRow, 'hash'> => ({
@@ -140,6 +147,9 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerA'].fadeRate).toBeCloseTo(2 / 21, 6); // scored for blocking
       expect(stats['fillerA'].newCompletions).toEqual(0); // not yet streak-classified
       expect(stats['fillerA'].newFades).toEqual(0);
+      // the chronic watchlist view also scores only final rows (a not-yet-loaded fill would
+      // read as a transient fade and sawtooth the metric every load cycle)
+      expect(stats['fillerA'].chronicTotal).toEqual(0);
 
       // next run after the row ages past the horizon: classified exactly once
       const later = now + STREAK_FINALITY_LAG_SECS;
@@ -229,6 +239,25 @@ describe('FadeRateV2 cron', () => {
       expect(stats['fillerC'].fadeRate).toBeCloseTo(3 / 24, 6);
       expect(stats['fillerC'].duringBlockRate).toBeCloseTo(0.05, 6);
     });
+
+    it('flags addresses whose latest-N window has outrun the streak finality horizon', () => {
+      // fillerA: a full window whose OLDEST row is fresher than the finality horizon — rows
+      // are being evicted before they can ever be streak-classified
+      const rows: V2FadesRowType[] = [
+        ...Array(ORDERS_PER_FILLER_LIMIT)
+          .fill(0)
+          .map((_, i) => order('0x0000000000000000000000000000000000000001', 0, now - 200 - i)),
+        // fillerB: also a full window, but it still reaches past the horizon (oldest row is
+        // final) — that's the designed adaptive window, not degradation
+        ...Array(ORDERS_PER_FILLER_LIMIT - 1)
+          .fill(0)
+          .map((_, i) => order('0x0000000000000000000000000000000000000002', 0, now - 200 - i)),
+        order('0x0000000000000000000000000000000000000002', 0, now - FINAL),
+      ];
+      const stats = getFillersFadeStats(rows, ADDRESS_TO_FILLER, new Map(), now, logger);
+      expect(stats['fillerA'].saturatedAddresses).toEqual(1);
+      expect(stats['fillerB'].saturatedAddresses).toEqual(0);
+    });
   });
 
   describe('calculateBlockUntilTimestamp', () => {
@@ -296,6 +325,35 @@ describe('FadeRateV2 cron', () => {
       const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
       expect(row.blockUntilTimestamp).toEqual(now + BASE_BLOCK_SECS * 2 ** MAX_BLOCK_BACKOFF_EXPONENT);
       expect(row.consecutiveBlocks).toEqual(MAX_BLOCK_BACKOFF_EXPONENT); // counter capped too
+    });
+
+    it('clamps legacy over-cap stored consecutiveBlocks on every path, not just re-blocks', () => {
+      // Rows written before the cap existed can hold values > MAX_BLOCK_BACKOFF_EXPONENT.
+      // The clamp happens where stored state is read, so the keep-block and decay paths
+      // normalize it too — otherwise a legacy 12 needs 12 * CLEAN_RUNS_PER_DECAY clean runs
+      // to recover, violating the documented bound, and the metric charts impossible levels.
+      const legacyBlocked: FillerTimestamps = new Map([
+        ['legacy', cbState({ blockUntilTimestamp: now + 300, fadeWindowStart: now + 300, consecutiveBlocks: 12 })],
+      ]);
+      const [kept] = calculateNewTimestamps(legacyBlocked, { legacy: fadeStats() }, now, logger);
+      expect(kept.consecutiveBlocks).toEqual(MAX_BLOCK_BACKOFF_EXPONENT); // normalized while benched
+
+      const legacyDecaying: FillerTimestamps = new Map([
+        ['legacy', cbState({ consecutiveBlocks: 12, consecutiveCleanRuns: CLEAN_RUNS_PER_DECAY - 1 })],
+      ]);
+      const [decayed] = calculateNewTimestamps(legacyDecaying, { legacy: fadeStats() }, now, logger);
+      expect(decayed.consecutiveBlocks).toEqual(MAX_BLOCK_BACKOFF_EXPONENT - 1); // clamped, then decayed
+    });
+
+    it('clamps corrupted negative stored consecutiveBlocks back to zero', () => {
+      // No code path writes negatives, but a manual edit or bad backfill could: unclamped,
+      // decay would drive it lower and a later block would compute 2^negative — a
+      // sub-base-length fractional block. The read clamp floors it at 0.
+      const timestamps: FillerTimestamps = new Map([['corrupted', cbState({ consecutiveBlocks: -3 })]]);
+      const stats: FillerFadeStatsMap = { corrupted: fadeStats() };
+      const [row] = calculateNewTimestamps(timestamps, stats, now, logger);
+      expect(row.consecutiveBlocks).toEqual(0);
+      expect(row.consecutiveCleanRuns).toEqual(0);
     });
 
     it('resets blockUntilTimestamp but preserves fadeWindowStart when the decay streak completes', () => {
@@ -543,6 +601,8 @@ describe('FadeRateV2 cron', () => {
         watchme: fadeStats({ fadeRate: 0.11, chronicRate: 0.2, chronicTotal: CHRONIC_RATE_MIN_SAMPLE }),
         // below the sample gate: a single faded order must not chart as a 100% swing
         tiny: fadeStats({ fadeRate: 0.09, newFades: 1, chronicRate: 1, chronicTotal: CHRONIC_RATE_MIN_SAMPLE - 1 }),
+        // below the rate floor: a healthy filler must not get a permanent flat-zero series
+        healthy: fadeStats({ chronicRate: CHRONIC_RATE_EMISSION_FLOOR - 0.01, chronicTotal: 50 }),
       };
       calculateNewTimestamps(new Map(), stats, now, logger, metrics);
       expect(metrics.putMetric).toHaveBeenCalledWith(
@@ -553,6 +613,25 @@ describe('FadeRateV2 cron', () => {
       expect(metrics.putMetric).not.toHaveBeenCalledWith(
         metricContext(Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE, 'tiny'),
         expect.anything(),
+        expect.anything()
+      );
+      expect(metrics.putMetric).not.toHaveBeenCalledWith(
+        metricContext(Metric.CIRCUIT_BREAKER_V2_CHRONIC_RATE, 'healthy'),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('emits the aggregate count of window-saturated addresses', () => {
+      const metrics = { putMetric: jest.fn() } as any;
+      const stats: FillerFadeStatsMap = {
+        busy: fadeStats({ saturatedAddresses: 2 }),
+        quiet: fadeStats(),
+      };
+      calculateNewTimestamps(new Map(), stats, now, logger, metrics);
+      expect(metrics.putMetric).toHaveBeenCalledWith(
+        Metric.CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES,
+        2,
         expect.anything()
       );
     });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -17,6 +17,7 @@ export const MOCK_V2_CB_PROVIDER = new MockV2CircuitBreakerConfigurationProvider
         fadeWindowStart: now + 100000,
         lastExaminedTimestamp: now - 10,
         consecutiveBlocks: 0,
+        consecutiveCleanRuns: 0,
       },
     ],
     [
@@ -26,6 +27,7 @@ export const MOCK_V2_CB_PROVIDER = new MockV2CircuitBreakerConfigurationProvider
         fadeWindowStart: now - 10,
         lastExaminedTimestamp: now - 100,
         consecutiveBlocks: NaN,
+        consecutiveCleanRuns: 0,
       },
     ],
   ])

--- a/test/providers/circuit-breaker/cb-provider.test.ts
+++ b/test/providers/circuit-breaker/cb-provider.test.ts
@@ -6,11 +6,23 @@ const now = Math.floor(Date.now() / 1000);
 const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
   [
     'filler1',
-    { lastExaminedTimestamp: now - 150, blockUntilTimestamp: NaN, fadeWindowStart: NaN, consecutiveBlocks: NaN },
+    {
+      lastExaminedTimestamp: now - 150,
+      blockUntilTimestamp: NaN,
+      fadeWindowStart: NaN,
+      consecutiveBlocks: NaN,
+      consecutiveCleanRuns: 0,
+    },
   ],
   [
     'filler2',
-    { lastExaminedTimestamp: now - 75, blockUntilTimestamp: now - 50, fadeWindowStart: now - 50, consecutiveBlocks: 0 },
+    {
+      lastExaminedTimestamp: now - 75,
+      blockUntilTimestamp: now - 50,
+      fadeWindowStart: now - 50,
+      consecutiveBlocks: 0,
+      consecutiveCleanRuns: 0,
+    },
   ],
   [
     'filler3',
@@ -19,11 +31,18 @@ const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
       blockUntilTimestamp: now + 1000,
       fadeWindowStart: now + 1000,
       consecutiveBlocks: 0,
+      consecutiveCleanRuns: 0,
     },
   ],
   [
     'filler4',
-    { lastExaminedTimestamp: now - 150, blockUntilTimestamp: NaN, fadeWindowStart: NaN, consecutiveBlocks: 0 },
+    {
+      lastExaminedTimestamp: now - 150,
+      blockUntilTimestamp: NaN,
+      fadeWindowStart: NaN,
+      consecutiveBlocks: 0,
+      consecutiveCleanRuns: 0,
+    },
   ],
   [
     'filler5',
@@ -32,6 +51,7 @@ const FILLER_TIMESTAMPS: FillerTimestamps = new Map([
       blockUntilTimestamp: now + 100,
       fadeWindowStart: now + 100,
       consecutiveBlocks: 1,
+      consecutiveCleanRuns: 0,
     },
   ],
 ]);

--- a/test/repositories/timestamp-repository.test.ts
+++ b/test/repositories/timestamp-repository.test.ts
@@ -27,6 +27,10 @@ describe('Dynamo TimestampRepo tests', () => {
         blockUntilTimestamp: undefined,
         fadeWindowStart: undefined,
         consecutiveBlocks: 0,
+        // simulate a pre-migration writer that never knew about the attribute (the type
+        // requires it precisely so real callers can't do this silently); the put omits it
+        // and the read path must default it to 0
+        consecutiveCleanRuns: undefined as unknown as number,
       },
       {
         hash: '0x2',
@@ -34,6 +38,7 @@ describe('Dynamo TimestampRepo tests', () => {
         blockUntilTimestamp: 5,
         fadeWindowStart: 5,
         consecutiveBlocks: 0,
+        consecutiveCleanRuns: 0,
       },
       {
         hash: '0x3',

--- a/test/repositories/timestamp-repository.test.ts
+++ b/test/repositories/timestamp-repository.test.ts
@@ -41,6 +41,7 @@ describe('Dynamo TimestampRepo tests', () => {
         blockUntilTimestamp: 6,
         fadeWindowStart: 4,
         consecutiveBlocks: 1,
+        consecutiveCleanRuns: 4,
       },
     ];
 
@@ -53,6 +54,7 @@ describe('Dynamo TimestampRepo tests', () => {
     expect(row?.blockUntilTimestamp).toBe(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
     expect(row?.fadeWindowStart).toBe(UNBLOCKED_BLOCK_UNTIL_TIMESTAMP);
     expect(row?.consecutiveBlocks).toBe(0);
+    expect(row?.consecutiveCleanRuns).toBe(0); // missing attribute (pre-migration row) reads as 0
 
     row = await repo.getFillerTimestamps('0x2');
     expect(row).toBeDefined();
@@ -67,6 +69,7 @@ describe('Dynamo TimestampRepo tests', () => {
     expect(row?.blockUntilTimestamp).toBe(6);
     expect(row?.fadeWindowStart).toBe(4);
     expect(row?.consecutiveBlocks).toBe(1);
+    expect(row?.consecutiveCleanRuns).toBe(4);
   });
 
   it('should batch get timestamps', async () => {
@@ -80,6 +83,7 @@ describe('Dynamo TimestampRepo tests', () => {
           blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
           fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
           consecutiveBlocks: 0,
+          consecutiveCleanRuns: 0,
         },
         {
           hash: '0x2',
@@ -87,6 +91,7 @@ describe('Dynamo TimestampRepo tests', () => {
           blockUntilTimestamp: 5,
           fadeWindowStart: 5,
           consecutiveBlocks: 0,
+          consecutiveCleanRuns: 0,
         },
         {
           hash: '0x3',
@@ -94,6 +99,7 @@ describe('Dynamo TimestampRepo tests', () => {
           blockUntilTimestamp: 6,
           fadeWindowStart: 4,
           consecutiveBlocks: 1,
+          consecutiveCleanRuns: 4,
         },
       ])
     );


### PR DESCRIPTION
## Why

The V2 breaker's exponential backoff never engages against chronic **low-volume** faders. Decay required only `newCompletions > 0`, and `newCompletions` counts *faded* completions — so a fader whose fades land in separate cron runs gets this cycle:

1. fade #1 → window rate 2/21 = 9.5%, under threshold → run counts as "activity" → **decay −1**
2. fade #2 → 3/22 = 13.6% → **block, +1**

Net escalation per cycle: **zero**. `consecutiveBlocks` pins at ~0–2, every block stays 15–30 minutes, and a filler with a ~2h natural order gap loses almost no volume to the bench.

Confirmed in production (a filler fading ~94% of a week's orders sat at `consecutiveBlocks = 2` with an active block) **and quantified by replaying 2 weeks of real order history** (24,315 orders) through the cron logic: under the old code, **57% of all decay events granted to chronic fillers came from runs whose completions included a fade** — for the extreme faders, 100% did. Moderate chronic faders (24–39% fade mix) sat in near-perfect trip/decay equilibrium (e.g. 64 trips vs 63 decays), `consecutiveBlocks` never exceeding 2 for the entire fortnight.

## Fix 1 — decay requires sustained clean activity

Decay one escalation level only after **`CLEAN_RUNS_PER_DECAY` (6) consecutive clean runs**, tracked in a new `consecutiveCleanRuns` field on the CB state row:

- **clean run** = ≥1 newly classified completion past the clean-slate floor **and** 0 new fades (per new `newFades` stat)
- any new fade **resets** the streak — a sub-threshold fade is not recovery; in-flight fades while blocked also reset it
- an idle run (no completions) **freezes** the streak — idling neither builds nor breaks it
- fills served while benched earn nothing (deadline on/before the floor is excluded from streak credit)
- a block/extension restarts the streak at 0; completing a streak decays one level and restarts it

**Load-lag tolerance:** streak inputs are classified against a horizon trailing wall clock by `STREAK_FINALITY_LAG_SECS` (2h) — each run classifies deadlines in `(lastExamined − LAG, now − LAG]`, which partitions time across runs with no extra state. Redshift is batch-loaded hourly, so without this a late-loading fade never reset the streak and a not-yet-loaded fill read as a transient fade that reset it spuriously. Rows are classified exactly once, after their load state is final. (Blocking itself stays on the un-lagged rate window — only decay is deferred.)

At the 10-minute cron cadence, recovery costs ≥1 hour of demonstrated clean activity per level, making decay structurally slower than escalation (+1 per block event).

**Backtested impact** (replay, same fortnight, fade semantics matching live SQL): chronic >30% faders go from 17% time benched to **59%**, with fades reaching swappers dropping **~70%** (605 → 180); the 16–30% band goes from 1.7% to **27%** benched (246 → 128 allowed fades); collateral on legitimate ≤11% fillers stays ≤0.8% bench time with ≤2h worst sentences.

## Fix 2 — cap block backoff at 2^7 (32h per increment), counter included

Uncapped, the replay produced a **128h (5.3-day)** block. `calculateBlockUntilTimestamp` caps the duration exponent at `MAX_BLOCK_BACKOFF_EXPONENT = 7`, and `newConsecutiveBlocks` caps the **stored counter** at the same bound — so full recovery is bounded at 7 × 6 clean runs (~7h of clean activity) instead of growing with block history. Projected cost: +38 allowed fades per fortnight across the worst offenders (+21%); benefit: bounded worst-case sentence (~64h with stacked extensions) and automatic recovery from pathological stored state.

## Fix 3 — chronic-rate watchlist metric + dashboard widget

New `CIRCUIT_BREAKER_V2_CHRONIC_RATE`: each filler's **raw** fade rate over the entire query window — no clean-slate amnesty, no smoothing — emitted at a ≥10-order sample, with a dashboard widget annotated at the block threshold.

Rationale: the backtest exposed a low-volume ~20% fader living permanently **inside** the threshold's envelope (`maxFadesPerDay ≈ 0.12n + 1.4`, i.e. ~21% raw at 15 orders/day). Every candidate mechanism was tested against them — threshold 10%, weaker prior (α=0.5), raw-rate dual rules, a chronic decay gate, and an EWMA-scored breaker — and **each either fails to contain them or benches legitimate fillers heavily**. The correct move is visibility, not a trigger change: this metric makes such fillers a deliberate human decision.

## Not included (deliberately)

- **EWMA-scored breaker**: backtested; structurally worse exit dynamics for high-volume fillers (a bursty hour → day-scale bench for a legitimate filler, since the score exits multiplicatively) and weaker than the ratchet against sparse extreme faders. May revisit as shadow-mode metric.
- **Threshold/prior recalibration**: every variant tested sits inside the collateral/containment frontier of the current parameters.
- **Detection latency** (hourly Redshift loads → up to ~1h of unprotected acute fading): tracked separately. The streak's finality lag tolerates this for *decay*; trip latency is inherent to the data path.

## Tests / docs

- Repro-first: the decay-leak suite drives the real `getFillersFadeStats → calculateNewTimestamps` pipeline with the production profile and failed on the old code (decay 2→1; next block 2^1 instead of 2^2).
- Streak build/complete/reset/freeze, deferred + exactly-once lag classification, bench-fill exclusion, duration + counter cap pinning, chronic-rate stats (no-amnesty semantics), metric emission gating, repo round-trip + missing-attribute default. `fadeStats()`/`cbState()` factories keep test literals to the fields under test.
- CLAUDE.md documents the backtest extract SQL (fade semantics kept in sync with `V2_FADE_RATE_SQL` — thanks review for catching the #461 drift) and replay conventions.

## Migration

None. Existing `FillerCBTimestampsV2` rows lack the new attribute; reads default it to 0 and the next cron write populates it.

## Review updates (post-review commit cc7c6d6)

All six review findings addressed: lag-tolerant streak classification, bench fills excluded from streak credit, `consecutiveBlocks` counter capped, `consecutiveCleanRuns` required in the write type, extract SQL corrected to `fillTimeBlocks > 0`, and test factories. The backtest was re-run with corrected fade semantics; all figures above reflect the corrected data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Hardening (post-review commit 5e28393)

Follow-ups from the `/code-review` pass and the eviction-boundary analysis, with the backtest rerun modeling the **complete final behavior** (lagged streak classification fed only from window-surviving rows, bench-fill exclusion, both caps, read clamp):

- **Read-site clamp**: stored `consecutiveBlocks` is clamped into `[0, MAX_BLOCK_BACKOFF_EXPONENT]` where state is read, so legacy over-cap rows normalize on every path (keep/decay/extend/re-block and the metric) and corrupted negative values self-heal instead of yielding `2^negative` sub-base blocks.
- **Chronic watchlist noise**: tallies score only rows past the finality horizon (not-yet-loaded fills can no longer sawtooth the metric), and emission requires a 6% rate floor (`CHRONIC_RATE_EMISSION_FLOOR`) so per-filler series exist only for watch-worthy fillers.
- **`CIRCUIT_BREAKER_V2_SATURATED_ADDRESSES`**: fires when an address's latest-N window is full AND its oldest row is fresher than the finality horizon — the true "rows evicted before streak classification" condition. Merely sitting at the latest-N cap is the designed adaptive window and is not flagged (backtest: cap occupancy is near-constant for big fillers — 98.8% of runs — while true degradation occurred on **1.0% of runs, confined to the two busiest, never-escalated addresses** at 104–123% of the cap during peak bursts). The boundary (~50 orders/hour sustained per address) is documented on `STREAK_FINALITY_LAG_SECS`.
- Chronic widget retitled: the window is adaptive (24h / latest-100), not "24h".

**Final backtest posture** (2 weeks, 24,315 orders, corrected fade semantics, eviction modeled): chronic >30% faders **50% benched, 218 allowed fades** (vs 17% / 605 pre-#482); 16–30% band 26% benched, 135 allowed (vs 1.7% / 246); worst continuous sentence **64h** (vs 128h uncapped); collateral on ≤11% fillers unchanged at ≤0.9% bench / ≤2h. The review fixes cost no containment beyond the already-priced cap.
