### PR TITLE
fix: bound config fetches, drop dead RFQ_WEBHOOK_CONFIG, remove dead active-orders Firehose path

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -106,10 +106,6 @@ export class APIPipeline extends Stack {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-service-api-xCINOs',
     });
 
-    const rfqWebhookConfig = sm.Secret.fromSecretAttributes(this, 'RfqConfig', {
-      secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:rfq-webhook-config-sy04bH',
-    });
-
     const internalApiKey = sm.Secret.fromSecretAttributes(this, 'internal-api-key', {
       secretCompleteArn:
         'arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-parameterization-api-internal-api-key-uw4sIa',
@@ -136,7 +132,6 @@ export class APIPipeline extends Stack {
       stage: STAGE.BETA,
       envVars: {
         ...jsonRpcProviders,
-        RFQ_WEBHOOK_CONFIG: rfqWebhookConfig.secretValue.toString(),
         ORDER_SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_BETA').toString(),
         FILL_LOG_SENDER_ACCOUNT: '321377678687',
         ORDER_LOG_SENDER_ACCOUNT: '321377678687',
@@ -156,7 +151,6 @@ export class APIPipeline extends Stack {
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       envVars: {
         ...jsonRpcProviders,
-        RFQ_WEBHOOK_CONFIG: rfqWebhookConfig.secretValue.toString(),
         ORDER_SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_PROD').toString(),
         FILL_LOG_SENDER_ACCOUNT: '316116520258',
         ORDER_LOG_SENDER_ACCOUNT: '316116520258',

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -71,7 +71,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     const unifiedRoutingResponseBucket = new aws_s3.Bucket(this, 'UnifiedRoutingResponseBucket');
     const fillBucket = new aws_s3.Bucket(this, 'FillBucket');
     const ordersBucket = new aws_s3.Bucket(this, 'OrdersBucket');
-    const activeOrdersBucket = new aws_s3.Bucket(this, 'ActiveOrdersBucket');
     const botOrderLoaderBucket = new aws_s3.Bucket(this, 'BotOrderLoaderBucket');
     const botOrderRouterBucket = new aws_s3.Bucket(this, 'BotOrderRouterBucket');
     const botOrderBroadcasterBucket = new aws_s3.Bucket(this, 'BotOrderBroadcasterBucket');
@@ -87,7 +86,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     unifiedRoutingResponseBucket.grantRead(dsRole);
     fillBucket.grantRead(dsRole);
     ordersBucket.grantRead(dsRole);
-    activeOrdersBucket.grantRead(dsRole);
     botOrderLoaderBucket.grantRead(dsRole);
     botOrderRouterBucket.grantRead(dsRole);
     botOrderBroadcasterBucket.grantRead(dsRole);
@@ -648,17 +646,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       },
     });
 
-    // cannot setup log processor for s3 destination via cfnDeliveryStream even though
-    //    it's supported through the console :(
-    const activeOrderRedshiftStreamName = 'activeOrderRedshiftStream';
-    const activeOrderStream = new aws_firehose.CfnDeliveryStream(this, activeOrderRedshiftStreamName, {
-      s3DestinationConfiguration: {
-        bucketArn: activeOrdersBucket.bucketArn,
-        roleArn: firehoseRole.roleArn,
-        compressionFormat: 'UNCOMPRESSED',
-      },
-    });
-
     const orderStream = new aws_firehose.CfnDeliveryStream(this, 'OrderStream', {
       redshiftDestinationConfiguration: {
         clusterJdbcurl: `jdbc:redshift://${rsCluster.clusterEndpoint.hostname}:${rsCluster.clusterEndpoint.port}/${RS_DATABASE_NAME}`,
@@ -747,7 +734,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       { stream: rfqResponseFirehoseStream, hasRedshift: true },
       { stream: fillStream, hasRedshift: true },
       { stream: orderStream, hasRedshift: true },
-      { stream: activeOrderStream, hasRedshift: false },
       { stream: unimindResponseStream, hasRedshift: false },
       { stream: unimindParameterUpdateStream, hasRedshift: false },
     ];
@@ -776,19 +762,17 @@ export class AnalyticsStack extends cdk.NestedStack {
         statistic: 'Sum',
         period: cdk.Duration.minutes(5),
       });
-      if (stream.node.id !== activeOrderRedshiftStreamName) {
-        const missingRecordsSev3 = new cdk.aws_cloudwatch.Alarm(this, missingRecordsName, {
-          metric: incomingRecords,
-          comparisonOperator: cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-          threshold: 1,
-          evaluationPeriods: (12 * 60) / 5, // 12 hours (12 * 60 / 5 minutes)
-          treatMissingData: cdk.aws_cloudwatch.TreatMissingData.BREACHING,
-          actionsEnabled: true,
-          alarmName: missingRecordsName,
-        });
-        if (chatBotTopic) {
-          missingRecordsSev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
-        }
+      const missingRecordsSev3 = new cdk.aws_cloudwatch.Alarm(this, missingRecordsName, {
+        metric: incomingRecords,
+        comparisonOperator: cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        threshold: 1,
+        evaluationPeriods: (12 * 60) / 5, // 12 hours (12 * 60 / 5 minutes)
+        treatMissingData: cdk.aws_cloudwatch.TreatMissingData.BREACHING,
+        actionsEnabled: true,
+        alarmName: missingRecordsName,
+      });
+      if (chatBotTopic) {
+        missingRecordsSev3.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic));
       }
 
       const s3DeliverySev3 = new cdk.aws_cloudwatch.Alarm(this, s3DeliverySuccessSev3Name, {
@@ -868,12 +852,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       destinationName: 'fillEventDestination',
     });
 
-    const activeOrderDestination = new aws_logs.CfnDestination(this, 'activeOrderEventDestination', {
-      roleArn: subscriptionRole.roleArn,
-      targetArn: activeOrderStream.attrArn,
-      destinationName: 'activeOrderEventDestination',
-    });
-
     const postedOrderDestination = new aws_logs.CfnDestination(this, 'PostedOrderDestination', {
       roleArn: subscriptionRole.roleArn,
       targetArn: orderStream.attrArn,
@@ -896,20 +874,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     // enclosed in if statement to allow deploying stack w/o having to set up x-account logging
     if (props.envVars['FILL_LOG_SENDER_ACCOUNT']) {
       fillDestination.destinationPolicy = JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Sid: '',
-            Effect: 'Allow',
-            Principal: {
-              AWS: props.envVars['FILL_LOG_SENDER_ACCOUNT'],
-            },
-            Action: 'logs:PutSubscriptionFilter',
-            Resource: '*',
-          },
-        ],
-      });
-      activeOrderDestination.destinationPolicy = JSON.stringify({
         Version: '2012-10-17',
         Statement: [
           {

--- a/lib/providers/compliance/s3.ts
+++ b/lib/providers/compliance/s3.ts
@@ -1,9 +1,15 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
 import axios from 'axios';
 import { default as Logger } from 'bunyan';
 
 import { FillerComplianceConfiguration, FillerComplianceConfigurationProvider, FillerComplianceList } from '.';
 import { checkDefined } from '../../preconditions/preconditions';
+import { createConfigS3Client } from '../../util/config-s3-client';
+
+// Bounds the per-config complianceListUrl fetch, which runs serially on the quote
+// path right after each config refresh. Without it a dead upstream stalled every
+// quote on the instance for ~15s (2026-07 incident); failures already fail open.
+export const COMPLIANCE_LIST_TIMEOUT_MS = 2000;
 
 export class S3FillerComplianceConfigurationProvider implements FillerComplianceConfigurationProvider {
   private log: Logger;
@@ -21,7 +27,7 @@ export class S3FillerComplianceConfigurationProvider implements FillerCompliance
 
   private async fetchComplianceList(url: string): Promise<string[]> {
     try {
-      const response = await axios.get(url);
+      const response = await axios.get(url, { timeout: COMPLIANCE_LIST_TIMEOUT_MS });
       if (response.status !== 200) {
         this.log.warn({ url, status: response.status }, 'Failed to fetch compliance list');
         return [];
@@ -76,7 +82,7 @@ export class S3FillerComplianceConfigurationProvider implements FillerCompliance
   }
 
   async fetchConfigs(): Promise<void> {
-    const s3Client = new S3Client({});
+    const s3Client = createConfigS3Client();
     try {
       const s3Res = await s3Client.send(
         new GetObjectCommand({
@@ -88,7 +94,9 @@ export class S3FillerComplianceConfigurationProvider implements FillerCompliance
       this.configs = JSON.parse(await s3Body.transformToString()) as FillerComplianceConfiguration[];
       this.log.info({ configsLength: this.configs.map((c) => c.addresses.length) }, `Fetched configs`);
     } catch (e: any) {
-      this.log.info(
+      // Fails open on the last fetched configs (or none): a timed-out refresh must
+      // not hold or 500 the quote path.
+      this.log.warn(
         { name: e.name, message: e.message },
         'Error fetching compliance s3 config. Default to allowing all'
       );

--- a/lib/providers/webhook/s3.ts
+++ b/lib/providers/webhook/s3.ts
@@ -1,10 +1,11 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { metric, MetricLoggerUnit } from '@uniswap/smart-order-router';
 import { default as Logger } from 'bunyan';
 
 import { WebhookConfiguration, WebhookConfigurationProvider } from '.';
 import { Metric } from '../../entities/aws-metrics-logger';
 import { checkDefined } from '../../preconditions/preconditions';
+import { createConfigS3Client } from '../../util/config-s3-client';
 
 // reads endpoint configuration from a static file
 export class S3WebhookConfigurationProvider implements WebhookConfigurationProvider {
@@ -32,14 +33,25 @@ export class S3WebhookConfigurationProvider implements WebhookConfigurationProvi
       this.endpoints.length === 0 ||
       Date.now() - this.lastUpdatedEndpointsTimestamp > S3WebhookConfigurationProvider.UPDATE_ENDPOINTS_PERIOD_MS
     ) {
-      await this.fetchEndpoints();
-      this.lastUpdatedEndpointsTimestamp = Date.now();
+      try {
+        await this.fetchEndpoints();
+      } catch (e: any) {
+        // Fail open on the cached config: a stalled or failed refresh must never hold
+        // or 500 the quote path. The next attempt is at the normal cadence — or on the
+        // next request if nothing has ever been cached (endpoints.length === 0).
+        this.log.warn(
+          { name: e?.name, message: e?.message, cachedEndpoints: this.endpoints.length },
+          'Error refreshing webhook config from S3; serving cached endpoints'
+        );
+      } finally {
+        this.lastUpdatedEndpointsTimestamp = Date.now();
+      }
     }
     return this.endpoints;
   }
 
   async fetchEndpoints(): Promise<void> {
-    const s3Client = new S3Client({});
+    const s3Client = createConfigS3Client();
     const s3Res = await s3Client.send(
       new GetObjectCommand({
         Bucket: this.bucket,

--- a/lib/util/config-s3-client.ts
+++ b/lib/util/config-s3-client.ts
@@ -1,0 +1,23 @@
+import { S3Client } from '@aws-sdk/client-s3';
+
+// The webhook and compliance config providers refresh their S3 JSON inline on the
+// quote path (~every 5 minutes per instance). The SDK ships with no client-side
+// timeout, so a stalled connection held every quote on that instance until the
+// kernel gave up (~15s SYN-retransmit ladder — the 2026-07 quote-stall incident).
+// These bounds cap the stall; callers keep serving their last cached config when a
+// refresh fails.
+export const CONFIG_S3_CONNECTION_TIMEOUT_MS = 1000;
+export const CONFIG_S3_REQUEST_TIMEOUT_MS = 2000;
+// The standard retry strategy defaults to 3 attempts, which would triple the
+// worst-case stall. Two attempts bounds it at roughly 2 × requestTimeout.
+export const CONFIG_S3_MAX_ATTEMPTS = 2;
+
+export function createConfigS3Client(): S3Client {
+  return new S3Client({
+    requestHandler: {
+      connectionTimeout: CONFIG_S3_CONNECTION_TIMEOUT_MS,
+      requestTimeout: CONFIG_S3_REQUEST_TIMEOUT_MS,
+    },
+    maxAttempts: CONFIG_S3_MAX_ATTEMPTS,
+  });
+}

--- a/test/providers/compliance/s3.test.ts
+++ b/test/providers/compliance/s3.test.ts
@@ -6,6 +6,7 @@ import {
   FillerComplianceConfiguration,
   S3FillerComplianceConfigurationProvider,
 } from '../../../lib/providers/compliance';
+import { COMPLIANCE_LIST_TIMEOUT_MS } from '../../../lib/providers/compliance/s3';
 
 const mockConfigs = [
   {
@@ -82,12 +83,36 @@ describe('S3ComplianceConfigurationProvider', () => {
     const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
     const map = await provider.getEndpointToExcludedAddrsMap();
 
-    expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/compliance-list.json');
+    expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/compliance-list.json', {
+      timeout: COMPLIANCE_LIST_TIMEOUT_MS,
+    });
     expect(map).toMatchObject(
       new Map([
         ['https://google.com', new Set(['0x1234'])],
         ['https://meta.com', new Set(['0x1234', '0x5678'])],
         ['https://x.com', new Set(['0x7890', '0x2345', '0x6789'])],
+      ])
+    );
+  });
+
+  it('keeps serving the cached configs when the S3 refresh fails', async () => {
+    applyMock(mockConfigs);
+    // one rejection per refresh: the initial build and the post-failure rebuild
+    mockedAxios.get.mockRejectedValueOnce(new Error('Network error')).mockRejectedValueOnce(new Error('Network error'));
+    const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
+    const before = await provider.getEndpointToExcludedAddrsMap();
+    expect(before.size).toBe(3);
+
+    jest.useFakeTimers().setSystemTime(Date.now() + 10 * 60 * 1000);
+    jest.spyOn(S3Client.prototype, 'send').mockImplementationOnce(() => Promise.reject(new Error('TimeoutError')));
+    const after = await provider.getEndpointToExcludedAddrsMap();
+    jest.useRealTimers();
+
+    expect(after).toMatchObject(
+      new Map([
+        ['https://google.com', new Set(['0x1234'])],
+        ['https://meta.com', new Set(['0x1234', '0x5678'])],
+        ['https://x.com', new Set(['0x7890'])],
       ])
     );
   });
@@ -99,7 +124,9 @@ describe('S3ComplianceConfigurationProvider', () => {
     const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
     const map = await provider.getEndpointToExcludedAddrsMap();
 
-    expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/compliance-list.json');
+    expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/compliance-list.json', {
+      timeout: COMPLIANCE_LIST_TIMEOUT_MS,
+    });
     expect(map).toMatchObject(
       new Map([
         ['https://google.com', new Set(['0x1234'])],

--- a/test/providers/webhook/s3.test.ts
+++ b/test/providers/webhook/s3.test.ts
@@ -41,6 +41,9 @@ describe('S3WebhookConfigurationProvider', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    // 'Refetches after cache expires' leaves fake timers installed; a following test
+    // that re-installs them would otherwise see the clock reset and its cache unexpired.
+    jest.useRealTimers();
   });
 
   it('Fetches endpoints', async () => {
@@ -86,6 +89,56 @@ describe('S3WebhookConfigurationProvider', () => {
     jest.useFakeTimers().setSystemTime(Date.now() + 1000000);
     endpoints = await provider.getEndpoints();
     expect(endpoints).toEqual(updatedEndpoints);
+  });
+
+  describe('refresh failure', () => {
+    const expireCache = () => jest.useFakeTimers().setSystemTime(Date.now() + 1000000);
+    const applyFailure = () =>
+      jest.spyOn(S3Client.prototype, 'send').mockImplementationOnce(() => Promise.reject(new Error('TimeoutError')));
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('keeps serving the cached endpoints and does not throw when the refresh fails', async () => {
+      applyMock(mockEndpoints);
+      const provider = new S3WebhookConfigurationProvider(logger, bucket, key);
+      await provider.getEndpoints();
+
+      expireCache();
+      applyFailure();
+      await expect(provider.getEndpoints()).resolves.toEqual(mockEndpoints);
+    });
+
+    it('does not retry on every request after a failed refresh — the next attempt waits for the cadence', async () => {
+      applyMock(mockEndpoints);
+      const provider = new S3WebhookConfigurationProvider(logger, bucket, key);
+      await provider.getEndpoints();
+
+      expireCache();
+      applyFailure();
+      await provider.getEndpoints();
+      const sendSpy = jest.spyOn(S3Client.prototype, 'send');
+      // initial fetch + the failed refresh
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+      await provider.getEndpoints();
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not throw on a cold-start failure; returns no endpoints and retries on the next request', async () => {
+      applyFailure();
+      const provider = new S3WebhookConfigurationProvider(logger, bucket, key);
+      await expect(provider.getEndpoints()).resolves.toEqual([]);
+
+      applyMock(mockEndpoints);
+      await expect(provider.getEndpoints()).resolves.toEqual(mockEndpoints);
+    });
+
+    it('fetchEndpoints itself still throws, so the cron sees S3 failures', async () => {
+      applyFailure();
+      const provider = new S3WebhookConfigurationProvider(logger, bucket, key);
+      await expect(provider.fetchEndpoints()).rejects.toThrow('TimeoutError');
+    });
   });
 
   describe('config change detection', () => {

--- a/test/util/config-s3-client.test.ts
+++ b/test/util/config-s3-client.test.ts
@@ -1,0 +1,29 @@
+import { S3Client } from '@aws-sdk/client-s3';
+
+import {
+  CONFIG_S3_CONNECTION_TIMEOUT_MS,
+  CONFIG_S3_MAX_ATTEMPTS,
+  CONFIG_S3_REQUEST_TIMEOUT_MS,
+  createConfigS3Client,
+} from '../../lib/util/config-s3-client';
+
+jest.mock('@aws-sdk/client-s3');
+
+describe('createConfigS3Client', () => {
+  it('bounds connection, request, and retry budget so a stalled fetch cannot hold the quote path', () => {
+    createConfigS3Client();
+    expect(S3Client).toHaveBeenCalledWith({
+      requestHandler: {
+        connectionTimeout: CONFIG_S3_CONNECTION_TIMEOUT_MS,
+        requestTimeout: CONFIG_S3_REQUEST_TIMEOUT_MS,
+      },
+      maxAttempts: CONFIG_S3_MAX_ATTEMPTS,
+    });
+  });
+
+  it('keeps the total worst-case stall on the order of seconds, not the kernel SYN ladder', () => {
+    // 2 attempts × 2s request timeout + retry backoff (~hundreds of ms) ≈ 4s ≪ 15s
+    expect(CONFIG_S3_MAX_ATTEMPTS * CONFIG_S3_REQUEST_TIMEOUT_MS).toBeLessThanOrEqual(5000);
+    expect(CONFIG_S3_CONNECTION_TIMEOUT_MS).toBeLessThanOrEqual(CONFIG_S3_REQUEST_TIMEOUT_MS);
+  });
+});


### PR DESCRIPTION
Three small, deliberate changes, one commit each so any one can be reverted independently.

> **Depends on #488 (contract snapshots + invariant tests) — merge that first.** The snapshot suite is the safety net for this PR and is not on `main` yet; it is up as #488. I ran the exact files from #488 (4 test files, 38 snapshots, byte-for-byte the same as its head) against this branch: **49/49 pass, `.snap` files unchanged** before and after. Once #488 lands, re-run CI here before merging. Merging auto-deploys to beta and prod.

## Changes

1. **Timeouts on config downloads** (`dab5d21`) — no more config-fetch stalls. The webhook and compliance providers' S3 `GetObject` now use a shared client with a 1s connection timeout, 2s request timeout, and 2 attempts (default 3 would triple the worst case), so the worst-case stall is ~4s instead of the ~15s kernel SYN ladder from the 2026-07 incident. The `complianceListUrl` `axios.get` gets a 2s timeout. On failure both providers keep serving the last cached config and log a warning; nothing throws through the quote path. `fetchEndpoints()` still throws for the fade-rate cron, which has no cache to fall back on. Refresh cadence unchanged; no log-line shapes changed (the compliance S3 catch moves from `info` to `warn`, same message and fields).
2. **Remove a dead secret from the Lambda environment** (`edf3801`) — no functional change. `RFQ_WEBHOOK_CONFIG` was injected from Secrets Manager into the beta and prod env vars, but nothing under `lib/` reads it (grep before and after: only the two injection sites in `bin/app.ts`). The env entries and the now-unused `fromSecretAttributes` reference are removed. Because `envVars` is also spread into the analytics-stack processors, the var disappears from those five lambdas too. The secret itself is untouched in Secrets Manager.
3. **Remove the dead active-orders Firehose path** (`2a5408f`) — nothing observable changes, because nothing has ever landed. `activeOrderRedshiftStream` (S3-destination Firehose, fed by the cross-account CloudWatch Logs destination `activeOrderEventDestination`) was missing the `FirehoseRole` grant on `ActiveOrdersBucket` and has delivered nothing since it was created on 2024-03-26. Verified in prod: `DeliveryToS3.Success` averages exactly 0.0 over 171k samples in the last 90 days while the stream still receives ~500–1,500 records/week from account 316116520258, and the bucket holds 0 objects. Since nobody has needed that data in the intervening years, this removes the path rather than repairing it: the delivery stream, the Logs destination and its cross-account policy, the bucket (`RETAIN` removal policy, so it is orphaned, not deleted), the `bq-load-sa` read grant, the stream's two `S3Delivery` alarms, and the now-dead carve-out in the alarm loop. No `MissingRecords` alarm existed for it, so no alarm is added elsewhere.
   **Follow-ups outside this repo:** (a) delete the empty orphaned bucket `prod-us-east-2-goudaparam-activeordersbucket9cccf5-btaukr03xw8k` (and its beta twin); (b) remove the producer in `uniswapx-service`: `bin/stacks/step-function-stack.ts` construct `nonTerminalSub` — a `CfnSubscriptionFilter` on the CheckOrderStatus lambda's log group with pattern `{ $.orderInfo.orderStatus = "insufficient-funds" }` pointing at `activeOrderEventDestination` (prod filter `...-nonTerminalSub-YVXxSFEBHU7l` on `/aws/lambda/prod-us-east-2-GoudaServi-GoudaServiceprodCheckOrd-GKF7SRNo7Pxj`, confirmed in account 316116520258). So this feed was insufficient-funds status events, never 'active orders'. Its sibling `TerminalStateSub` (filled/cancelled → `fillEventDestination`) is live and must stay. The destination ARN reaches that stack as `ACTIVE_ORDER_EVENT_DESTINATION_ARN`, read in `bin/app.ts` from the resource-ARN secret's `ACTIVE_ORDER_EVENT_DESTINATION_ARN_BETA/_PROD` keys — retire those with the filter. Until (b) lands, the filter publishes to a deleted destination, which is harmless to the sender.

## Verification

- `yarn build`, `yarn test:unit` (298 tests), `yarn lint` (0 errors) — all pass.
- New/updated unit tests: bounded S3 client config; webhook provider serves cached endpoints on a failed refresh, waits for the cadence before retrying, does not throw on a cold-start failure; compliance provider serves cached configs on a failed refresh; `axios.get` called with the timeout.
- `cdk synth` on `main` and on this branch (twice each from an identical `cdk.context.json`, second runs compared; both sides converge with 0 self-diff). Semantic template diff, asset hashes normalized:
  - `RFQ_WEBHOOK_CONFIG` removed from Quote, HardQuote, and the five analytics processors (beta + prod) — change 2.
  - AnalyticsStack (root, beta, prod): 6 resources removed — `ActiveOrdersBucket`, its `BucketPolicy`, `activeOrderEventDestination`, `activeOrderRedshiftStream`, and its SEV2/SEV3 `S3Delivery` alarms. Nothing added, no other policy changes — change 3.
  - ParamDashboard body: only the git-derived deploy-marker list shifting (this branch's commits enter, the three oldest roll off) — a synth-time artifact, not a code change.
  - Everything else is the expected Lambda `CurrentVersion` logical-ID / asset-publish churn from the code change in change 1.
- Contract snapshot suite from #488: 49 tests pass, 38 snapshots byte-identical (see note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
