### PR TITLE
fix: don't let a failed filler-address write 5xx a quote; skip reads for capped fillers

### DIFF
--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -71,6 +71,10 @@ export enum Metric {
   RFQ_COUNT_2 = 'RFQ_COUNT_2',
   RFQ_COUNT_3 = 'RFQ_COUNT_3',
   RFQ_COUNT_4_PLUS = 'RFQ_COUNT_4_PLUS',
+  // The fire-and-forget FillerAddress write after a successful quote rejected (e.g. a throttled
+  // DynamoDB read). The quote itself is unaffected; a sustained non-zero rate means fills from
+  // new filler addresses are going unattributed to the fade-rate breaker.
+  RFQ_FILLER_ADDRESS_RECORD_FAILED = 'RFQ_FILLER_ADDRESS_RECORD_FAILED',
 
   // Latency-attribution metrics.
   // Time spent resolving webhook config + circuit-breaker state before fan-out.

--- a/lib/quoters/WebhookQuoter.ts
+++ b/lib/quoters/WebhookQuoter.ts
@@ -344,9 +344,18 @@ export class WebhookQuoter implements Quoter {
         })
       );
 
-      // do not await to minimize latency
+      // Fire-and-forget to keep latency down. Attribution is best-effort: a rejection here (a
+      // throttled FillerAddress read took /quote to 5xx on 2026-09-07) must never fail a quote
+      // that has already been obtained, so it is caught and counted rather than left as an
+      // unhandled rejection for the Lambda runtime to turn into an invocation error.
       if (response.filler) {
-        this.repository.addNewAddressToFiller(response.filler, endpoint);
+        this.repository.addNewAddressToFiller(response.filler, endpoint).catch((err) => {
+          metric.putMetric(Metric.RFQ_FILLER_ADDRESS_RECORD_FAILED, 1, MetricLoggerUnit.Count);
+          log.warn(
+            { err, filler: response.filler, endpoint },
+            'failed to record filler address; quote unaffected, attribution skipped'
+          );
+        });
       }
       //if valid quote, log the opposing side as well
       const opposingRequest = request.toOpposingRequest();

--- a/lib/repositories/filler-address-repository.ts
+++ b/lib/repositories/filler-address-repository.ts
@@ -11,8 +11,10 @@ export type DynamoFillerToAddressRow = {
 };
 
 // Max distinct on-chain addresses a single filler (webhook endpoint) may register, bounding
-// Sybil breadth. Registrations beyond the cap are a safe no-op — the order still quotes and
-// fills, the address just isn't attributed — so this can't break quoting.
+// Sybil breadth. Registrations beyond the cap are a no-op — the order still quotes and fills,
+// the address just isn't attributed. Note the no-op is not free: without the capped-filler
+// cache below, every over-cap attempt costs two DynamoDB reads (address miss + owner's list),
+// and a filler rotating addresses per quote turned that into read throttling on 2026-09-07.
 export const MAX_FILLER_ADDRESSES = 3;
 
 export interface FillerAddressRepository {
@@ -63,6 +65,13 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
 
     return new DynamoFillerAddressRepository(addressTable, fillerToAddressEntity, addressToFillerEntity);
   }
+  // Fillers known to be at MAX_FILLER_ADDRESSES. A capped filler's registrations are no-ops, so
+  // there is nothing to read; skipping the lookups is what keeps a per-quote address rotator
+  // from costing two GetItems per quote forever. Per container, cleared on cold start. This code
+  // path never removes addresses, so an entry can only go stale via a manual table edit, which
+  // a container recycle picks up.
+  private readonly _cappedFillers = new Set<string>();
+
   private constructor(
     private readonly _addressTable: Table<'FillerAddress', 'pk', null>,
     private readonly _fillerToAddressEntity: Entity,
@@ -83,6 +92,12 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
   }
 
   async addNewAddressToFiller(address: string, filler?: string): Promise<void> {
+    // At cap, every outcome below is a no-op (already ours, someone else's, or over the cap), so
+    // answer from memory and touch nothing.
+    if (filler && this._cappedFillers.has(filler)) {
+      return;
+    }
+
     const addrToAdd = getAddress(address);
     const existingOwner = await this.getFillerByAddress(addrToAdd);
     const owner = filler ?? existingOwner;
@@ -109,6 +124,7 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
     // New address for this owner — enforce the per-filler cap.
     const fillerAddresses = (await this.getFillerAddresses(owner)) ?? [];
     if (fillerAddresses.length >= MAX_FILLER_ADDRESSES) {
+      this._cappedFillers.add(owner);
       DynamoFillerAddressRepository.log.info(
         { filler: owner, address: addrToAdd, count: fillerAddresses.length, max: MAX_FILLER_ADDRESSES },
         'filler address cap reached; ignoring new address'
@@ -121,6 +137,9 @@ export class DynamoFillerAddressRepository implements FillerAddressRepository {
       await this._fillerToAddressEntity.put({ pk: owner, addresses: [addrToAdd] });
     } else {
       await this._fillerToAddressEntity.update({ pk: owner, addresses: { $add: [addrToAdd] } });
+    }
+    if (fillerAddresses.length + 1 >= MAX_FILLER_ADDRESSES) {
+      this._cappedFillers.add(owner);
     }
   }
 

--- a/test/providers/quoters/WebhookQuoter.test.ts
+++ b/test/providers/quoters/WebhookQuoter.test.ts
@@ -65,7 +65,13 @@ describe('WebhookQuoter tests', () => {
     },
   ]);
 
-  const logger = { child: jest.fn(() => logger), info: jest.fn(), error: jest.fn(), debug: jest.fn() } as any;
+  const logger = {
+    child: jest.fn(() => logger),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as any;
   const mockFirehoseLogger = new FirehoseLogger(logger, 'arn:aws:deliverystream/dummy');
   const webhookQuoter = new WebhookQuoter(logger, mockFirehoseLogger, webhookProvider, MOCK_V2_CB_PROVIDER, repository);
 
@@ -273,6 +279,51 @@ describe('WebhookQuoter tests', () => {
       });
     await webhookQuoter.quote(request);
     expect(repository.getFillerAddresses(WEBHOOK_URL)).resolves.toEqual([FILLER]);
+  });
+
+  it('a failed filler-address write does not fail the quote', async () => {
+    // Regression for 2026-09-07: a throttled FillerAddress read rejected the un-awaited
+    // addNewAddressToFiller call, and the unhandled rejection failed the whole Lambda invocation
+    // (5xx on /quote) even though every filler had already answered.
+    const rejectingRepository = {
+      ...new MockFillerAddressRepository(),
+      addNewAddressToFiller: jest.fn().mockRejectedValue(new Error('ProvisionedThroughputExceededException')),
+    } as any;
+    const quoter = new WebhookQuoter(
+      logger,
+      mockFirehoseLogger,
+      webhookProvider,
+      MOCK_V2_CB_PROVIDER,
+      rejectingRepository
+    );
+    const putMetricSpy = jest.spyOn(metric, 'putMetric');
+    mockedAxios.post
+      .mockImplementationOnce((_endpoint, _req, _options) => {
+        return Promise.resolve({
+          data: { ...quote, requestId: (_req as any).requestId },
+        });
+      })
+      .mockImplementationOnce((_endpoint, _req, _options) => {
+        return Promise.resolve({
+          data: {
+            ...quote,
+            tokenIn: request.tokenOut,
+            tokenOut: request.tokenIn,
+          },
+        });
+      });
+
+    const response = await quoter.quote(request);
+    // let the fire-and-forget rejection settle
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(response.length).toEqual(1);
+    expect(rejectingRepository.addNewAddressToFiller).toHaveBeenCalledWith(FILLER, WEBHOOK_URL);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ filler: FILLER, endpoint: WEBHOOK_URL }),
+      expect.stringContaining('failed to record filler address')
+    );
+    expect(putMetricSpy).toHaveBeenCalledWith(Metric.RFQ_FILLER_ADDRESS_RECORD_FAILED, 1, MetricLoggerUnit.Count);
   });
 
   describe('Circuit Breaker v2 tests', () => {

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -134,4 +134,46 @@ describe('filler address repository test', () => {
     // the over-cap address is attributed to no filler
     expect(await repository.getFillerByAddress(addrs[MAX_FILLER_ADDRESSES])).toBeUndefined();
   });
+
+  it('once a filler is at the cap, further registrations make no DynamoDB calls', async () => {
+    // capFiller reached the cap in the previous test (via the write path filling the last slot,
+    // and again via the over-cap read path). Either way the repository must now remember that
+    // and short-circuit: a rotating filler at cap is the 2026-09-07 read-throttle driver.
+    const send = jest.spyOn(documentClient, 'send');
+    try {
+      await repository.addNewAddressToFiller('0x0000000000000000000000000000000000000014', 'capFiller');
+      await repository.addNewAddressToFiller('0x0000000000000000000000000000000000000015', 'capFiller');
+      expect(send).not.toHaveBeenCalled();
+      // and the table is unchanged
+      expect(((await repository.getFillerAddresses('capFiller')) ?? []).length).toEqual(MAX_FILLER_ADDRESSES);
+    } finally {
+      send.mockRestore();
+    }
+  });
+
+  it('a filler below the cap still reads (the cache only covers capped fillers)', async () => {
+    const send = jest.spyOn(documentClient, 'send');
+    try {
+      // filler2 has one address; an idempotent re-add must still consult the table
+      await repository.addNewAddressToFiller(ADDR3, 'filler2');
+      expect(send).toHaveBeenCalled();
+    } finally {
+      send.mockRestore();
+    }
+  });
+
+  it('the cap cache is populated by the write path, not only the over-cap read path', async () => {
+    // register exactly MAX_FILLER_ADDRESSES for a fresh filler; the last write should mark it capped
+    const base = '0x00000000000000000000000000000000000000';
+    for (let i = 0; i < MAX_FILLER_ADDRESSES; i++) {
+      await repository.addNewAddressToFiller(`${base}2${i}`, 'writePathFiller');
+    }
+    const send = jest.spyOn(documentClient, 'send');
+    try {
+      await repository.addNewAddressToFiller(`${base}2${MAX_FILLER_ADDRESSES}`, 'writePathFiller');
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      send.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the `/quote` 5xx incident of 2026-09-07 (SEV2/SEV3-5XX alarms firing from 12:05 UTC, intermittent since). Two changes, one cause:

1. **A failed filler-address write can no longer fail a quote.** `WebhookQuoter` fires `addNewAddressToFiller` without awaiting it. When that rejected (DynamoDB `ProvisionedThroughputExceededException`), the unhandled rejection failed the whole Lambda invocation and API Gateway returned 502, even though every filler had already answered. The call now has a `.catch` that logs at `warn` and emits a new `RFQ_FILLER_ADDRESS_RECORD_FAILED` count metric.
2. **Fillers at the address cap cost zero reads.** `DynamoFillerAddressRepository` keeps a per-container set of fillers known to be at `MAX_FILLER_ADDRESSES`. A registration for a capped filler is a no-op in every branch, so it now returns before touching DynamoDB.

## Why

`FillerAddress` is fixed provisioned at 70 RCU with no autoscaling (`bin/config.ts`). Reads per Quote invocation climbed from 0.58 on Sep 4 to 2.0 on Sep 7 while traffic stayed flat. One filler (`filler.wraxyn.xyz`) returns a fresh address on nearly every quote and is already at the 3-address cap, so each of its quotes cost two GetItems (address miss + owner's list), never wrote, and repeated on the next quote. Its "cap reached" log lines went 242k → 948k per 6h over three days. Consumption had exceeded 70 RCU/s since Sep 5; DynamoDB began enforcing at ~115 RCU/s and about 10% of reads were rejected, each one taking a swapper's quote down with it.

The comment on `MAX_FILLER_ADDRESSES` said over-cap registrations "can't break quoting". With a throttled read on that path they did exactly that; the comment is updated.

## Effect

- Change 1 bounds the blast radius: a DynamoDB problem on this path degrades attribution, not quoting.
- Change 2 removes the load at its source. Well-behaved fillers still cost one read per successful quote (~60 RCU/s today); the rotating filler drops to zero after its first over-cap attempt per container.

## Not in this PR

- No capacity change. If you want headroom while this rolls out, bump `readCapacity` in `bin/config.ts` (a console-only change is reverted by the next CDK deploy). With change 2, steady-state demand should sit under the current 70.
- Nothing about *why* wraxyn rotates addresses. Only its first 3 addresses are attributed, so most of its fills/fades are invisible to the fade-rate breaker. Worth a separate look.

## Test plan

- [x] `test/providers/quoters/WebhookQuoter.test.ts`: new test constructs a quoter with a rejecting repository, asserts the quote still returns, `warn` is logged with filler/endpoint, and the metric is emitted.
- [x] `test/repositories/filler-address-repository.test.ts`: three new tests against DynamoDB Local, spying on `documentClient.send`: a capped filler makes zero calls; a below-cap filler still reads; the cache is populated by the write path (3rd registration), not only by the over-cap read path.
- [x] Full unit suite: 41 suites / 436 tests pass. `tsc --noEmit`, `yarn lint` (prettier + eslint) clean.
- [ ] After deploy: `FillerAddress` `ReadThrottleEvents` → 0, `ConsumedReadCapacityUnits` drops well under 70/s, `RFQ_FILLER_ADDRESS_RECORD_FAILED` stays at 0 once throttling stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
