### PR TITLE
fix(ci): let TruffleHog derive its own scan range

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -50,9 +50,11 @@ jobs:
         continue-on-error: true
         with:
           path: ./
-          base: "${{ github.event.repository.default_branch }}"
-          head: HEAD
-          extra_args: --debug --only-verified 
+          # Leave base/head unset so the action derives the scan range from the
+          # event: before..after on push, base.sha..head.sha on pull_request.
+          # Setting them explicitly resolved to main..HEAD on a push to main —
+          # the same commit — which the action rejects as an error.
+          extra_args: --debug --only-verified
 
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'


### PR DESCRIPTION
## What

Deletes the `base` and `head` inputs from the TruffleHog step. Two lines.

## Why

The workflow pinned `base` to the default branch and `head` to `HEAD`:

```yaml
base: "${{ github.event.repository.default_branch }}"   # → "main"
head: HEAD
```

On a push to `main` both resolve to the same commit. The action has an explicit guard for that case:

```bash
if [ $base_commit == $head_commit ] ; then
  echo "::error::BASE and HEAD commits are the same. TruffleHog won't scan anything."
  exit 1
fi
```

`continue-on-error: true` swallows the failure, then `Scan Results Status` re-raises it as `exit 1`. Result: **every push to main goes red without a single commit ever being scanned.**

38 consecutive failures on main going back to April 2026. There is no successful run on main anywhere in this workflow's history. PRs are green only because on a PR `HEAD` ≠ `main`, so a real diff scan happens.

## The fix

The action already derives the right range per event — but only when `base`/`head` are left empty:

```bash
if [ "${{ github.event_name }}" == "push" ]; then
  HEAD=${{ github.event.after }}; BASE=${{ github.event.before }}
elif [ "${{ github.event_name }}" == "pull_request" ]; then
  BASE=${{ github.event.pull_request.base.sha }}; HEAD=${{ github.event.pull_request.head.sha }}
```

The `pull_request` branch is exactly what this workflow was already getting, so **PR behavior is byte-for-byte identical**. Pushes to main start scanning the range that was actually pushed. The all-zeros first-push case is handled by the action.

## Why it matters

`--only-verified` means this job fires only on secrets TruffleHog has confirmed live against the provider. That's a high-signal alert, and it has been buried under four months of meaningless red X's. If a real credential landed on main, nobody would look.

## Heads up

- **This file came from the org infra template** (`320134e`, "chore(infra): add trufflehog", by `mr-uniswap`) with these inputs already set. Other Uniswap repos seeded from that template are almost certainly red on main for the same reason — the fix likely belongs upstream too, or a template sync will revert this.
- **The first post-merge run on main is the first time main is genuinely scanned.** If there's a live verified secret in recent history, this is when we find out. That's the point, but worth expecting.

## Verification

The push-event path can't be exercised from a PR — it only runs after merge. What this PR can show is that the `pull_request` path is unchanged (this PR's own TruffleHog check should pass exactly as before). The push path is confirmed by reading the action source at the pinned SHA `b0fd951`, quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)