### PR TITLE
chore: bump FillerAddress table read capacity to 250

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -3,6 +3,6 @@ import { BillingMode } from 'aws-cdk-lib/aws-dynamodb';
 import { TableCapacityConfig } from './stacks/cron-stack';
 
 export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
-  fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 70, writeCapacity: 250 },
+  fillerAddress: { billingMode: BillingMode.PROVISIONED, readCapacity: 250, writeCapacity: 250 },
   timestamps: { billingMode: BillingMode.PROVISIONED, readCapacity: 100, writeCapacity: 10 },
 };


### PR DESCRIPTION
## Summary
- Raise the provisioned read capacity of the prod `FillerAddress` DynamoDB table from 70 to 250 RCU (write capacity is already 250).

## Why
The `FillerAddress` table is fixed at 70 RCU. On 2026-09-07 a burst of filler address rotation pushed reads past that and the table throttled, which surfaced as `/quote` 5xx (the un-awaited `addNewAddressToFiller` turns throttles into 502s). 250 RCU matches the write side and gives headroom for rotation bursts.

## Notes
- Config-only change in `bin/config.ts`; applied via the api-stack table definition on deploy.
- Cost impact: +180 RCU provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)