### PR TITLE
refactor(compliance): stale-while-revalidate S3 provider; drop complianceListUrl

### DIFF
--- a/lib/providers/compliance/index.ts
+++ b/lib/providers/compliance/index.ts
@@ -1,15 +1,33 @@
 export interface FillerComplianceConfiguration {
   endpoints: string[];
   addresses: string[];
-  complianceListUrl?: string;
-}
-export interface FillerComplianceList {
-  addresses: string[];
 }
 
 export interface FillerComplianceConfigurationProvider {
-  getConfigs(): Promise<FillerComplianceConfiguration[]>;
-  getEndpointToExcludedAddrsMap(): Promise<Map<string, Set<string>>>;
+  // The first call per container awaits the load; every later call resolves immediately.
+  ensureLoaded(): Promise<void>;
+  // Synchronous by design: called once per endpoint on the quote path after ensureLoaded().
+  isExcluded(endpoint: string, swapper: string): boolean;
+}
+
+// endpoint -> excluded swappers, lowercased on both sides of the comparison so a
+// checksum-cased config entry still matches a lowercased request swapper (and vice versa).
+export type ExclusionIndex = Map<string, Set<string>>;
+
+export function buildExclusionIndex(configs: FillerComplianceConfiguration[]): ExclusionIndex {
+  const index: ExclusionIndex = new Map();
+  for (const { endpoints, addresses } of configs) {
+    for (const endpoint of endpoints) {
+      const excluded = index.get(endpoint) ?? new Set<string>();
+      addresses.forEach((address) => excluded.add(address.toLowerCase()));
+      index.set(endpoint, excluded);
+    }
+  }
+  return index;
+}
+
+export function isExcludedIn(index: ExclusionIndex, endpoint: string, swapper: string): boolean {
+  return index.get(endpoint)?.has(swapper.toLowerCase()) ?? false;
 }
 
 export * from './mock';

--- a/lib/providers/compliance/mock.ts
+++ b/lib/providers/compliance/mock.ts
@@ -1,24 +1,22 @@
-import { FillerComplianceConfiguration, FillerComplianceConfigurationProvider } from '.';
+import {
+  buildExclusionIndex,
+  FillerComplianceConfiguration,
+  FillerComplianceConfigurationProvider,
+  isExcludedIn,
+} from '.';
 
 export class MockFillerComplianceConfigurationProvider implements FillerComplianceConfigurationProvider {
-  constructor(private configs: FillerComplianceConfiguration[]) {}
+  private readonly index;
 
-  async getConfigs(): Promise<FillerComplianceConfiguration[]> {
-    return this.configs;
+  constructor(configs: FillerComplianceConfiguration[]) {
+    this.index = buildExclusionIndex(configs);
   }
 
-  async getEndpointToExcludedAddrsMap(): Promise<Map<string, Set<string>>> {
-    const map = new Map<string, Set<string>>();
-    this.configs.forEach((config) => {
-      config.endpoints.forEach((endpoint) => {
-        if (!map.has(endpoint)) {
-          map.set(endpoint, new Set<string>());
-        }
-        config.addresses.forEach((address) => {
-          map.get(endpoint)?.add(address);
-        });
-      });
-    });
-    return map;
+  ensureLoaded(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  isExcluded(endpoint: string, swapper: string): boolean {
+    return isExcludedIn(this.index, endpoint, swapper);
   }
 }

--- a/lib/providers/compliance/s3.ts
+++ b/lib/providers/compliance/s3.ts
@@ -1,105 +1,69 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
-import axios from 'axios';
 import { default as Logger } from 'bunyan';
 
-import { FillerComplianceConfiguration, FillerComplianceConfigurationProvider, FillerComplianceList } from '.';
+import {
+  buildExclusionIndex,
+  ExclusionIndex,
+  FillerComplianceConfiguration,
+  FillerComplianceConfigurationProvider,
+  isExcludedIn,
+} from '.';
 import { checkDefined } from '../../preconditions/preconditions';
 import { createConfigS3Client } from '../../util/config-s3-client';
 
-// Bounds the per-config complianceListUrl fetch, which runs serially on the quote
-// path right after each config refresh. Without it a dead upstream stalled every
-// quote on the instance for ~15s (2026-07 incident); failures already fail open.
-export const COMPLIANCE_LIST_TIMEOUT_MS = 2000;
+export const COMPLIANCE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
+// The slice of S3Client this provider uses, typed structurally so tests can inject a fake.
+export interface ComplianceS3Client {
+  send(command: GetObjectCommand): Promise<{ Body?: { transformToString(): Promise<string> } }>;
+}
+
+// Stale-while-revalidate: the first call per container awaits one bounded fetch; after that a
+// call that finds the interval elapsed starts a single background refresh and keeps serving the
+// current index, which is swapped atomically when the fetch completes. The fetch stays on the
+// request path (not container init) because of a Dec-2024 S3 clock-skew issue.
 export class S3FillerComplianceConfigurationProvider implements FillerComplianceConfigurationProvider {
-  private log: Logger;
-  private configs: FillerComplianceConfiguration[];
-  private endpointToExcludedAddrsMap: Map<string, Set<string>>;
-  private lastFetchTime: number;
-  private readonly REFRESH_INTERVAL = 5 * 60 * 1000;
+  private readonly log: Logger;
+  private index: ExclusionIndex = new Map();
+  // Tracked explicitly: an empty config (prod today) is a loaded config, not a missing one.
+  private loaded = false;
+  private lastFetchTime = 0;
+  private inflight: Promise<void> | undefined;
 
-  constructor(_log: Logger, private bucket: string, private key: string) {
-    this.configs = [];
+  constructor(
+    _log: Logger,
+    private readonly bucket: string,
+    private readonly key: string,
+    private readonly s3Client: ComplianceS3Client = createConfigS3Client()
+  ) {
     this.log = _log.child({ quoter: 'S3FillerComplianceConfigurationProvider' });
-    this.endpointToExcludedAddrsMap = new Map<string, Set<string>>();
-    this.lastFetchTime = 0;
   }
 
-  private async fetchComplianceList(url: string): Promise<string[]> {
+  async ensureLoaded(): Promise<void> {
+    if (Date.now() - this.lastFetchTime >= COMPLIANCE_REFRESH_INTERVAL_MS && !this.inflight) {
+      this.inflight = this.fetchConfigs().finally(() => (this.inflight = undefined));
+    }
+    if (!this.loaded) await this.inflight;
+  }
+
+  isExcluded(endpoint: string, swapper: string): boolean {
+    return isExcludedIn(this.index, endpoint, swapper);
+  }
+
+  private async fetchConfigs(): Promise<void> {
     try {
-      const response = await axios.get(url, { timeout: COMPLIANCE_LIST_TIMEOUT_MS });
-      if (response.status !== 200) {
-        this.log.warn({ url, status: response.status }, 'Failed to fetch compliance list');
-        return [];
-      }
-      const complianceList = response.data as FillerComplianceList;
-      return complianceList.addresses;
-    } catch (e: any) {
-      this.log.warn({ url, error: e.message }, 'Error fetching compliance list');
-      return [];
-    }
-  }
-
-  async getEndpointToExcludedAddrsMap(): Promise<Map<string, Set<string>>> {
-    const now = Date.now();
-    if (this.configs.length === 0 || now - this.lastFetchTime >= this.REFRESH_INTERVAL) {
-      await this.fetchConfigs();
-      this.endpointToExcludedAddrsMap.clear();
-      this.lastFetchTime = now;
-    }
-    if (this.endpointToExcludedAddrsMap.size > 0) {
-      return this.endpointToExcludedAddrsMap;
-    }
-
-    // Fetch additional addresses from complianceListUrl for each config
-    for (const config of this.configs) {
-      if (config.complianceListUrl) {
-        const additionalAddresses = await this.fetchComplianceList(config.complianceListUrl);
-        config.addresses = [...config.addresses, ...additionalAddresses];
-      }
-    }
-
-    // Build the endpoint to addresses map
-    this.configs.forEach((config) => {
-      config.endpoints.forEach((endpoint) => {
-        if (!this.endpointToExcludedAddrsMap.has(endpoint)) {
-          this.endpointToExcludedAddrsMap.set(endpoint, new Set<string>());
-        }
-        config.addresses.forEach((address) => {
-          this.endpointToExcludedAddrsMap.get(endpoint)?.add(address);
-        });
-      });
-    });
-
-    return this.endpointToExcludedAddrsMap;
-  }
-
-  async getConfigs(): Promise<FillerComplianceConfiguration[]> {
-    if (this.configs.length === 0) {
-      await this.fetchConfigs();
-    }
-    return this.configs;
-  }
-
-  async fetchConfigs(): Promise<void> {
-    const s3Client = createConfigS3Client();
-    try {
-      const s3Res = await s3Client.send(
-        new GetObjectCommand({
-          Bucket: this.bucket,
-          Key: this.key,
-        })
-      );
+      const s3Res = await this.s3Client.send(new GetObjectCommand({ Bucket: this.bucket, Key: this.key }));
       const s3Body = checkDefined(s3Res.Body, 's3Res.Body is undefined');
-      this.configs = JSON.parse(await s3Body.transformToString()) as FillerComplianceConfiguration[];
-      this.log.info({ configsLength: this.configs.map((c) => c.addresses.length) }, `Fetched configs`);
-    } catch (e: any) {
-      // Fails open on the last fetched configs (or none): a timed-out refresh must
-      // not hold or 500 the quote path.
-      this.log.warn(
-        { name: e.name, message: e.message },
-        'Error fetching compliance s3 config. Default to allowing all'
-      );
+      const configs = JSON.parse(await s3Body.transformToString()) as FillerComplianceConfiguration[];
+      this.index = buildExclusionIndex(configs);
+      this.log.info({ configsLength: configs.map((c) => c.addresses.length) }, 'Fetched configs');
+    } catch (e) {
+      // Fails open on the last good index (or an empty one); the next attempt waits for the interval.
+      const { name, message } = e instanceof Error ? e : { name: 'UnknownError', message: String(e) };
+      this.log.warn({ name, message }, 'Error fetching compliance s3 config. Default to allowing all');
+    } finally {
+      this.loaded = true;
+      this.lastFetchTime = Date.now();
     }
   }
 }

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -81,7 +81,7 @@ export class WebhookQuoter implements Quoter {
     metric.putMetric(Metric.RFQ_PHASE_ENDPOINT_STATUSES, Date.now() - beforeStatuses, MetricLoggerUnit.Milliseconds);
 
     const beforeCompliance = Date.now();
-    const endpointToAddrsMap = await this.complianceProvider.getEndpointToExcludedAddrsMap();
+    await this.complianceProvider.ensureLoaded();
     metric.putMetric(Metric.RFQ_PHASE_COMPLIANCE, Date.now() - beforeCompliance, MetricLoggerUnit.Milliseconds);
     // Ignore endpoint status if token is permissioned
     const isPermissionedToken =
@@ -92,7 +92,7 @@ export class WebhookQuoter implements Quoter {
       : statuses.enabled;
     const enabledEndpoints = baseFillerSet.filter(
       (e) =>
-        passFillerCompliance(e, endpointToAddrsMap, request.swapper) &&
+        !this.complianceProvider.isExcluded(e.endpoint, request.swapper) &&
         getEndpointSupportedProtocols(e).includes(request.protocol)
     );
 
@@ -478,12 +478,4 @@ export function getEndpointSupportedProtocols(e: WebhookConfiguration) {
     return [ProtocolVersion.V2, ProtocolVersion.V3];
   }
   return e.supportedVersions;
-}
-
-export function passFillerCompliance(
-  e: WebhookConfiguration,
-  endpointToAddrsMap: Map<string, Set<string>>,
-  swapper: string
-) {
-  return endpointToAddrsMap.get(e.endpoint) === undefined || !endpointToAddrsMap.get(e.endpoint)?.has(swapper);
 }

--- a/test/providers/compliance/s3.test.ts
+++ b/test/providers/compliance/s3.test.ts
@@ -1,138 +1,127 @@
-import { S3Client } from '@aws-sdk/client-s3';
-import axios from 'axios';
 import { default as Logger } from 'bunyan';
 
+import { FillerComplianceConfiguration } from '../../../lib/providers/compliance';
 import {
-  FillerComplianceConfiguration,
+  COMPLIANCE_REFRESH_INTERVAL_MS,
+  ComplianceS3Client,
   S3FillerComplianceConfigurationProvider,
-} from '../../../lib/providers/compliance';
-import { COMPLIANCE_LIST_TIMEOUT_MS } from '../../../lib/providers/compliance/s3';
+} from '../../../lib/providers/compliance/s3';
 
-const mockConfigs = [
-  {
-    endpoints: ['https://google.com'],
-    addresses: ['0x1234'],
-  },
-  {
-    endpoints: ['https://meta.com'],
-    addresses: ['0x1234', '0x5678'],
-  },
-  {
-    endpoints: ['https://x.com'],
-    addresses: ['0x7890'],
-    complianceListUrl: 'https://example.com/compliance-list.json',
-  },
-];
+type SendResult = Awaited<ReturnType<ComplianceS3Client['send']>>;
 
-const mockComplianceList = {
-  addresses: ['0x2345', '0x6789'],
-};
+// Each send() runs the next queued outcome; an unqueued send() throws instead of hanging.
+class FakeS3Client implements ComplianceS3Client {
+  public sendCount = 0;
+  constructor(private readonly outcomes: (() => Promise<SendResult>)[]) {}
 
-function applyMock(configs: FillerComplianceConfiguration[]) {
-  jest.spyOn(S3Client.prototype, 'send').mockImplementationOnce(() =>
-    Promise.resolve({
-      Body: {
-        transformToString: () => Promise.resolve(JSON.stringify(configs)),
-      },
-    })
-  );
+  send(): Promise<SendResult> {
+    const next = this.outcomes[this.sendCount++];
+    if (!next) throw new Error(`unexpected S3 fetch #${this.sendCount}`);
+    return next();
+  }
 }
 
-// silent logger in tests
+const ok = (configs: FillerComplianceConfiguration[]) => () =>
+  Promise.resolve({ Body: { transformToString: () => Promise.resolve(JSON.stringify(configs)) } });
+const fail = () => Promise.reject(new Error('TimeoutError'));
+// Drains pending microtasks so a background refresh can land.
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const ENDPOINT = 'https://filler.example/rfq';
+const SWAPPER = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const OTHER = '0x0000000000000000000000000000000000000001';
+const configs = [{ endpoints: [ENDPOINT], addresses: [SWAPPER] }];
+
 const logger = Logger.createLogger({ name: 'test' });
 logger.level(Logger.FATAL);
 
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+describe('S3FillerComplianceConfigurationProvider', () => {
+  const START = 1_700_000_000_000;
+  let now: number;
 
-describe('S3ComplianceConfigurationProvider', () => {
-  const bucket = 'test-bucket';
-  const key = 'test-key';
+  beforeEach(() => {
+    now = START;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  const makeProvider = (s3: FakeS3Client) =>
+    new S3FillerComplianceConfigurationProvider(logger, 'test-bucket', 'test-key', s3);
+
+  it('treats an empty config as loaded and does not refetch it per request', async () => {
+    const s3 = new FakeS3Client([ok([])]);
+    const provider = makeProvider(s3);
+    for (let i = 0; i < 5; i++) {
+      await provider.ensureLoaded();
+      expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(false);
+    }
+    expect(s3.sendCount).toBe(1);
   });
 
-  it('fetches configs', async () => {
-    applyMock(mockConfigs);
-    const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
-    const endpoints = await provider.getConfigs();
-    expect(endpoints).toEqual(mockConfigs);
+  it('matches swapper addresses case-insensitively and ignores unknown endpoints', async () => {
+    const provider = makeProvider(new FakeS3Client([ok(configs)]));
+    await provider.ensureLoaded();
+    expect(provider.isExcluded(ENDPOINT, SWAPPER.toLowerCase())).toBe(true);
+    expect(provider.isExcluded(ENDPOINT, SWAPPER.toUpperCase())).toBe(true);
+    expect(provider.isExcluded(ENDPOINT, OTHER)).toBe(false);
+    expect(provider.isExcluded('https://unknown.example', SWAPPER)).toBe(false);
   });
 
-  it('generates endpoint to addrs map', async () => {
-    applyMock(mockConfigs);
-    const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
-    const map = await provider.getEndpointToExcludedAddrsMap();
-    expect(map).toMatchObject(
-      new Map([
-        ['https://google.com', new Set(['0x1234'])],
-        ['https://meta.com', new Set(['0x1234', '0x5678'])],
-        ['https://x.com', new Set(['0x7890'])],
-      ])
-    );
+  it('refreshes in the background once the interval elapses, then swaps the new data in', async () => {
+    let finishRefresh!: (result: SendResult) => void;
+    const pending = new Promise<SendResult>((resolve) => (finishRefresh = resolve));
+    const s3 = new FakeS3Client([ok(configs), () => pending]);
+    const provider = makeProvider(s3);
+    await provider.ensureLoaded();
+
+    now = START + COMPLIANCE_REFRESH_INTERVAL_MS - 1;
+    await provider.ensureLoaded();
+    expect(s3.sendCount).toBe(1);
+
+    now = START + COMPLIANCE_REFRESH_INTERVAL_MS;
+    // Resolves while the fetch is still pending, still serving the old data.
+    await provider.ensureLoaded();
+    expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(true);
+    // Concurrent callers share the single in-flight fetch.
+    await provider.ensureLoaded();
+    expect(s3.sendCount).toBe(2);
+
+    finishRefresh(await ok([{ endpoints: [ENDPOINT], addresses: [OTHER] }])());
+    await flush();
+    expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(false);
+    expect(provider.isExcluded(ENDPOINT, OTHER)).toBe(true);
   });
 
-  it('fetches and merges compliance list addresses', async () => {
-    applyMock(mockConfigs);
-    mockedAxios.get.mockResolvedValueOnce({
-      status: 200,
-      data: mockComplianceList,
-    });
+  it('keeps the last good data when a refresh fails and retries only at the next interval', async () => {
+    const s3 = new FakeS3Client([ok(configs), fail, ok([])]);
+    const provider = makeProvider(s3);
+    await provider.ensureLoaded();
 
-    const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
-    const map = await provider.getEndpointToExcludedAddrsMap();
+    now = START + COMPLIANCE_REFRESH_INTERVAL_MS;
+    await provider.ensureLoaded();
+    await flush();
+    await provider.ensureLoaded();
+    expect(s3.sendCount).toBe(2);
+    expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(true);
 
-    expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/compliance-list.json', {
-      timeout: COMPLIANCE_LIST_TIMEOUT_MS,
-    });
-    expect(map).toMatchObject(
-      new Map([
-        ['https://google.com', new Set(['0x1234'])],
-        ['https://meta.com', new Set(['0x1234', '0x5678'])],
-        ['https://x.com', new Set(['0x7890', '0x2345', '0x6789'])],
-      ])
-    );
+    now = START + 2 * COMPLIANCE_REFRESH_INTERVAL_MS;
+    await provider.ensureLoaded();
+    await flush();
+    expect(s3.sendCount).toBe(3);
+    expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(false);
   });
 
-  it('keeps serving the cached configs when the S3 refresh fails', async () => {
-    applyMock(mockConfigs);
-    // one rejection per refresh: the initial build and the post-failure rebuild
-    mockedAxios.get.mockRejectedValueOnce(new Error('Network error')).mockRejectedValueOnce(new Error('Network error'));
-    const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
-    const before = await provider.getEndpointToExcludedAddrsMap();
-    expect(before.size).toBe(3);
+  it('fails open on a failed first load and retries only at the next interval', async () => {
+    const s3 = new FakeS3Client([fail, ok(configs)]);
+    const provider = makeProvider(s3);
+    await provider.ensureLoaded();
+    await provider.ensureLoaded();
+    expect(s3.sendCount).toBe(1);
+    expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(false);
 
-    jest.useFakeTimers().setSystemTime(Date.now() + 10 * 60 * 1000);
-    jest.spyOn(S3Client.prototype, 'send').mockImplementationOnce(() => Promise.reject(new Error('TimeoutError')));
-    const after = await provider.getEndpointToExcludedAddrsMap();
-    jest.useRealTimers();
-
-    expect(after).toMatchObject(
-      new Map([
-        ['https://google.com', new Set(['0x1234'])],
-        ['https://meta.com', new Set(['0x1234', '0x5678'])],
-        ['https://x.com', new Set(['0x7890'])],
-      ])
-    );
-  });
-
-  it('handles compliance list fetch failure gracefully', async () => {
-    applyMock(mockConfigs);
-    mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
-
-    const provider = new S3FillerComplianceConfigurationProvider(logger, bucket, key);
-    const map = await provider.getEndpointToExcludedAddrsMap();
-
-    expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/compliance-list.json', {
-      timeout: COMPLIANCE_LIST_TIMEOUT_MS,
-    });
-    expect(map).toMatchObject(
-      new Map([
-        ['https://google.com', new Set(['0x1234'])],
-        ['https://meta.com', new Set(['0x1234', '0x5678'])],
-        ['https://x.com', new Set(['0x7890'])],
-      ])
-    );
+    now = START + COMPLIANCE_REFRESH_INTERVAL_MS;
+    await provider.ensureLoaded();
+    await flush();
+    expect(provider.isExcluded(ENDPOINT, SWAPPER)).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

The filler-compliance feature (per-market-maker swapper exclusion lists from S3) stays, but the provider behind it had three problems on the quote hot path:

1. **Every prod quote did an S3 GetObject.** `configs.length === 0` was used as "never loaded"; prod's config is an empty `[]`, so nothing was ever considered loaded (~95k GetObjects/hour fleet-wide).
2. **Refreshes were `await`ed inside the request.** A slow refresh stalled the quote. The 2026-07 incident (dead upstream, ~15s stalls) came from exactly this shape.
3. **A dead sub-feature, `complianceListUrl`**: a per-config HTTP fetch of extra addresses from a market-maker-hosted URL. No fetch of it ever observably succeeded, it caused the July incident, and no config uses it.

## What changed

- **Loaded-ness is tracked explicitly.** An empty config is a loaded config.
- **Stale-while-revalidate.** The first call per container awaits one bounded S3 fetch (the shared bounded client from `lib/util/config-s3-client.ts`). After that, a request that notices the 5-minute interval has elapsed kicks off a single-flight background refresh and returns the current data immediately; the new index swaps in atomically when the fetch completes. The fetch deliberately stays on the request path rather than container init (Dec-2024 S3 clock-skew issue).
- **Fail-open preserved.** A failed first load serves an empty exclusion set; a failed refresh keeps the last good data. Either way the next attempt waits for the interval, so there is no retry storm.
- **Precomputed lookup.** The endpoint → excluded-swapper index is built once at load time, not per request.
- **`complianceListUrl` deleted entirely**: the field, `FillerComplianceList`, the axios call, and `COMPLIANCE_LIST_TIMEOUT_MS`.
- **Interface reduced** to `ensureLoaded(): Promise<void>` + `isExcluded(endpoint, swapper): boolean`. `getConfigs()` and `getEndpointToExcludedAddrsMap()` are gone; `passFillerCompliance()` in `WebhookQuoter` collapses into `isExcluded`. `isExcluded` is synchronous by design so it cannot add latency; `ensureLoaded` exists only because the first-use fetch has to be awaited somewhere, and it resolves immediately on every call after that.
- **Mock** updated to the new interface. Hard-quote still injects `new MockFillerComplianceConfigurationProvider([])` deliberately.
- **`RFQ_PHASE_COMPLIANCE` emission in `WebhookQuoter` is unchanged**; it now times only `ensureLoaded()`.

### The one deliberate behavior change: case-insensitive address matching

Addresses are lowercased on both sides of the comparison (config entries at index-build time, the request swapper at lookup time). Previously this was an exact string match, which silently failed to exclude a swapper whenever the config's checksum casing differed from the request's. Endpoint matching is unchanged (exact URL).

### Line counts

| File | Before | After |
|---|---|---|
| `lib/providers/compliance/s3.ts` | 105 | 69 |
| `lib/providers/compliance/index.ts` | 16 | 34 |
| `lib/providers/compliance/mock.ts` | 24 | 22 |
| **Provider total** | **145** | **125** |
| `test/providers/compliance/s3.test.ts` | 138 | 127 |
| `lib/quoters/WebhookQuoter.ts` | 489 | 481 |

`index.ts` grows because the shared endpoint → excluded-swapper index builder and lookup (used by both the S3 and mock providers) live there next to the interface. Runtime dependencies of the provider: axios removed.

## Tests

`test/providers/compliance/s3.test.ts` is rewritten around an injected hand-written fake S3 client (optional constructor parameter, defaults to the shared bounded client). No `jest.mock()`, no `S3Client.prototype` patching. Covers:

- empty config does **not** trigger a refetch per request
- no refresh before the interval; interval-elapsed refresh does not block the caller; new data swaps in afterward; concurrent callers share one in-flight fetch
- failed refresh keeps the last good data and retries only at the next interval
- failed first load fails open and retries only at the next interval
- case-insensitive matching in both directions; unknown endpoint → not excluded

## Verification

- `yarn build && yarn test:unit && yarn lint`: 36 suites / 347 tests / 38 snapshots pass; `.snap` files untouched; 0 lint errors, and the repo-wide warning count drops 87 → 85 (the two removed `catch (e: any)`).
- `cdk synth` vs `main` (both sides from clean installs, identical converged `cdk.context.json`, synthesized twice each, compared before committing): 13 of 19 templates byte-identical, including every nested stack. The 6 that differ change **only** the Quote and HardQuote Lambda asset hashes and the resulting `AWS::Lambda::Version` logical IDs / alias references (the two bundles that contain this code). Zero resource additions, removals, or type changes.

## What to watch after deploy

1. **`RFQ_PHASE_COMPLIANCE` p99 → ~0 ms.** It now measures only `ensureLoaded()`, which awaits I/O once per container lifetime. Anything above a few ms outside cold starts means the refresh is somehow back on the request path.
2. **The compliance provider's `Fetched configs` log line** (`quoter: S3FillerComplianceConfigurationProvider`) should fall from once per quote request to once per 5 minutes per container. Its `configsLength` payload is unchanged.

## Out of scope (left as-is per the change boundary; worth a follow-up)

- `lib/handlers/hard-quote/injector.ts` comment still mentions `passFillerCompliance()` and "the outbound compliance-list fetch", both now gone.
- `lib/util/config-s3-client.ts` comment says the compliance provider refreshes "inline on the quote path"; it is now background after first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
