### PR TITLE
feat: add Ink (57073) to SUPPORTED_CHAINS

### DIFF
--- a/lib/util/chains.ts
+++ b/lib/util/chains.ts
@@ -27,6 +27,7 @@ export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.BLAST,
   ChainId.ROBINHOOD,
   ChainId.ARC,
+  ChainId.INK,
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@uniswap/sdk-core": "^7.18.0",
     "@uniswap/signer": "0.0.3-beta.4",
     "@uniswap/smart-order-router": "^4.22.20",
-    "@uniswap/uniswapx-sdk": "3.0.10",
+    "@uniswap/uniswapx-sdk": "3.1.0",
     "aws-cdk-lib": "^2.262.1",
     "aws-embedded-metrics": "^4.1.0",
     "aws-sdk": "^2.1542.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,6 +3814,23 @@
     toformat "^2.0.0"
     tslib "^2.3.0"
 
+"@uniswap/sdk-core@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-7.19.1.tgz#2a91e1eb777efa5af159802ed14cf4c60bbbf8fc"
+  integrity sha512-3M8T1JXjy3Ypz/yKC9w75PH5EwpVgFIU5E7V8dI7+CBaZ2wr2RZeVlBrhJljdyGWYLjHT7owtA+SrOcwnhN2fA==
+  dependencies:
+    "@ethersproject/address" "^5.0.2"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.4"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
+    tslib "^2.3.0"
+
 "@uniswap/sdk-core@^7.7.1", "@uniswap/sdk-core@^7.7.2":
   version "7.7.2"
   resolved "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz#dc3a9b63b343640754860dce05d06972815eaee6"
@@ -3887,16 +3904,16 @@
   resolved "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.34.tgz#879461f5d4009327a24259bbab797e0f22db58c8"
   integrity sha512-Hc3TfrFaupg0M84e/Zv7BoF+fmMWDV15mZ5s8ZQt2qZxUcNw2GQW+L6L/2k74who31G+p1m3GRYbJpAo7d1pqA==
 
-"@uniswap/uniswapx-sdk@3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-3.0.10.tgz#6fdb915b06fa98b4bccd11aa4a1df3c3ffb1d099"
-  integrity sha512-SBEAKsNQFFm3WB9sZs6bqAFnyOLVV0YNqBTknYm/4tJdtBYXUKdRMaHjk20Xh9gzf/QFhM+IsxBhv0pnuHpBFQ==
+"@uniswap/uniswapx-sdk@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-3.1.0.tgz#ca8aa7eef979e41dfa391992f1f024cf65bdd133"
+  integrity sha512-scWOSHC+bJosuZYGIX3rGTlApsEuwVKEdJ1PdHDzIpdJhOe14s4hSv3zAcbPBk9fk8b1oBjEerZeuLhI/HgcDQ==
   dependencies:
     "@ethersproject/abi" "^5.5.0"
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"
     "@uniswap/permit2-sdk" "^1.4.0"
-    "@uniswap/sdk-core" "^7.18.0"
+    "@uniswap/sdk-core" "^7.19.1"
     ethers "^5.7.0"
     tiny-invariant "^1.1.0"
 


### PR DESCRIPTION
Phase 3 of the Ink (chainId 57073) DutchV3 rollout. Contracts are deployed and verified (Uniswap/UniswapX#375), and the SDK mappings are published in `@uniswap/uniswapx-sdk@3.1.0` (Uniswap/sdks#682).

## Changes

- `ChainId.INK` added to `SUPPORTED_CHAINS` in `lib/util/chains.ts`.
- `@uniswap/uniswapx-sdk` bumped `3.0.10` → `3.1.0`, plus the lockfile entry.

## Why these ship together

Adding `ChainId.INK` to `SUPPORTED_CHAINS` makes the Joi `chainId` validator accept Ink quote requests immediately. On 3.0.10 those requests would then throw during parsing:

```
UnsignedV3DutchOrder.parse(encoded, 57073)
  → getPermit2(57073)
  → PERMIT2_MAPPING[57073] is undefined
  → throw MissingConfiguration("permit2", "57073")
```

I verified 3.0.10 and 3.0.11 both lack `57073` entirely. Shipping the chain entry without the bump would turn "Ink is unsupported" into "Ink is accepted, then 500s" — strictly worse. Hence one PR.

## Verification

Against the resolved dependency tree after install:

```
ChainId.INK                                = 57073
PERMIT2_MAPPING[57073]                     = 0x000000000022d473030f116ddee9f6b43ac78ba3
UNISWAPX_ORDER_QUOTER_MAPPING[57073]       = 0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58
REACTOR_ADDRESS_MAPPING[57073].Dutch_V3    = 0x000000007A1C8e570011EeDF86A2A35593013cBA
EXCLUSIVE_FILLER_VALIDATION_MAPPING[57073] = 0x0000000000000000000000000000000000000000
```

`tsc` build clean. **261 unit tests across 30 suites pass.** (`yarn test` also runs `test:integ`, which needs `COSIGNER_ADDR` and other env creds, so I ran `test:unit`.)

## What is *not* needed

No per-chain decay or block-time entry. `getV3BlockBuffer` derives from sdk-core's `secondsToBlocks`, and sdk-core already registers Ink:

```
getAverageBlockTimeSecs(57073) = 1
secondsToBlocks(5, 57073)      = 5 blocks
```

sdk-core is pinned `^7.18.0` and Ink shipped in 7.18.0. `lib/util/chains.ts` is the only place in the repo that enumerates chains outside tests, and there are no exhaustive `Record<ChainId, …>` types requiring a new entry.

## Playbook drift, filed separately

`playbook/NEW_CHAIN.md` §3.4 is stale for this repo (Uniswap/UniswapX#376 covers the Phase 2 half; §3.4 will follow):

- It says the ChainId enum lives in **two** files and that forgetting `lib/config/chains.ts` breaks Joi validation ("Correction C"). That file no longer exists — `lib/util/chains.ts` is now the documented single source of truth for both the injectors and the validator.
- It names `V3_BLOCK_BUFFER` and `getBlockTimeSecs` as per-chain knobs. Neither symbol exists; block time moved to sdk-core.
- It says to add `RPC_<chainId>` to `.env.example`. RPCs now resolve via `getRpcUrl` from a single `RPC_PREFIX_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
