### PR TITLE
fix(fades): paginate PostedOrders index queries; fills without timing carry no verdict

### DIFF
--- a/lib/cron/order-service-fades-source.ts
+++ b/lib/cron/order-service-fades-source.ts
@@ -60,8 +60,8 @@ export type Classification =
   // The order service still says `open` even though the deadline has passed: its status
   // poller has not caught up yet. Leave the row pending and ask again next run.
   | { kind: 'still-open' }
-  // A status we cannot score (unknown status string, a fill without timing, an unknown order
-  // type). Left pending so it is visible as a count; it expires with the row's TTL.
+  // A status we cannot score (unknown status string, unknown order type). Left pending so it is
+  // visible as a count; it expires with the row's TTL.
   | { kind: 'unclassifiable'; reason: string };
 
 /**
@@ -71,6 +71,7 @@ export type Classification =
  *   status              | Dutch_V2                                | Dutch_V3
  *   --------------------|-----------------------------------------|----------------------------------
  *   filled              | faded iff fillTimestamp > decayStartTime| faded iff fillBlock > decayStartBlock
+ *   filled, no timing   | recorded, no verdict (see below)        | recorded, no verdict
  *   expired             | faded                                   | faded
  *   cancelled / insufficient-funds / error | recorded, no verdict (scored by policy flag; the SQL's
  *                       |   `fillTimestamp IS NULL` branch counts these as fades today)
@@ -78,6 +79,12 @@ export type Classification =
  *
  * A fill AT the decay-start block/time is not a fade: the exclusive filler still paid the
  * undecayed price (the SQL's `fillTimeBlocks > 0` / `decayStartTime < fillTimestamp`).
+ *
+ * "Filled, no timing": when the order service fails to process a fill event it still marks the
+ * order `filled`, with `fillBlock: -1`, no fillTimestamp and an empty txHash (check-order-status
+ * catch path). Such a fill is terminal — so it is recorded and stops being re-fetched — but it
+ * carries no verdict: it is neither a fade nor a clean fill and contributes no row, which is
+ * also what the Redshift path sees (no Fill Info log is ever emitted for it).
  */
 export function classifyOutcome(
   record: PostedOrderRecord,
@@ -97,22 +104,25 @@ export function classifyOutcome(
     case ORDER_STATUS.ERROR:
       return { kind: 'resolved', resolution: { ...base, outcome: PostedOrderOutcome.ERROR } };
     case ORDER_STATUS.FILLED: {
-      const timing = { fillBlock: status.fillBlock, fillTimestamp: status.fillTimestamp };
+      if (record.orderType !== OrderType.Dutch_V3 && record.orderType !== OrderType.Dutch_V2) {
+        return { kind: 'unclassifiable', reason: `unknown order type ${record.orderType}` };
+      }
+      const fillBlock = status.fillBlock !== undefined && status.fillBlock >= 0 ? status.fillBlock : undefined;
+      const timing = { ...(fillBlock !== undefined && { fillBlock }), fillTimestamp: status.fillTimestamp };
+      const filled = { ...base, ...timing, outcome: PostedOrderOutcome.FILLED as const };
       if (record.orderType === OrderType.Dutch_V3) {
-        if (status.fillBlock === undefined || record.decayStartBlock === undefined) {
-          return { kind: 'unclassifiable', reason: 'Dutch_V3 fill without fillBlock/decayStartBlock' };
+        if (fillBlock === undefined || record.decayStartBlock === undefined) {
+          return { kind: 'resolved', resolution: filled }; // filled, no verdict
         }
-        const faded = status.fillBlock > record.decayStartBlock ? 1 : 0;
-        return { kind: 'resolved', resolution: { ...base, ...timing, outcome: PostedOrderOutcome.FILLED, faded } };
+        return { kind: 'resolved', resolution: { ...filled, faded: fillBlock > record.decayStartBlock ? 1 : 0 } };
       }
-      if (record.orderType === OrderType.Dutch_V2) {
-        if (status.fillTimestamp === undefined || record.decayStartTime === undefined) {
-          return { kind: 'unclassifiable', reason: 'Dutch_V2 fill without fillTimestamp/decayStartTime' };
-        }
-        const faded = status.fillTimestamp > record.decayStartTime ? 1 : 0;
-        return { kind: 'resolved', resolution: { ...base, ...timing, outcome: PostedOrderOutcome.FILLED, faded } };
+      if (status.fillTimestamp === undefined || record.decayStartTime === undefined) {
+        return { kind: 'resolved', resolution: filled }; // filled, no verdict
       }
-      return { kind: 'unclassifiable', reason: `unknown order type ${record.orderType}` };
+      return {
+        kind: 'resolved',
+        resolution: { ...filled, faded: status.fillTimestamp > record.decayStartTime ? 1 : 0 },
+      };
     }
     default:
       return { kind: 'unclassifiable', reason: `unknown order status ${status.orderStatus}` };
@@ -228,6 +238,9 @@ export type ResolutionSummary = {
   // GPA and the order service disagree about what was posted.
   notFound: number;
   unclassifiable: number;
+  // Terminal `filled` orders the service could not attach timing to (fillBlock -1): recorded,
+  // excluded from scoring. A rising count means the order service's fill processing is failing.
+  fillsWithoutVerdict: number;
   failedWrites: number;
   byOutcome: Partial<Record<PostedOrderOutcome, number>>;
 };
@@ -304,6 +317,7 @@ export class OrderServiceFadesSource implements FadesSource {
       stillOpen: 0,
       notFound: 0,
       unclassifiable: 0,
+      fillsWithoutVerdict: 0,
       failedWrites: 0,
       byOutcome: {},
     };
@@ -366,6 +380,13 @@ export class OrderServiceFadesSource implements FadesSource {
               await postedOrders.recordOutcome(record.orderHash, resolution);
               summary.resolved += 1;
               summary.byOutcome[resolution.outcome] = (summary.byOutcome[resolution.outcome] ?? 0) + 1;
+              if (resolution.outcome === PostedOrderOutcome.FILLED && resolution.faded === undefined) {
+                summary.fillsWithoutVerdict += 1;
+                log.warn(
+                  { orderHash: record.orderHash, status },
+                  'filled order without fill timing; recorded without verdict'
+                );
+              }
             } catch (e) {
               summary.failedWrites += 1;
               log.warn(

--- a/lib/repositories/posted-order-repository.ts
+++ b/lib/repositories/posted-order-repository.ts
@@ -136,10 +136,23 @@ type PostedOrderItem = PostedOrderRecord & {
   ttl: number;
 };
 
+// One page of a dynamodb-toolbox query: items plus a `next` that is present only while DynamoDB
+// reported a LastEvaluatedKey (i.e. the 1MB page or the Limit cut the result short).
+type QueryPage = { Items?: unknown[]; next?: () => Promise<QueryPage> };
+
+export type DynamoPostedOrderRepositoryOptions = {
+  // Items requested per DynamoDB page. Production leaves this unset (DynamoDB's 1MB page);
+  // tests set it small to exercise pagination without writing a megabyte of rows.
+  pageSize?: number;
+};
+
 export class DynamoPostedOrderRepository implements PostedOrderRepository {
   static PARTITION_KEY = 'orderHash';
 
-  static create(documentClient: DynamoDBDocumentClient = postedOrderDocumentClient()): PostedOrderRepository {
+  static create(
+    documentClient: DynamoDBDocumentClient = postedOrderDocumentClient(),
+    options: DynamoPostedOrderRepositoryOptions = {}
+  ): PostedOrderRepository {
     const table = new Table({
       name: DYNAMO_TABLE_NAME.POSTED_ORDERS,
       partitionKey: DynamoPostedOrderRepository.PARTITION_KEY,
@@ -180,10 +193,38 @@ export class DynamoPostedOrderRepository implements PostedOrderRepository {
       autoExecute: true,
     } as const);
 
-    return new DynamoPostedOrderRepository(entity);
+    return new DynamoPostedOrderRepository(entity, options.pageSize);
   }
 
-  private constructor(private readonly entity: Entity) {}
+  private constructor(private readonly entity: Entity, private readonly pageSize?: number) {}
+
+  /**
+   * Drains every page of an index query. A single DynamoDB page is at most 1MB (~1,600 of these
+   * rows), and a high-volume filler completes more than that in 24h — an unpaginated read would
+   * silently drop its most recent orders (deadline-ascending index), exactly the ones the
+   * breaker scores. `max` caps the total; DynamoDB's Limit alone cannot, because a Limit page can
+   * still be cut short by the size cap.
+   */
+  private async queryAll(
+    partitionKey: string,
+    options: Record<string, unknown>,
+    max?: number
+  ): Promise<PostedOrderItem[]> {
+    const pageLimit = this.pageSize ?? max;
+    const items: PostedOrderItem[] = [];
+    let page = (await this.entity.query(partitionKey, {
+      ...options,
+      ...(pageLimit !== undefined && { limit: pageLimit }),
+      execute: true,
+      parse: true,
+    })) as QueryPage;
+    for (;;) {
+      items.push(...((page.Items ?? []) as PostedOrderItem[]));
+      if (max !== undefined && items.length >= max) return items.slice(0, max);
+      if (!page.next) return items;
+      page = await page.next();
+    }
+  }
 
   public async putPostedOrder(record: PostedOrderRecord): Promise<void> {
     const item: PostedOrderItem = {
@@ -200,24 +241,17 @@ export class DynamoPostedOrderRepository implements PostedOrderRepository {
   }
 
   public async getPendingPastDeadline(now: number, limit?: number): Promise<PostedOrderRecord[]> {
-    const { Items } = await this.entity.query(PENDING_INDEX_KEY, {
-      index: POSTED_ORDERS_INDEX.PENDING_DEADLINE,
-      lt: now,
-      ...(limit !== undefined && { limit }),
-      execute: true,
-      parse: true,
-    });
-    return ((Items ?? []) as PostedOrderItem[]).map(toRecord);
+    const items = await this.queryAll(
+      PENDING_INDEX_KEY,
+      { index: POSTED_ORDERS_INDEX.PENDING_DEADLINE, lt: now },
+      limit
+    );
+    return items.map(toRecord);
   }
 
   public async getFillerOrdersByDeadline(filler: string, from: number, to: number): Promise<PostedOrderRecord[]> {
-    const { Items } = await this.entity.query(filler, {
-      index: POSTED_ORDERS_INDEX.FILLER_DEADLINE,
-      between: [from, to],
-      execute: true,
-      parse: true,
-    });
-    return ((Items ?? []) as PostedOrderItem[]).map(toRecord);
+    const items = await this.queryAll(filler, { index: POSTED_ORDERS_INDEX.FILLER_DEADLINE, between: [from, to] });
+    return items.map(toRecord);
   }
 
   public async recordOutcome(orderHash: string, resolution: PostedOrderResolution): Promise<void> {

--- a/test/crons/order-service-fades-source.test.ts
+++ b/test/crons/order-service-fades-source.test.ts
@@ -124,10 +124,12 @@ describe('OrderServiceFadesSource', () => {
         faded: 1,
       },
       {
-        name: 'V2 filled without fillTimestamp -> unclassifiable',
+        name: 'V2 filled without fillTimestamp -> recorded FILLED, no verdict',
         record: v2(),
         status: status('h', ORDER_STATUS.FILLED, { fillBlock: 1 }),
-        expected: 'unclassifiable',
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
       },
       // Dutch_V3 fills decay by block: fillTimeBlocks = fillBlock - decayStartBlock must be > 0.
       {
@@ -163,16 +165,28 @@ describe('OrderServiceFadesSource', () => {
         faded: 0,
       },
       {
-        name: 'V3 filled without fillBlock -> unclassifiable',
+        name: 'V3 filled without fillBlock -> recorded FILLED, no verdict',
         record: v3(),
         status: status('h', ORDER_STATUS.FILLED, { fillTimestamp: NOW }),
-        expected: 'unclassifiable',
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
       },
       {
-        name: 'V3 record missing decayStartBlock -> unclassifiable',
+        name: 'V3 filled with the order service fillBlock -1 sentinel (fill event unprocessed) -> no verdict, not a clean fill',
+        record: v3(),
+        status: status('h', ORDER_STATUS.FILLED, { fillBlock: -1 }),
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
+      },
+      {
+        name: 'V3 record missing decayStartBlock -> recorded FILLED, no verdict',
         record: v3({ decayStartBlock: undefined }),
         status: status('h', ORDER_STATUS.FILLED, { fillBlock: DECAY_START_BLOCK + 5 }),
-        expected: 'unclassifiable',
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
       },
       {
         name: 'unknown order type fill -> unclassifiable',
@@ -244,7 +258,10 @@ describe('OrderServiceFadesSource', () => {
         expect(classification.resolution.faded).toBe(faded);
         expect(classification.resolution.orderStatus).toBe(status.orderStatus);
         expect(classification.resolution.resolvedAt).toBe(NOW);
-        expect(classification.resolution.fillBlock).toBe(status.fillBlock);
+        // the -1 sentinel is not real timing and is not persisted as such
+        expect(classification.resolution.fillBlock).toBe(
+          status.fillBlock !== undefined && status.fillBlock >= 0 ? status.fillBlock : undefined
+        );
         expect(classification.resolution.fillTimestamp).toBe(status.fillTimestamp);
       }
     });
@@ -506,13 +523,29 @@ describe('OrderServiceFadesSource', () => {
     });
 
     it('leaves unclassifiable orders pending and counts them', async () => {
-      const [fillNoTiming] = await seed(v3());
-      service.seed(status(fillNoTiming.orderHash, ORDER_STATUS.FILLED));
+      const [weird] = await seed(v3());
+      service.seed(status(weird.orderHash, 'settling'));
 
       const summary = await source.resolvePendingOutcomes(NOW);
 
       expect(summary).toMatchObject({ resolved: 0, unclassifiable: 1 });
-      expect(await repo.getPostedOrder(fillNoTiming.orderHash)).toMatchObject({ outcome: PostedOrderOutcome.PENDING });
+      expect(await repo.getPostedOrder(weird.orderHash)).toMatchObject({ outcome: PostedOrderOutcome.PENDING });
+    });
+
+    it('records a fill without timing as FILLED with no verdict, counts it, and never scores it', async () => {
+      const [sentinel] = await seed(v3({ deadline: NOW - 500 }));
+      service.seed(status(sentinel.orderHash, ORDER_STATUS.FILLED, { fillBlock: -1 }));
+
+      const rows = await source.getFades();
+
+      expect(source.lastResolution).toMatchObject({ resolved: 1, fillsWithoutVerdict: 1, unclassifiable: 0 });
+      const stored = await repo.getPostedOrder(sentinel.orderHash);
+      expect(stored).toMatchObject({ outcome: PostedOrderOutcome.FILLED, orderStatus: 'filled' });
+      expect(stored).not.toHaveProperty('faded');
+      expect(stored).not.toHaveProperty('fillBlock');
+      expect(rows).toEqual([]);
+      // Not re-fetched next run.
+      expect(await repo.getPendingPastDeadline(NOW)).toEqual([]);
     });
 
     it('batches at the order service cap and never exceeds it', async () => {

--- a/test/repositories/posted-order-repository.test.ts
+++ b/test/repositories/posted-order-repository.test.ts
@@ -190,4 +190,38 @@ describe('DynamoPostedOrderRepository', () => {
       expect(await repo.getPostedOrder('0xdoesnotexist')).toBeUndefined();
     });
   });
+
+  describe('pagination', () => {
+    // A 2-item page stands in for DynamoDB's 1MB page: production hit this with a filler that
+    // completes >1,600 orders in 24h, whose newest rows fell off the (deadline-ascending) first
+    // page and were silently missing from the fade rows.
+    const paged = DynamoPostedOrderRepository.create(documentClient, { pageSize: 2 });
+    const FILLER_P = 'https://filler-paged.example/rfq';
+    const rows = Array.from({ length: 7 }, (_, i) =>
+      record({ orderHash: `0xp${i}`, filler: FILLER_P, fillerName: 'paged', deadline: NOW - 1_000 + i })
+    );
+
+    beforeAll(async () => {
+      for (const r of rows) await paged.putPostedOrder(r);
+    });
+
+    it('getFillerOrdersByDeadline drains every page', async () => {
+      const got = await paged.getFillerOrdersByDeadline(FILLER_P, NOW - 1_000, NOW - 994);
+      expect(got.map((r) => r.orderHash)).toEqual(rows.map((r) => r.orderHash));
+    });
+
+    it('getPendingPastDeadline drains pages up to the requested limit, oldest first', async () => {
+      const got = await paged.getPendingPastDeadline(NOW - 990, 5);
+      const mine = got.filter((r) => r.filler === FILLER_P);
+      expect(got.length).toBeLessThanOrEqual(5);
+      // Every returned row precedes every omitted one (ascending deadline across pages).
+      const omitted = rows.filter((r) => !mine.some((g) => g.orderHash === r.orderHash));
+      expect(Math.max(...mine.map((r) => r.deadline))).toBeLessThan(Math.min(...omitted.map((r) => r.deadline)));
+    });
+
+    it('getPendingPastDeadline without a limit returns everything across pages', async () => {
+      const got = (await paged.getPendingPastDeadline(NOW - 990)).filter((r) => r.filler === FILLER_P);
+      expect(got).toHaveLength(7);
+    });
+  });
 });


### PR DESCRIPTION
Superseded by #504, which carries this commit (rebased onto main) as its first commit. Description removed; see #504.