### PR TITLE
chore: remove unused API Gateway keys/usage plan and the retired Unimind analytics path

### DIFF
--- a/bin/stacks/analytics-stack.ts
+++ b/bin/stacks/analytics-stack.ts
@@ -73,8 +73,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     const botOrderLoaderBucket = new aws_s3.Bucket(this, 'BotOrderLoaderBucket');
     const botOrderRouterBucket = new aws_s3.Bucket(this, 'BotOrderRouterBucket');
     const botOrderBroadcasterBucket = new aws_s3.Bucket(this, 'BotOrderBroadcasterBucket');
-    const unimindResponseBucket = new aws_s3.Bucket(this, 'UnimindResponseBucket');
-    const unimindParameterUpdateBucket = new aws_s3.Bucket(this, 'UnimindParameterUpdateBucket');
 
     const dsRole = aws_iam.Role.fromRoleArn(this, 'DsRole', 'arn:aws:iam::867401673276:user/bq-load-sa');
     rfqRequestBucket.grantRead(dsRole);
@@ -88,8 +86,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     botOrderLoaderBucket.grantRead(dsRole);
     botOrderRouterBucket.grantRead(dsRole);
     botOrderBroadcasterBucket.grantRead(dsRole);
-    unimindResponseBucket.grantRead(dsRole);
-    unimindParameterUpdateBucket.grantRead(dsRole);
 
     /* Redshift Initialization */
     const rsRole = new aws_iam.Role(this, 'RedshiftRole', {
@@ -304,8 +300,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     botOrderLoaderBucket.grantReadWrite(firehoseRole);
     botOrderRouterBucket.grantReadWrite(firehoseRole);
     botOrderBroadcasterBucket.grantReadWrite(firehoseRole);
-    unimindResponseBucket.grantReadWrite(firehoseRole);
-    unimindParameterUpdateBucket.grantReadWrite(firehoseRole);
 
     const quoteProcessorLambda = new aws_lambda_nodejs.NodejsFunction(this, 'QuoteRequestProcessor', {
       runtime: aws_lambda.Runtime.NODEJS_20_X,
@@ -355,42 +349,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       },
     });
 
-    const unimindResponseProcessorLambda = new aws_lambda_nodejs.NodejsFunction(this, 'UnimindResponseProcessor', {
-      runtime: aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/handlers/index.ts'),
-      handler: 'unimindResponseProcessor',
-      timeout: cdk.Duration.seconds(60),
-      memorySize: 512,
-      bundling: LAMBDA_BUNDLING,
-      environment: {
-        VERSION: '2',
-        NODE_OPTIONS: '--enable-source-maps',
-        ANALYTICS_STREAM_ARN: analyticsStreamArn,
-        ...props.envVars,
-        stage,
-      },
-    });
-
-    const unimindParameterUpdateProcessorLambda = new aws_lambda_nodejs.NodejsFunction(
-      this,
-      'UnimindParameterUpdateProcessor',
-      {
-        runtime: aws_lambda.Runtime.NODEJS_18_X,
-        entry: path.join(__dirname, '../../lib/handlers/index.ts'),
-        handler: 'unimindParameterUpdateProcessor',
-        timeout: cdk.Duration.seconds(60),
-        memorySize: 512,
-        bundling: LAMBDA_BUNDLING,
-        environment: {
-          VERSION: '2',
-          NODE_OPTIONS: '--enable-source-maps',
-          ANALYTICS_STREAM_ARN: analyticsStreamArn,
-          ...props.envVars,
-          stage,
-        },
-      }
-    );
-
     firehoseRole.addToPolicy(
       new aws_iam.PolicyStatement({
         effect: aws_iam.Effect.ALLOW,
@@ -399,8 +357,6 @@ export class AnalyticsStack extends cdk.NestedStack {
           quoteProcessorLambda.functionArn,
           fillEventProcessorLambda.functionArn,
           postOrderProcessorLambda.functionArn,
-          unimindResponseProcessorLambda.functionArn,
-          unimindParameterUpdateProcessorLambda.functionArn,
         ],
       })
     );
@@ -410,13 +366,7 @@ export class AnalyticsStack extends cdk.NestedStack {
     }
 
     /* log processor alarms */
-    [
-      quoteProcessorLambda,
-      fillEventProcessorLambda,
-      postOrderProcessorLambda,
-      unimindResponseProcessorLambda,
-      unimindParameterUpdateProcessorLambda,
-    ].forEach((lambda) => {
+    [quoteProcessorLambda, fillEventProcessorLambda, postOrderProcessorLambda].forEach((lambda) => {
       const successRateSev2Name = `${lambda.node.id}-SEV2-SuccessRate`;
       const successRateSev3Name = `${lambda.node.id}-SEV3-SuccessRate`;
 
@@ -663,53 +613,8 @@ export class AnalyticsStack extends cdk.NestedStack {
       },
     });
 
-    // S3-only streams for Unimind events (no Redshift needed)
-    const unimindResponseStream = new aws_firehose.CfnDeliveryStream(this, 'UnimindResponseStream', {
-      extendedS3DestinationConfiguration: {
-        bucketArn: unimindResponseBucket.bucketArn,
-        roleArn: firehoseRole.roleArn,
-        compressionFormat: 'UNCOMPRESSED',
-        processingConfiguration: {
-          enabled: true,
-          processors: [
-            {
-              type: 'Lambda',
-              parameters: [
-                {
-                  parameterName: 'LambdaArn',
-                  parameterValue: unimindResponseProcessorLambda.functionArn,
-                },
-              ],
-            },
-          ],
-        },
-      },
-    });
-
-    const unimindParameterUpdateStream = new aws_firehose.CfnDeliveryStream(this, 'UnimindParameterUpdateStream', {
-      extendedS3DestinationConfiguration: {
-        bucketArn: unimindParameterUpdateBucket.bucketArn,
-        roleArn: firehoseRole.roleArn,
-        compressionFormat: 'UNCOMPRESSED',
-        processingConfiguration: {
-          enabled: true,
-          processors: [
-            {
-              type: 'Lambda',
-              parameters: [
-                {
-                  parameterName: 'LambdaArn',
-                  parameterValue: unimindParameterUpdateProcessorLambda.functionArn,
-                },
-              ],
-            },
-          ],
-        },
-      },
-    });
-
     /* Firehose Alarms */
-    // hasRedshift gates the DeliveryToRedshift alarms: the S3-only streams never emit that
+    // hasRedshift gates the DeliveryToRedshift alarms: an S3-only stream never emits that
     // metric, and with treatMissingData NOT_BREACHING an alarm on it can never leave OK.
     const allStreams = [
       { stream: rfqRequestFirehoseStream, hasRedshift: true },
@@ -718,8 +623,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       { stream: rfqResponseFirehoseStream, hasRedshift: true },
       { stream: fillStream, hasRedshift: true },
       { stream: orderStream, hasRedshift: true },
-      { stream: unimindResponseStream, hasRedshift: false },
-      { stream: unimindParameterUpdateStream, hasRedshift: false },
     ];
 
     allStreams.forEach(({ stream, hasRedshift }) => {
@@ -842,18 +745,6 @@ export class AnalyticsStack extends cdk.NestedStack {
       destinationName: 'postedOrderDestination',
     });
 
-    const unimindResponseDestination = new aws_logs.CfnDestination(this, 'UnimindResponseDestination', {
-      roleArn: subscriptionRole.roleArn,
-      targetArn: unimindResponseStream.attrArn,
-      destinationName: 'unimindResponseDestination',
-    });
-
-    const unimindParameterUpdateDestination = new aws_logs.CfnDestination(this, 'UnimindParameterUpdateDestination', {
-      roleArn: subscriptionRole.roleArn,
-      targetArn: unimindParameterUpdateStream.attrArn,
-      destinationName: 'unimindParameterUpdateDestination',
-    });
-
     // hack to get around with CDK bug where `new aws_iam.PolicyDocument({...}).string()` doesn't really turn it into a string
     // enclosed in if statement to allow deploying stack w/o having to set up x-account logging
     if (props.envVars['FILL_LOG_SENDER_ACCOUNT']) {
@@ -882,38 +773,6 @@ export class AnalyticsStack extends cdk.NestedStack {
             Effect: 'Allow',
             Principal: {
               AWS: props.envVars['FILL_LOG_SENDER_ACCOUNT'],
-            },
-            Action: 'logs:PutSubscriptionFilter',
-            Resource: '*',
-          },
-        ],
-      });
-    }
-
-    // Use ORDER_LOG_SENDER_ACCOUNT since uniswapx-service is in the same account as order-service
-    if (props.envVars['ORDER_LOG_SENDER_ACCOUNT']) {
-      unimindResponseDestination.destinationPolicy = JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Sid: '',
-            Effect: 'Allow',
-            Principal: {
-              AWS: props.envVars['ORDER_LOG_SENDER_ACCOUNT'],
-            },
-            Action: 'logs:PutSubscriptionFilter',
-            Resource: '*',
-          },
-        ],
-      });
-      unimindParameterUpdateDestination.destinationPolicy = JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Sid: '',
-            Effect: 'Allow',
-            Principal: {
-              AWS: props.envVars['ORDER_LOG_SENDER_ACCOUNT'],
             },
             Action: 'logs:PutSubscriptionFilter',
             Resource: '*',
@@ -957,12 +816,6 @@ export class AnalyticsStack extends cdk.NestedStack {
     });
     new CfnOutput(this, 'postedOrderDestinationName', {
       value: postedOrderDestination.attrArn,
-    });
-    new CfnOutput(this, 'unimindResponseDestinationName', {
-      value: unimindResponseDestination.attrArn,
-    });
-    new CfnOutput(this, 'unimindParameterUpdateDestinationName', {
-      value: unimindParameterUpdateDestination.attrArn,
     });
     new CfnOutput(this, 'BOT_ACCOUNT', {
       value: props.envVars['BOT_ACCOUNT'],

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -346,28 +346,11 @@ export class APIStack extends cdk.Stack {
     });
 
     hardQuote.addMethod('POST', hardQuoteLambdaIntegration, {
-      apiKeyRequired: false, // TODO: Set to true once Trading API has integrated
-    });
-
-    /* add auth keys */
-    // No method currently sets apiKeyRequired; these exist for the hard-quote
-    // gating TODO above. Unrelated to the WAF's `x-api-key` byte-match, which
-    // matches a hand-managed Secrets Manager value, not an API Gateway key.
-    const tradingAPIKey = api.addApiKey('TradingAPIKey', {
-      apiKeyName: 'tradingAPIKey',
-      description: 'API Key for trading endpoints',
-    });
-    const devAPIKey = api.addApiKey('DevAPIKey', {
-      apiKeyName: 'devAPIKey',
-      description: 'API Key for development use',
-    });
-    const plan = api.addUsagePlan('AccessPlan', {
-      name: 'AccessPlan',
-    });
-    plan.addApiKey(tradingAPIKey);
-    plan.addApiKey(devAPIKey);
-    plan.addApiStage({
-      stage: api.deploymentStage,
+      // Explicitly the default: no API Gateway key gating on any method. Request
+      // gating is the entry gateway's job after the monorepo migration. Unrelated
+      // to the WAF's `x-api-key` byte-match above, which matches a hand-managed
+      // Secrets Manager value, not an API Gateway key.
+      apiKeyRequired: false,
     });
 
     /*

--- a/lib/handlers/blueprints/cw-log-firehose-processor.js
+++ b/lib/handlers/blueprints/cw-log-firehose-processor.js
@@ -227,5 +227,3 @@ const handler = async function (event, context, transformFn) {
 export const quoteProcessor = async (event, context) => handler(event, context, transformLogEvent);
 export const fillEventProcessor = async (event, context) => handler(event, context, transformFillLogEvent);
 export const postOrderProcessor = async (event, context) => handler(event, context, transformPostOrderLogEvent);
-export const unimindResponseProcessor = async (event, context) => handler(event, context, transformLogEvent);
-export const unimindParameterUpdateProcessor = async (event, context) => handler(event, context, transformLogEvent);

--- a/lib/handlers/index.ts
+++ b/lib/handlers/index.ts
@@ -1,15 +1,7 @@
-import {
-  fillEventProcessor,
-  postOrderProcessor,
-  quoteProcessor,
-  unimindParameterUpdateProcessor,
-  unimindResponseProcessor,
-} from './blueprints/cw-log-firehose-processor';
+import { fillEventProcessor, postOrderProcessor, quoteProcessor } from './blueprints/cw-log-firehose-processor';
 
 module.exports = {
   fillEventProcessor: fillEventProcessor,
   postOrderProcessor: postOrderProcessor,
   quoteProcessor: quoteProcessor,
-  unimindResponseProcessor: unimindResponseProcessor,
-  unimindParameterUpdateProcessor: unimindParameterUpdateProcessor,
 };


### PR DESCRIPTION
Two infra removals, one commit each. CDK and handler-export changes only; no quote-path files touched; contract snapshot tests pass unmodified.

## 1. API Gateway API keys and usage plan (`bin/stacks/api-stack.ts`)

Removes `tradingAPIKey`, `devAPIKey`, the `AccessPlan` usage plan and its two key associations. No method sets `apiKeyRequired`, so API Gateway never evaluated these keys; they gated nothing. Request gating becomes the entry gateway's job after the monorepo migration.

Deliberately untouched: the WAF `x-api-key` byte-match (it compares against a hand-managed Secrets Manager value, not an API Gateway key), the hard-quote method itself (`apiKeyRequired: false` stays so the method's template is byte-identical), and the CORS `Access-Control-Allow-Headers` string in `api-handler.ts`, which is part of the frozen response contract.

## 2. Unimind analytics path (`bin/stacks/analytics-stack.ts`, `lib/handlers/`)

Unimind is retired and the senders in uniswapx-service are being removed separately, so nothing is preserved for them. Removed per stage:

| Removed | Resources |
|---|---|
| Firehose delivery streams | `UnimindResponseStream`, `UnimindParameterUpdateStream` |
| Processor Lambdas + service roles | `UnimindResponseProcessor`, `UnimindParameterUpdateProcessor` — the last two functions on the deprecated **nodejs18.x** runtime; no `NODEJS_18_X` reference remains in the repo |
| CloudWatch Logs destinations + cross-account `logs:PutSubscriptionFilter` policies | `UnimindResponseDestination`, `UnimindParameterUpdateDestination` |
| Alarms (10) | 2× SuccessRate per Lambda, MissingRecords + SEV2/SEV3 S3Delivery per stream |
| Grants | FirehoseRole read/write on both buckets, `lambda:InvokeFunction` on both processors, bq-load read (bucket policies) |
| Outputs | `unimindResponseDestinationName`, `unimindParameterUpdateDestinationName` |
| Handler exports | `unimindResponseProcessor`, `unimindParameterUpdateProcessor` in `lib/handlers/index.ts` and the Firehose processor blueprint |

Following the active-orders precedent in d7555e2 (#489), the two S3 buckets keep their `Retain` deletion policy: dropping the constructs **orphans** the buckets, it does not delete data.

## Verification

- `yarn build` ✅, `yarn lint` ✅ (0 errors, pre-existing warnings only), `yarn test:unit` ✅ 36 suites / 347 tests / 38 snapshots, snapshot files untouched (`git diff origin/main -- test/` is empty).
- Clean worktree, clean `yarn install --frozen-lockfile`, identical converged `cdk.context.json` on both sides, `cdk synth` run twice per side (both sides byte-stable across runs), then a semantic per-template diff of all 19 templates against `origin/main` (2d41fb3).

### Synth diff summary

Removed resources, per template (identical in the local stack and the beta/prod pipeline assemblies):

| Template | Before → after | Removed |
|---|---|---|
| API stack (×3) | 88→83 / 91→86 / 91→86 | 2× `AWS::ApiGateway::ApiKey`, 1× `UsagePlan`, 2× `UsagePlanKey` |
| Analytics nested stack (×3) | 160→138 | 2× `S3::Bucket`, 2× `S3::BucketPolicy`, 2× `Lambda::Function`, 2× `IAM::Role`, 2× `KinesisFirehose::DeliveryStream`, 2× `Logs::Destination`, 10× `CloudWatch::Alarm`, 2 outputs |
| Cron, Firehose, HardQuoteCosignerKey nested stacks (×3 each) | — | **byte-identical** |

Nothing added. Every modified (not removed) resource is a direct consequence of the removals:

- `FirehoseRoleDefaultPolicy`: 12→10 statements. The two Unimind bucket read/write statements are gone, and the `lambda:InvokeFunction` statement's resource list drops the two processor ARNs. Nothing else changed.
- `QuoteRequestProcessor`, `FillLogProcessor`, `postedOrderProcessor`: `Code.S3Key` moves `c7d5791b…` → `450ae637…`. These share the `lib/handlers/index.ts` bundle with the removed processors. Source-map comparison: all 565 bundled sources identical by path, content differs in exactly two (`lib/handlers/index.ts`, `cw-log-firehose-processor.js`), bundle 119 bytes smaller, no `unimind` string remains. The quote / hard-quote / cron bundles are unchanged (no asset present only in the baseline).
- Nested-stack `TemplateURL` hashes (Analytics, ParamDashboard) and the pipeline's 5 `FileAsset` CodeBuild buildspecs: asset-hash substitutions only.
- `CDKMetadata/Analytics`: construct census shrinks.
- `UniswapXParamDashboard` body: same length; the only replacements are the git-derived deploy-marker window rolling forward by this branch's two commits (oldest two markers fall off). Synth-time git state, not a code change.

`cdk deploy` was **not** run.

## Follow-ups (manual, after merge)

Orphaned buckets to delete once nobody wants the data. Object counts as of 2026-09-03:

| Stage | Bucket | Objects |
|---|---|---|
| prod | `prod-us-east-2-goudaparam-unimindresponsebucket861-mkgwaz4duyti` | 66,283 (≈35.7 GB) |
| prod | `prod-us-east-2-goudaparam-unimindparameterupdatebu-0jfywcadrstn` | 692 (≈0.6 MB) |
| beta | `beta-us-east-2-goudaparam-unimindresponsebucket861-m9q2ycijfxl5` | 380 (≈1 MB) |
| beta | `beta-us-east-2-goudaparam-unimindparameterupdatebu-ppyi3kclq1a0` | 0 |

Note the prod response bucket holds real data (35.7 GB); confirm with the data team before deleting. The sender-side subscription filters in uniswapx-service (targeting `unimindResponseDestination` / `unimindParameterUpdateDestination`) are being removed in that repo; until then they point at deleted destinations, which is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
