### PR TITLE
build: externalize source-map-support from Lambda bundles; ts-mocha 11, ts-jest 29.4.12; fix the two suppressed lint findings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,13 +41,7 @@
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-inferrable-types": "error",
-    // New in v8's recommended preset. Off to keep the lint gate identical across the TypeScript
-    // upgrade: its only hits are RedshiftColumnType in bin/stacks/analytics-stack.ts, where several
-    // semantic names intentionally share the same SQL type ('text'). Candidate to enable separately.
-    "@typescript-eslint/no-duplicate-enum-values": "off",
-    // v8 changed the no-unused-vars default for catch-clause bindings from "none" to "all";
-    // "caughtErrors": "none" keeps the v5 behaviour (unused `catch (err)` is not reported).
-    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "caughtErrors": "none" }],
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/ban-ts-comment": "off",
     // Two ways a test can silently stop running while CI still reports green: a focused test
     // (.only/fit/fdescribe) skips all its siblings, and a test block nested inside an it()

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -12,6 +12,7 @@ import * as aws_s3 from 'aws-cdk-lib/aws-s3';
 import * as sm from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 import path from 'path';
+import { LAMBDA_BUNDLING } from './lambda-bundling';
 
 const RS_DATABASE_NAME = 'uniswap_x'; // must be lowercase
 const ADMIN = 'admin';
@@ -314,10 +315,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       handler: 'quoteProcessor',
       timeout: cdk.Duration.seconds(60), // AWS suggests 1 min or higher
       memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
@@ -333,10 +331,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       handler: 'postOrderProcessor',
       timeout: cdk.Duration.seconds(60), // AWS suggests 1 min or higher
       memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
@@ -352,10 +347,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       handler: 'fillEventProcessor',
       timeout: cdk.Duration.seconds(60), // AWS suggests 1 min or higher
       memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
@@ -371,10 +363,7 @@ export class AnalyticsStack extends cdk.NestedStack {
       handler: 'unimindResponseProcessor',
       timeout: cdk.Duration.seconds(60),
       memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         VERSION: '2',
         NODE_OPTIONS: '--enable-source-maps',
@@ -393,10 +382,7 @@ export class AnalyticsStack extends cdk.NestedStack {
         handler: 'unimindParameterUpdateProcessor',
         timeout: cdk.Duration.seconds(60),
         memorySize: 512,
-        bundling: {
-          minify: true,
-          sourceMap: true,
-        },
+        bundling: LAMBDA_BUNDLING,
         environment: {
           VERSION: '2',
           NODE_OPTIONS: '--enable-source-maps',

--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -28,11 +28,9 @@ enum RS_DATA_TYPES {
   BIGINT = 'bigint',
   INTEGER = 'integer',
   TERMINAL_STATUS = 'varchar(9)', // 'filled' || 'expired' || 'cancelled
-  ALL_STATUS = 'text',
   TRADE_TYPE = 'varchar(12)', // 'EXACT_INPUT' || 'EXACT_OUTPUT'
   CALL_DATA = 'varchar(5000)',
   UnitInETH = 'float8',
-  BOT_EVENT_TYPE = 'text', // 'fetch' || 'filter' || 'execution' || 'quote'
   ORDER_TYPE = 'text', // 'Limit' || 'Dutch'
 }
 

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -28,6 +28,7 @@ import { SERVICE_NAME } from '../constants';
 import { AnalyticsStack } from './analytics-stack';
 import { CronStack } from './cron-stack';
 import { FirehoseStack } from './firehose-stack';
+import { LAMBDA_BUNDLING } from './lambda-bundling';
 import { ParamDashboardStack } from './param-dashboard-stack';
 
 /**
@@ -256,10 +257,7 @@ export class APIStack extends cdk.Stack {
         subnets: [...vpc.privateSubnets],
       },
       memorySize: 2048,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',
@@ -291,10 +289,7 @@ export class APIStack extends cdk.Stack {
         subnets: [...vpc.privateSubnets],
       },
       memorySize: 2048,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -16,6 +16,7 @@ import { DYNAMO_TABLE_NAME, FADE_RATE_BUCKET } from '../../lib/constants';
 import { STAGE } from '../../lib/util/stage';
 import { PROD_TABLE_CAPACITY } from '../config';
 import { SERVICE_NAME } from '../constants';
+import { LAMBDA_BUNDLING } from './lambda-bundling';
 
 type CapacityOptions = {
   readCapacity?: number;
@@ -67,10 +68,7 @@ export class CronStack extends cdk.NestedStack {
         handler: 'handler',
         timeout: Duration.seconds(240),
         memorySize: 512,
-        bundling: {
-          minify: true,
-          sourceMap: true,
-        },
+        bundling: LAMBDA_BUNDLING,
         environment: {
           REDSHIFT_DATABASE: RsDatabase,
           REDSHIFT_CLUSTER_IDENTIFIER: RsClusterIdentifier,
@@ -113,10 +111,7 @@ export class CronStack extends cdk.NestedStack {
       handler: 'handler',
       timeout: Duration.seconds(600), // deletion of large number of rows can take a while
       memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
+      bundling: LAMBDA_BUNDLING,
       environment: {
         REDSHIFT_DATABASE: RsDatabase,
         REDSHIFT_CLUSTER_IDENTIFIER: RsClusterIdentifier,

--- a/bin/stacks/lambda-bundling.ts
+++ b/bin/stacks/lambda-bundling.ts
@@ -1,0 +1,18 @@
+import { aws_lambda_nodejs } from 'aws-cdk-lib';
+
+/**
+ * esbuild options shared by every NodejsFunction in this app.
+ *
+ * `externalModules` replaces CDK's default (`@aws-sdk/*`, provided by the Node 18+ runtimes), so that
+ * default is restated here. `source-map-support` is excluded on purpose: nothing in this repo depends
+ * on it, but bunyan does an optional `require('source-map-support')` behind a try/catch (used only when
+ * a logger is created with `src: true`, which we never do). Left bundleable, whichever copy happens to
+ * be hoisted by dev tooling gets baked into the production bundles and changes their asset hash on
+ * unrelated dependency PRs. Externalizing it makes bunyan's require throw at runtime, which its
+ * try/catch swallows, so the deployed behaviour is unchanged minus the dead code.
+ */
+export const LAMBDA_BUNDLING: aws_lambda_nodejs.BundlingOptions = {
+  minify: true,
+  sourceMap: true,
+  externalModules: ['@aws-sdk/*', 'source-map-support'],
+};

--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -307,7 +307,7 @@ export abstract class APIGLambdaHandler<
     if (event.body) {
       try {
         bodyRaw = JSON.parse(event.body);
-      } catch (err) {
+      } catch {
         return {
           state: 'invalid',
           errorResponse: {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "prettier-plugin-organize-imports": "^3.2.4",
-    "ts-jest": "^29.0.3",
+    "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
     "typescript": "5.5.4"
   },
@@ -75,7 +75,7 @@
     "dynamodb-toolbox": "^0.8.5",
     "joi": "^17.7.0",
     "mocha": "^10.2.0",
-    "ts-mocha": "^10.1.0",
+    "ts-mocha": "^11.1.0",
     "uuid": "^9.0.0"
   },
   "prettier": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4211,11 +4211,6 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
-arrify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
-
 asn1.js@^5.4.1:
   version "5.4.1"
   resolved "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
@@ -4527,7 +4522,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0, buffer-from@^1.1.0:
+buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
@@ -4971,11 +4966,6 @@ diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
-
-diff@^3.1.0:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -5966,10 +5956,10 @@ graphql@^15.5.0:
   resolved "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz#e9ff3bb928749275477f748b14aa5c30dcad6f2f"
   integrity sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==
 
-handlebars@^4.7.8:
-  version "4.7.8"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"
@@ -7172,7 +7162,7 @@ minizlib@^1.3.3:
   dependencies:
     minipass "^2.9.0"
 
-mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -7851,7 +7841,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.2:
+semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
@@ -7987,14 +7977,6 @@ source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map-support@^0.5.6:
-  version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -8268,43 +8250,25 @@ ts-api-utils@^2.5.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
-ts-jest@^29.0.3:
-  version "29.4.1"
-  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz#42d33beb74657751d315efb9a871fe99e3b9b519"
-  integrity sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==
+ts-jest@^29.4.12:
+  version "29.4.12"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.12.tgz#c34cd91f02d364e9286d2c016843315fd0efff76"
+  integrity sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==
   dependencies:
     bs-logger "^0.2.6"
     fast-json-stable-stringify "^2.1.0"
-    handlebars "^4.7.8"
+    handlebars "^4.7.9"
     json5 "^2.2.3"
     lodash.memoize "^4.1.2"
     make-error "^1.3.6"
-    semver "^7.7.2"
+    semver "^7.8.5"
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-mocha@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-10.1.0.tgz#17a1c055f5f7733fd82447c4420740db87221bc8"
-  integrity sha512-T0C0Xm3/WqCuF2tpa0GNGESTBoKZaiqdUP8guNv4ZY316AFXlyidnrzQ1LUrCT0Wb1i3J0zFTgOh/55Un44WdA==
-  dependencies:
-    ts-node "7.0.1"
-  optionalDependencies:
-    tsconfig-paths "^3.5.0"
-
-ts-node@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
-  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
-  dependencies:
-    arrify "^1.0.0"
-    buffer-from "^1.1.0"
-    diff "^3.1.0"
-    make-error "^1.1.1"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map-support "^0.5.6"
-    yn "^2.0.0"
+ts-mocha@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-11.1.0.tgz#d8336ec0146bd6f36cca2555f4cfc7df85bd1586"
+  integrity sha512-yT7FfzNRCu8ZKkYvAOiH01xNma/vLq6Vit7yINKYFNVP8e5UyrYXSOMIipERTpzVKJQ4Qcos5bQo1tNERNZevQ==
 
 ts-node@^10.9.2:
   version "10.9.2"
@@ -8330,7 +8294,7 @@ ts-toolbelt@^9.6.0:
   resolved "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
   integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
 
-tsconfig-paths@^3.15.0, tsconfig-paths@^3.5.0:
+tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
   integrity sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==
@@ -8764,11 +8728,6 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-
-yn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
-  integrity sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

Follow-up to #490. That PR held three things back to keep the Lambda bundles byte-identical; this PR takes them, plus the two lint findings #490 had to suppress. **This one does change 4 production Lambda bundles**, deliberately and only by removing dead code, so it should be reviewed and watched as a normal deploy rather than a no-op.

Three commits, in order:

### 1. `build:` externalize `source-map-support` from the Lambda bundles

New `bin/stacks/lambda-bundling.ts` exports `LAMBDA_BUNDLING` (`minify`, `sourceMap` as before, plus `externalModules: ['@aws-sdk/*', 'source-map-support']`), used by all nine `NodejsFunction`s in `api-stack`, `cron-stack` and `analytics-stack`. `@aws-sdk/*` restates CDK's default, which `externalModules` would otherwise replace (checked against the installed `aws-cdk-lib` bundling logic; no feature flags are set, so the default is exactly `['@aws-sdk/*']`).

Why: `bunyan` does an optional `try { require('source-map-support') } catch {}` at load. It only uses it when a logger is created with `src: true`, which nothing in this repo does, and every Lambda already runs with `NODE_OPTIONS=--enable-source-maps`, so the package was doubly redundant. Because nothing declares it, whichever copy dev tooling happened to hoist was baked into the prod bundles, which is why unrelated dependency changes churned asset hashes in #490. Externalizing it makes bunyan's `require` throw at runtime and its `try/catch` swallow that. The bundle still contains the guarded call (`try{fc=require("source-map-support")}catch{fc=null}`), verified in the synthesized `index.js`.

### 2. `chore(deps):` ts-mocha 10.1.0 → 11.1.0, ts-jest 29.4.1 → 29.4.12

Both were skipped in #490 because they changed the bundles through yarn hoisting (ts-mocha 11 drops its nested ts-node 7, which was the only thing pulling in `source-map-support@0.5.21`; ts-jest 29.4.12 moves `semver@7.8.5` to the top level). With commit 1 in place that no longer matters. **Behavioural note:** `yarn test:integ` (run by the pipeline against beta and prod) now compiles under the repo's ts-node 10.9.2 instead of the ts-node 7.0.1 that ts-mocha 10 bundled. `ts-mocha --dry-run` over `test/integ/**` compiles the suite and stops at the same `COSIGNER_ADDR` env check as before.

### 3. `fix(lint):` resolve the two findings #490 suppressed

Removes the `caughtErrors: "none"` and `no-duplicate-enum-values: "off"` overrides from `.eslintrc` and fixes what they hid:

- `lib/handlers/base/api-handler.ts:310`: `catch (err)` with an unused binding → `catch {`.
- `bin/stacks/analytics-stack.ts`: `RS_DATA_TYPES.ALL_STATUS` and `BOT_EVENT_TYPE` were unused and duplicated `ORDER_TYPE`'s `'text'` value (the only one referenced, by the `orderType` column). Both removed. Column types are unchanged, so the Analytics nested template is byte-identical.

Lint result is unchanged: `87 problems (0 errors, 87 warnings)`, same `file:line/rule/severity` set as `main`.

## Exactly what changes in the synthesized output

Method: clean `yarn install --frozen-lockfile` of `main` (c2ec148) and of this branch in separate worktrees, in-tree `cdk synth`, then per-asset source-map comparison (module list + `sourcesContent`).

| Lambda | asset | bundle change |
|---|---|---|
| Quote (`lib/handlers/quote/exports.ts`) | changed | −34,928 B: `source-map-support`, `source-map`, `buffer-from` removed; `api-handler.ts` `catch {}`; `semver` 7.7.2 moved to `@eth-optimism/sdk/node_modules/` in the source map (same bytes) |
| HardQuote (`lib/handlers/hard-quote/exports.ts`) | changed | −34,955 B: same as Quote |
| FadeRateV2Cron (`lib/cron/fade-rate-v2.ts`) | changed | −34,906 B: `source-map-support` trio removed; `semver` path move |
| Redshift reaper (`lib/cron/redshift-reaper.ts`) | changed | −34,469 B: `source-map-support` trio removed |
| 4 analytics processors (`lib/handlers/index.ts`) | **identical** | they never bundled bunyan |

No module other than those three has different content in any bundle. Template diffs are confined to the corresponding asset hashes, `AWS::Lambda::Version` logical IDs, and the nested Cron stack's template URL; the Analytics and Firehose nested templates and both KMS templates are byte-identical. Deploy shape: same as #489 today (new versions published, `live` aliases moved, provisioned concurrency re-warmed on Quote).

## Verification

| check | result |
|---|---|
| `yarn install --frozen-lockfile && yarn build` | ✅ |
| `npx tsc --noEmit -p tsconfig.cdk.json` | ✅ |
| `yarn test:unit` | ✅ 36 suites, 347 tests, 38 snapshots, no `.snap` modified |
| `yarn lint` | ✅ 87 / 0, identical set to `main`; prettier clean |
| `npx cdk synth` vs clean `main` | ✅ only the 4 bunyan bundles differ, as tabulated above |
| `ts-mocha -p tsconfig.cdk.json --dry-run 'test/integ/**/*.test.ts'` | ✅ compiles under ts-node 10.9.2 |

Post-merge, the same prod check as for #490 applies: expect 4 functions with new `LastModified`, `live` aliases on new versions, and flat errors/latency. The chronic `InvalidSignatureException: Signature expired` unhandled rejections on the Quote Lambda (0–5/hour, present all day before #490) are pre-existing and unrelated.
