### PR TITLE
fix: retain QuoteLambdaEIP on stack delete/replace

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { CfnOutput, Duration } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import * as aws_apigateway from 'aws-cdk-lib/aws-apigateway';
 import { MethodLoggingLevel } from 'aws-cdk-lib/aws-apigateway';
 import * as aws_asg from 'aws-cdk-lib/aws-applicationautoscaling';
@@ -231,6 +231,11 @@ export class APIStack extends cdk.Stack {
         },
       ],
     });
+    // Market makers firewall-allowlist this exact address for our RFQ webhook calls.
+    // CloudFormation's default is to release an EIP back to the public pool when the
+    // resource is removed or the stack is deleted, which is unrecoverable. RETAIN sets
+    // both DeletionPolicy and UpdateReplacePolicy so the allocation survives either path.
+    quoteLambdaElasticIp.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
     const vpc = new Vpc(this, 'QuoteLambdaVpc', {
       vpcName: 'QuoteLambdaVpc',


### PR DESCRIPTION
## What

Apply `RemovalPolicy.RETAIN` to the `QuoteLambdaElasticIp` `CfnEIP` in `bin/stacks/api-stack.ts`, so the synthesized `AWS::EC2::EIP` resource carries both:

```json
"UpdateReplacePolicy": "Retain",
"DeletionPolicy": "Retain"
```

Nothing else changes: same construct ID, same logical ID (`QuoteLambdaElasticIp`), same properties. Beta and prod share this code path, so one change covers both stages.

## Why

This EIP is the service's static egress address. It feeds the NAT gateway of the quote-lambda VPC, so every outbound RFQ webhook call to market makers originates from it. Market makers firewall-allowlist this exact IP; their servers reject RFQ traffic from any other source.

CloudFormation's default behaviour for an `AWS::EC2::EIP` with no `DeletionPolicy` is to **release the allocation back to the public AWS pool** whenever the resource is removed from the template or the stack is deleted. A released EIP cannot be reliably recovered, and every market maker would have to re-allowlist a new address. An upcoming migration depends on keeping this exact address, so this PR is the safety net against that failure mode:

- `DeletionPolicy: Retain` keeps the allocation if the resource is removed or the stack is deleted.
- `UpdateReplacePolicy: Retain` keeps the old allocation if a future change ever forces a replacement.

A `RemovalPolicy` change is metadata-only from CloudFormation's point of view. Applying it does **not** modify or replace the EIP, so deploying this is a no-op for the live address.

## Explicitly out of scope

Removing or orphaning the EIP from the stack is **not** done here. That happens at migration cutover and requires hardcoded allocation IDs on the consuming side. This PR only guarantees that when that step happens, the address survives it.

The three NAT EIPs in the nested `AnalyticsStack` (Redshift VPC) are left as-is; nothing external depends on those addresses.

## Verification

- `yarn install --frozen-lockfile && yarn build` clean.
- `npx cdk synth` from `main` and from this branch into separate output directories, then `diff -u` on every `*.template.json`. The **only** difference across all templates is the two policy lines above on the `QuoteLambdaElasticIp` resource in `GoudaParameterizationStack.template.json`. No logical-ID or property changes, no changes to nested templates or the pipeline stack.
- `yarn lint`: 0 errors (86 pre-existing warnings, unchanged).
- `cdk deploy` was **not** run.

## Reviewer note

Merging to `main` auto-deploys to beta and prod via the CDK pipeline. Please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
