### PR TITLE
fix: raise MAX_FILLER_ADDRESSES from 3 to 100

### DIFF
--- a/lib/repositories/filler-address-repository.ts
+++ b/lib/repositories/filler-address-repository.ts
@@ -10,10 +10,17 @@ export type DynamoFillerToAddressRow = {
   addresses: string[];
 };
 
-// Max distinct on-chain addresses a single filler (webhook endpoint) may register, bounding
-// Sybil breadth. Registrations beyond the cap are a safe no-op — the order still quotes and
-// fills, the address just isn't attributed — so this can't break quoting.
-export const MAX_FILLER_ADDRESSES = 3;
+// Max distinct on-chain addresses a single filler (webhook endpoint) may register, bounding the
+// size of the per-filler address set item. Registrations beyond the cap are a no-op — the order
+// still quotes and fills, the address just isn't attributed.
+//
+// The no-op is not free: an over-cap address is looked up (miss) and then the owner's set is read
+// on EVERY quote response that carries it, forever, because it can never be registered. With the
+// cap at 3, a filler that legitimately used 4-5 addresses paid two DynamoDB reads per response
+// and read-throttled this table on 2026-09-07 (which, via an un-awaited write in WebhookQuoter,
+// 5xx'd /quote). 100 is far above any real filler's address count (measured 1-5) while still
+// keeping a rotating filler's set item well under the 400KB item limit (~45 bytes per address).
+export const MAX_FILLER_ADDRESSES = 100;
 
 export interface FillerAddressRepository {
   getFillerAddresses(filler: string): Promise<string[] | undefined>;

--- a/test/repositories/filler-address-repository.test.ts
+++ b/test/repositories/filler-address-repository.test.ts
@@ -117,21 +117,31 @@ describe('filler address repository test', () => {
   });
 
   it('caps the number of addresses a single filler can register', async () => {
-    const addrs = [
-      '0x0000000000000000000000000000000000000010',
-      '0x0000000000000000000000000000000000000011',
-      '0x0000000000000000000000000000000000000012',
-      '0x0000000000000000000000000000000000000013',
-    ];
-    expect(addrs.length).toBeGreaterThan(MAX_FILLER_ADDRESSES); // guard: test must exceed the cap
+    // MAX_FILLER_ADDRESSES + 1 distinct addresses, disjoint from the fixtures above
+    const addrs = Array.from({ length: MAX_FILLER_ADDRESSES + 1 }, (_, i) =>
+      getAddress(`0x${(0x1000 + i).toString(16).padStart(40, '0')}`)
+    );
     for (const addr of addrs) {
       await repository.addNewAddressToFiller(addr, 'capFiller');
     }
     // only the first MAX_FILLER_ADDRESSES are registered; the rest are ignored
     const registered = (await repository.getFillerAddresses('capFiller')) ?? [];
     expect(registered.length).toEqual(MAX_FILLER_ADDRESSES);
-    expect(registered).toEqual(addrs.slice(0, MAX_FILLER_ADDRESSES).map((a) => getAddress(a)));
+    expect(new Set(registered)).toEqual(new Set(addrs.slice(0, MAX_FILLER_ADDRESSES)));
     // the over-cap address is attributed to no filler
     expect(await repository.getFillerByAddress(addrs[MAX_FILLER_ADDRESSES])).toBeUndefined();
+  });
+
+  it('a filler with more than 3 addresses (the old cap) is fully attributed', async () => {
+    // Regression for 2026-09-07: real fillers use up to 5 addresses; the ones beyond the old cap
+    // of 3 could never register and cost two reads per quote response forever.
+    const addrs = Array.from({ length: 5 }, (_, i) => getAddress(`0x${(0x2000 + i).toString(16).padStart(40, '0')}`));
+    for (const addr of addrs) {
+      await repository.addNewAddressToFiller(addr, 'fiveAddressFiller');
+    }
+    expect(new Set(await repository.getFillerAddresses('fiveAddressFiller'))).toEqual(new Set(addrs));
+    for (const addr of addrs) {
+      expect(await repository.getFillerByAddress(addr)).toEqual('fiveAddressFiller');
+    }
   });
 });


### PR DESCRIPTION
## Summary

Raise `MAX_FILLER_ADDRESSES` from 3 to 100. One constant, its comment, and the cap test.

## Why

Stopgap for the 2026-09-07 `/quote` 5xx incident, safe to ship immediately while #501 (winner-only attribution, no cap, per-address TTL rows) goes through review.

The `FillerAddress` table was read-throttled because a filler that legitimately uses 4–5 addresses sat against a cap of 3. Every quote response carrying address 4 or 5 hit the cap-reached branch, paid two GetItems (address miss, then the owner's set), and could never be registered, so it repeated on every response, forever. That was roughly half the table's read load. Once those addresses can register, each costs one read and the amplification is gone.

100 is far above any real filler's address count (measured 1–5 across all fillers today) and still keeps the per-filler set item well under the 400 KB DynamoDB item limit (~45 bytes per address).

## What this does not do

- It does not stop a throttled read from failing a quote. The attribution write in `WebhookQuoter` is still un-awaited and un-caught; that is fixed in #501 (and in #498, which #501 supersedes).
- It does not reduce the baseline load of one read per successful quote response. #501 takes `/quote` to zero DynamoDB calls.

## Test plan

- [x] Cap test now registers `MAX_FILLER_ADDRESSES + 1` addresses generated from the constant and asserts exactly `MAX_FILLER_ADDRESSES` land (set comparison, since DynamoDB string sets are unordered).
- [x] New regression test: a filler with 5 addresses is fully attributed.
- [x] `tsc --noEmit`, prettier, eslint clean.
- [ ] After deploy: "filler address cap reached" log lines for the affected filler go to zero and `FillerAddress` `ReadThrottleEvents` stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
