### PR TITLE
feat(cron): promote the order-service fades source to primary; Redshift becomes the shadow

### DIFF
--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -12,7 +12,12 @@ import { Construct } from 'constructs';
 import * as path from 'path';
 
 import { ITopic } from 'aws-cdk-lib/aws-sns';
-import { DYNAMO_TABLE_NAME, FADE_RATE_BUCKET } from '../../lib/constants';
+import {
+  DYNAMO_TABLE_NAME,
+  FADE_RATE_BUCKET,
+  FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE_ENV,
+  FADES_SOURCE_ENV,
+} from '../../lib/constants';
 import { STAGE } from '../../lib/util/stage';
 import { PROD_TABLE_CAPACITY } from '../config';
 import { SERVICE_NAME } from '../constants';
@@ -91,6 +96,12 @@ export class CronStack extends cdk.NestedStack {
           stage: stage,
           ...envVars,
           ...(orderServiceUrl && { ORDER_SERVICE_URL: orderServiceUrl }),
+          // Which fades source is authoritative for block decisions; the other runs as a shadow.
+          // Reverting to the Redshift-computed breaker is changing this one value to 'redshift'.
+          [FADES_SOURCE_ENV]: 'order-service',
+          // Cancelled / insufficient-funds / error orders are not fades (production parity);
+          // 'true' would score them as fades. Expiries always count.
+          [FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE_ENV]: 'false',
         },
       });
       // The shared Lambda role already carries AmazonDynamoDBFullAccess; the explicit grant

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -30,6 +30,12 @@ export const POSTED_ORDERS_INDEX = {
 // full 24h scoring window plus a day of slack for a stalled cron.
 export const POSTED_ORDER_TTL_SECS = 48 * 60 * 60;
 
+// Fade circuit breaker configuration, read by lib/cron/fade-rate-v2.ts and set on the cron Lambda
+// in bin/stacks/cron-stack.ts. Both are deliberately env-driven so operating the breaker (which
+// source is authoritative; how never-filled terminal orders are scored) is a config change.
+export const FADES_SOURCE_ENV = 'FADES_SOURCE';
+export const FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE_ENV = 'FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE';
+
 export const DYNAMO_TABLE_KEY = {
   BLOCK_UNTIL_TIMESTAMP: 'blockUntilTimestamp',
   LAST_EXAMINED_TIMESTAMP: 'lastExaminedTimestamp',

--- a/lib/cron/fade-rate-shadow.ts
+++ b/lib/cron/fade-rate-shadow.ts
@@ -5,37 +5,42 @@ import { Metric } from '../entities/aws-metrics-logger';
 import { ToUpdateTimestampRow, V2FadesRowType } from '../repositories';
 import { UNBLOCKED_BLOCK_UNTIL_TIMESTAMP } from '../repositories/timestamp-repository';
 import { withTimeout } from '../util/time';
-import { OrderServiceFadesSource, ResolutionSummary } from './order-service-fades-source';
+import { FadesScoringSource, FadesSourceKind } from './fades-sources';
+import { ResolutionSummary } from './order-service-fades-source';
 
-// Wall-time ceiling on everything the shadow adds to a cron run (order-service batches,
-// DynamoDB reads/writes, scoring). The fade cron's Lambda timeout is 240s and the Redshift
-// path runs first; one minute keeps the shadow comfortably inside that even if the Redshift
-// path is slow. The source stops starting order-service batches at this deadline, and the
-// runner races the whole thing against it as a backstop.
+// Wall-time ceiling on everything the shadow adds to a cron run. The fade cron's Lambda timeout
+// is 240s and the primary path runs first; one minute keeps the shadow comfortably inside that
+// even if the primary is slow. An order-service shadow stops starting batches at this deadline;
+// a Redshift shadow is simply cut off by the race below (its statement finishes server-side
+// regardless, harmlessly).
 export const SHADOW_TIME_BUDGET_MS = 60_000;
 
 // First moment PostedOrders had every post (PR #495 deployed 2026-09-04 21:29Z). Redshift's
-// 24h window contains orders older than this that the new source can never have, so the
-// comparison is restricted to orders posted at/after this floor. After the first day of shadow
-// the floor is moot (everything in the window is newer).
+// 24h window contains orders older than this that the order-service source can never have, so
+// the comparison is restricted to orders posted at/after this floor. Moot once the window has
+// rolled past it; kept so the report's definition does not silently change.
 export const POSTED_ORDERS_LIVE_SINCE = 1_788_557_340;
 
 /**
- * What the cron hands the shadow after the real path has written. `score` is the production
+ * What the cron hands the shadow after the primary path has written. `score` is the production
  * scoring code (getFillersFadeStats + calculateNewTimestamps) closed over the stored breaker
- * state the real run used, with metrics disabled. It resolves the filler behind every address
- * the rows it is given name (the real run's map, extended for addresses only these rows
+ * state the primary run used, with metrics disabled. It resolves the filler behind every address
+ * the rows it is given name (the primary run's map, extended for addresses only these rows
  * mention) — so shadow decisions differ from the real ones only through the rows.
  */
 export type ShadowContext = {
-  redshiftRows: V2FadesRowType[];
+  primary: FadesSourceKind;
+  primaryRows: V2FadesRowType[];
+  // Outcome-resolution summary when the primary is the order service (the shadow's own summary
+  // is read from the shadow source otherwise).
+  primaryResolution?: ResolutionSummary;
   realUpdates: ToUpdateTimestampRow[];
   score: (rows: V2FadesRowType[]) => Promise<ToUpdateTimestampRow[]>;
   now: number;
 };
 
 export type ShadowDeps = {
-  source: OrderServiceFadesSource;
+  shadow: FadesScoringSource;
   log: Logger;
   metrics: MetricsLogger;
   compareSince?: number;
@@ -44,6 +49,11 @@ export type ShadowDeps = {
 
 export type PerFillerCounts = { oldTotal: number; oldFades: number; newTotal: number; newFades: number };
 
+/**
+ * Row-level comparison. "old" is always the Redshift side and "new" always the order-service
+ * side, whichever of them is primary this run, so the ROWS_/FADES_ metrics keep one meaning
+ * across the flip.
+ */
 export type RowComparison = {
   since: number;
   oldRows: number;
@@ -68,12 +78,15 @@ export type DecisionComparison = {
 };
 
 export type ShadowReport = {
+  primary: FadesSourceKind;
+  shadow: FadesSourceKind;
   durationMs: number;
+  // The order-service side's outcome resolution this run, whichever role it played.
   resolution?: ResolutionSummary;
   rows: RowComparison;
-  // Shadow decisions vs. what the Redshift path actually wrote this run.
+  // Shadow decisions vs. what the primary actually wrote this run.
   decisionsVsProduction: DecisionComparison;
-  // Shadow decisions vs. the Redshift rows re-scored with the same go-live floor.
+  // Both sides' rows restricted to the comparison floor and re-scored, then compared.
   decisionsVsRestricted: DecisionComparison;
   wouldBlock: number;
 };
@@ -162,25 +175,27 @@ export function compareBlockDecisions(
 }
 
 /**
- * Runs the order-service fades source next to the Redshift path and reports how the two
- * compare. Writes nothing to FillerCBTimestampsV2 (it has no handle to it), notifies nobody,
- * and never throws: any failure — order-service timeout, DynamoDB error, a bug in
+ * Runs the non-primary fades source next to the primary and reports how the two compare.
+ * Writes nothing to FillerCBTimestampsV2 (it has no handle to it), notifies nobody, and never
+ * throws: any failure — order-service timeout, Redshift connectivity, DynamoDB error, a bug in
  * classification or comparison, the time budget — is logged and counted as
  * CIRCUIT_BREAKER_SHADOW_FAILURE. Resolves to the report on success, undefined on failure.
  */
 export async function runFadeRateShadow(ctx: ShadowContext, deps: ShadowDeps): Promise<ShadowReport | undefined> {
-  const { source, log, metrics } = deps;
+  const { shadow, log, metrics } = deps;
   const budgetMs = deps.budgetMs ?? SHADOW_TIME_BUDGET_MS;
   const since = deps.compareSince ?? POSTED_ORDERS_LIVE_SINCE;
   const start = Date.now();
-  source.deadlineMs = start + budgetMs;
+  shadow.setDeadline?.(start + budgetMs);
 
   try {
-    const report = await withTimeout(evaluate(ctx, source, since, start), budgetMs, 'fade shadow');
+    const report = await withTimeout(evaluate(ctx, shadow, since, start), budgetMs, 'fade shadow');
     emit(metrics, report);
     metrics.putMetric(Metric.CIRCUIT_BREAKER_SHADOW_SUCCESS, 1, Unit.Count);
     log.info(
       {
+        primary: report.primary,
+        shadow: report.shadow,
         durationMs: report.durationMs,
         resolution: report.resolution,
         rows: { ...report.rows, perFiller: undefined },
@@ -196,8 +211,12 @@ export async function runFadeRateShadow(ctx: ShadowContext, deps: ShadowDeps): P
     metrics.putMetric(Metric.CIRCUIT_BREAKER_SHADOW_FAILURE, 1, Unit.Count);
     metrics.putMetric(Metric.CIRCUIT_BREAKER_SHADOW_DURATION, Date.now() - start, Unit.Milliseconds);
     log.error(
-      { error: e instanceof Error ? e.message : e, stack: e instanceof Error ? e.stack : undefined },
-      'fade circuit breaker shadow failed; real decisions unaffected'
+      {
+        shadow: shadow.kind,
+        error: e instanceof Error ? e.message : e,
+        stack: e instanceof Error ? e.stack : undefined,
+      },
+      'fade circuit breaker shadow failed; primary decisions unaffected'
     );
     return undefined;
   }
@@ -205,22 +224,28 @@ export async function runFadeRateShadow(ctx: ShadowContext, deps: ShadowDeps): P
 
 async function evaluate(
   ctx: ShadowContext,
-  source: OrderServiceFadesSource,
+  shadow: FadesScoringSource,
   since: number,
   start: number
 ): Promise<ShadowReport> {
-  const newRows = await source.getFades();
-  const rows = compareFadeRows(ctx.redshiftRows, newRows, since);
-  const [shadowUpdates, restrictedRealUpdates] = await Promise.all([
-    ctx.score(newRows),
-    ctx.score(ctx.redshiftRows.filter((row) => row.postTimestamp >= since)),
+  const shadowRows = await shadow.fetchRows();
+  const redshiftRows = shadow.kind === 'redshift' ? shadowRows : ctx.primaryRows;
+  const orderServiceRows = shadow.kind === 'order-service' ? shadowRows : ctx.primaryRows;
+  const sinceFloor = (rows: V2FadesRowType[]) => rows.filter((row) => row.postTimestamp >= since);
+
+  const [shadowUpdates, restrictedPrimaryUpdates, restrictedShadowUpdates] = await Promise.all([
+    ctx.score(shadowRows),
+    ctx.score(sinceFloor(ctx.primaryRows)),
+    ctx.score(sinceFloor(shadowRows)),
   ]);
   return {
+    primary: ctx.primary,
+    shadow: shadow.kind,
     durationMs: Date.now() - start,
-    resolution: source.lastResolution,
-    rows,
+    resolution: ctx.primary === 'order-service' ? ctx.primaryResolution : shadow.lastResolution?.(),
+    rows: compareFadeRows(redshiftRows, orderServiceRows, since),
     decisionsVsProduction: compareBlockDecisions(ctx.realUpdates, shadowUpdates, ctx.now),
-    decisionsVsRestricted: compareBlockDecisions(restrictedRealUpdates, shadowUpdates, ctx.now),
+    decisionsVsRestricted: compareBlockDecisions(restrictedPrimaryUpdates, restrictedShadowUpdates, ctx.now),
     wouldBlock: shadowUpdates.filter((row) => (row.blockUntilTimestamp ?? UNBLOCKED_BLOCK_UNTIL_TIMESTAMP) > ctx.now)
       .length,
   };

--- a/lib/cron/fade-rate-v2.ts
+++ b/lib/cron/fade-rate-v2.ts
@@ -7,7 +7,13 @@ import { EventBridgeEvent } from 'aws-lambda/trigger/eventbridge';
 import Logger from 'bunyan';
 
 import { ethers } from 'ethers';
-import { BETA_S3_KEY, PRODUCTION_S3_KEY, WEBHOOK_CONFIG_BUCKET } from '../constants';
+import {
+  BETA_S3_KEY,
+  FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE_ENV,
+  FADES_SOURCE_ENV,
+  PRODUCTION_S3_KEY,
+  WEBHOOK_CONFIG_BUCKET,
+} from '../constants';
 import { AWSMetricsLogger, CircuitBreakerMetricDimension, Metric, metricContext } from '../entities';
 import { checkDefined } from '../preconditions/preconditions';
 import { S3WebhookConfigurationProvider, UniswapXServiceProvider } from '../providers';
@@ -24,8 +30,15 @@ import { DynamoFillerAddressRepository, FillerAddressRepository } from '../repos
 import { DynamoPostedOrderRepository } from '../repositories/posted-order-repository';
 import { TimestampRepository, UNBLOCKED_BLOCK_UNTIL_TIMESTAMP } from '../repositories/timestamp-repository';
 import { STAGE } from '../util/stage';
-import { runFadeRateShadow, ShadowContext } from './fade-rate-shadow';
-import { FadesSource, OrderServiceFadesSource } from './order-service-fades-source';
+import { runFadeRateShadow } from './fade-rate-shadow';
+import {
+  FadesScoringSource,
+  FadesSourceKind,
+  orderServiceScoringSource,
+  parseFadesSource,
+  redshiftScoringSource,
+} from './fades-sources';
+import { OrderServiceFadesSource } from './order-service-fades-source';
 
 // Re-exported for existing importers; the sentinel lives with the repository that owns the
 // stored value's parse/write semantics.
@@ -164,16 +177,20 @@ export const handler: ScheduledHandler = metricScope((metrics) => async (_event:
  * passes.
  */
 export type FadeRateCronDeps = {
-  fadesRepository: FadesSource & { createFadesView(): Promise<void> };
+  // Which source's rows drive the block decisions this run (FADES_SOURCE). The other source, if
+  // present, runs as the shadow: scored with the same code, written nowhere, compared.
+  primary: FadesSourceKind;
+  redshift: FadesScoringSource;
+  // Absent when the order service is not configured for this stage. Required when it is the
+  // primary; without it there is no shadow when Redshift is the primary.
+  orderService?: FadesScoringSource;
   webhookProvider: Pick<S3WebhookConfigurationProvider, 'fetchEndpoints' | 'fillerEndpoints'>;
   fillerAddressRepo: Pick<FillerAddressRepository, 'getAddressToFillerMap'>;
   timestampDB: BaseTimestampRepository;
-  // Optional shadow evaluation of the order-service fades source. Invoked strictly after the
-  // real path has written its decisions, with no handle to the timestamp table; it is expected
-  // not to throw, and the run additionally guards it so it cannot fail the cron.
-  shadow?: (ctx: ShadowContext) => Promise<unknown>;
   now?: () => number;
   log?: Logger;
+  shadowCompareSince?: number;
+  shadowBudgetMs?: number;
 };
 
 async function main(metrics: MetricsLogger) {
@@ -182,44 +199,52 @@ async function main(metrics: MetricsLogger) {
     ClusterIdentifier: checkDefined(process.env.REDSHIFT_CLUSTER_IDENTIFIER),
     SecretArn: checkDefined(process.env.REDSHIFT_SECRET_ARN),
   };
+  const primary = parseFadesSource(process.env[FADES_SOURCE_ENV], log);
+  const orderService = buildOrderServiceSource();
+  if (primary === 'order-service' && !orderService) {
+    // A misconfigured primary is a real cron failure, exactly like a Redshift outage was: the
+    // alarm fires and the breaker's stored blocks simply expire until it is fixed.
+    throw new Error(`${FADES_SOURCE_ENV}=order-service but ORDER_SERVICE_URL is not set`);
+  }
   await runFadeRateCron(metrics, {
-    fadesRepository: V2FadesRepository.create(sharedConfig),
+    primary,
+    redshift: redshiftScoringSource(V2FadesRepository.create(sharedConfig)),
+    orderService,
     webhookProvider,
     fillerAddressRepo,
     timestampDB,
-    shadow: buildOrderServiceShadow(metrics),
   });
 }
 
 /**
- * Production wiring of the shadow (see lib/cron/fade-rate-shadow.ts). Skipped, with a log
- * line, when the order service URL is not configured for this stage.
+ * Production wiring of the order-service/PostedOrders fades source (lib/cron/order-service-
+ * fades-source.ts). Undefined, with a log line, when the order service URL is not configured.
  */
-function buildOrderServiceShadow(metrics: MetricsLogger): FadeRateCronDeps['shadow'] {
+function buildOrderServiceSource(): FadesScoringSource | undefined {
   const orderServiceUrl = process.env.ORDER_SERVICE_URL;
   if (!orderServiceUrl) {
-    log.info('ORDER_SERVICE_URL is not set; skipping the order-service fade shadow');
+    log.info('ORDER_SERVICE_URL is not set; the order-service fades source is unavailable');
     return undefined;
   }
-  const shadowLog = log.child({ shadow: 'order-service-fades' });
+  const sourceLog = log.child({ fadesSource: 'order-service' });
   const source = new OrderServiceFadesSource({
     postedOrders: DynamoPostedOrderRepository.create(
       // Not the hard-quote path's 200/300ms-bounded client: the cron is not in series with a
-      // quote, and the shadow has its own wall-time budget.
+      // quote.
       DynamoDBDocumentClient.from(new DynamoDBClient({}), {
         marshallOptions: { convertEmptyValues: true, removeUndefinedValues: true },
         unmarshallOptions: { wrapNumbers: false },
       })
     ),
-    orderStatus: new UniswapXServiceProvider(shadowLog, orderServiceUrl),
+    orderStatus: new UniswapXServiceProvider(sourceLog, orderServiceUrl),
     fillerEndpoints: () => webhookProvider.fillerEndpoints(),
-    log: shadowLog,
-    // Parity flag (default on): never-filled cancelled / insufficient-funds / error orders
-    // count as fades, as the SQL's `fillTimestamp IS NULL` branch does today. Set the env var
-    // to 'false' to preview the candidate behavior change in the shadow metrics.
-    policy: { countNeverFilledTerminalAsFade: process.env.FADE_SHADOW_NEVER_FILLED_TERMINAL_AS_FADE !== 'false' },
+    log: sourceLog,
+    // Parity flag (default off): cancelled / insufficient-funds / error orders are excluded, as
+    // production's SQL effectively excludes them. 'true' scores them as fades. Expiries always
+    // count regardless.
+    policy: { countNeverFilledTerminalAsFade: process.env[FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE_ENV] === 'true' },
   });
-  return (ctx) => runFadeRateShadow(ctx, { source, log: shadowLog, metrics });
+  return orderServiceScoringSource(source);
 }
 
 /**
@@ -258,10 +283,11 @@ export async function lookupFillersForRows(
 }
 
 /**
- * The real run's address map, extended for any address in `rows` it does not cover. The
- * shadow's rows come from a different source and can name addresses the Redshift rows do not
- * (a batch load Redshift has not caught up with, or rows past its row cap); scoring them with
- * the Redshift-derived map alone would silently drop exactly the rows only the new source has.
+ * The primary run's address map, extended for any address in `rows` it does not cover. The
+ * shadow's rows come from a different source and can name addresses the primary's rows do not
+ * (a batch load Redshift has not caught up with, rows past its row cap, or orders that only one
+ * side records); scoring them with the primary's map alone would silently drop exactly the rows
+ * only the shadow has.
  */
 async function extendFillerMapForRows(
   base: Map<string, string>,
@@ -279,10 +305,22 @@ async function extendFillerMapForRows(
 }
 
 export async function runFadeRateCron(metrics: MetricsLogger, deps: FadeRateCronDeps): Promise<void> {
-  const { fadesRepository, webhookProvider, fillerAddressRepo, timestampDB } = deps;
-  const log = deps.log ?? defaultLog;
+  const { webhookProvider, fillerAddressRepo, timestampDB } = deps;
+  const primary = deps.primary === 'order-service' ? deps.orderService : deps.redshift;
+  if (!primary) {
+    throw new Error(`${FADES_SOURCE_ENV}=${deps.primary} but that source is not available`);
+  }
+  const shadow = deps.primary === 'order-service' ? deps.redshift : deps.orderService;
+  // Every log line and EMF record of this run says which source produced the decisions.
+  const log = (deps.log ?? defaultLog).child({ fadesSource: primary.kind });
   metrics.setNamespace('Uniswap');
   metrics.setDimensions(CircuitBreakerMetricDimension);
+  metrics.setProperty('fadesSource', primary.kind);
+  metrics.putMetric(
+    Metric.CIRCUIT_BREAKER_PRIMARY_IS_ORDER_SERVICE,
+    primary.kind === 'order-service' ? 1 : 0,
+    Unit.Count
+  );
   // The webhook config provider emits RFQ_CONFIG_CHANGED through the
   // smart-order-router module-global metric. The quote lambdas bind it per
   // request in their injector; without this binding here, the cron's
@@ -292,76 +330,89 @@ export async function runFadeRateCron(metrics: MetricsLogger, deps: FadeRateCron
   // alongside the quote lambdas' dimensionless one.
   setGlobalMetric(new AWSMetricsLogger(metrics));
 
-  await fadesRepository.createFadesView();
   await webhookProvider.fetchEndpoints();
   /*
-   query redshift for recent orders
-        | fillerAddress |    faded  |   postTimestamp |
-        |---- 0x1 ------|---- 0 ----|---- 12222222 ---|
-        |---- 0x2 ------|---- 1 ----|---- 12345679 --|
-        |---- 0x1 ------|---- 0 ----|---- 12345678 ---|
+   primary rows: one per recently completed order
+        | fillerAddress |    faded  |   postTimestamp |   deadline   |
+        |---- 0x1 ------|---- 0 ----|---- 12222222 ---|--- 12222282 -|
+        |---- 0x2 ------|---- 1 ----|---- 12345679 ---|--- 12345739 -|
+        |---- 0x1 ------|---- 0 ----|---- 12345678 ---|--- 12345738 -|
+   A failure here is a failure of the cron run — the primary is authoritative and there is no
+   fallback to the other source (that would be a silent, un-flagged switch of the breaker's input).
   */
-  const result = await fadesRepository.getFades();
+  const rows = await primary.fetchRows();
 
-  if (result) {
-    const fillerEndpoints = webhookProvider.fillerEndpoints();
-    const [addressToFillerMap, fillerTimestamps] = await Promise.all([
-      lookupFillersForRows(result, fillerEndpoints, fillerAddressRepo, log),
-      timestampDB.getFillerTimestampsMap(fillerEndpoints),
-    ]);
+  const fillerEndpoints = webhookProvider.fillerEndpoints();
+  const [addressToFillerMap, fillerTimestamps] = await Promise.all([
+    lookupFillersForRows(rows, fillerEndpoints, fillerAddressRepo, log),
+    timestampDB.getFillerTimestampsMap(fillerEndpoints),
+  ]);
 
-    const now = deps.now ? deps.now() : Math.floor(Date.now() / 1000);
+  const now = deps.now ? deps.now() : Math.floor(Date.now() / 1000);
 
-    // compute each filler's Laplace-smoothed fade rates (post-block window + during-block cohort):
-    //  | hash     |  fadeRate  |  duringBlockRate  |
-    //  |---- foo -|---- 0.18 --|------ 0.05 -------|
-    //  |---- bar -|---- 0.05 --|------ 0.20 -------|
-    const fillerFadeStats = getFillersFadeStats(result, addressToFillerMap, fillerTimestamps, now, log);
+  // compute each filler's Laplace-smoothed fade rates (post-block window + during-block cohort):
+  //  | hash     |  fadeRate  |  duringBlockRate  |
+  //  |---- foo -|---- 0.18 --|------ 0.05 -------|
+  //  |---- bar -|---- 0.05 --|------ 0.20 -------|
+  const fillerFadeStats = getFillersFadeStats(rows, addressToFillerMap, fillerTimestamps, now, log);
 
-    //  | hash        |lastExaminedTimestamp|blockUntilTimestamp|fadeWindowStart|
-    //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
-    //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
-    const updatedTimestamps = calculateNewTimestamps(fillerTimestamps, fillerFadeStats, now, log, metrics);
-    log.info({ updatedTimestamps }, 'filler for which to update timestamp');
-    metrics.putMetric(
-      Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS,
-      countActiveBlocks(fillerTimestamps, updatedTimestamps, now),
-      Unit.Count
-    );
-    metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, Object.keys(fillerFadeStats).length, Unit.Count);
-    if (updatedTimestamps.length > 0) {
-      await timestampDB.updateTimestampsBatch(updatedTimestamps);
-    } else {
-      log.info('no timestamp to update');
-    }
+  //  | hash        |lastExaminedTimestamp|blockUntilTimestamp|fadeWindowStart|
+  //  |---- foo ----|---- 1300000 ----|----      calculated block until  ----|
+  //  |---- bar ----|---- 1300000 ----|----      13500000                ----|
+  const updatedTimestamps = calculateNewTimestamps(fillerTimestamps, fillerFadeStats, now, log, metrics);
+  log.info({ updatedTimestamps }, 'filler for which to update timestamp');
+  metrics.putMetric(
+    Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS,
+    countActiveBlocks(fillerTimestamps, updatedTimestamps, now),
+    Unit.Count
+  );
+  metrics.putMetric(Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED, Object.keys(fillerFadeStats).length, Unit.Count);
+  if (updatedTimestamps.length > 0) {
+    await timestampDB.updateTimestampsBatch(updatedTimestamps);
+  } else {
+    log.info('no timestamp to update');
+  }
 
-    // Shadow evaluation of the order-service fades source: strictly after the real path has
-    // written its decisions. It scores its own rows with the same code against the same stored
-    // state (metrics and row logging off), writes nothing and notifies nobody. Guarded so that
-    // nothing it does can fail the cron — the shadow's own runner already never throws; this
-    // covers the wiring around it.
-    if (deps.shadow) {
-      try {
-        await deps.shadow({
-          redshiftRows: result,
+  // Shadow evaluation of the other source: strictly after the primary has written its decisions.
+  // It scores its own rows with the same code against the same stored state (metrics and row
+  // logging off), writes nothing and notifies nobody. Guarded so that nothing it does — a Redshift
+  // connectivity error, an order-service timeout, a bug — can fail the cron or touch the
+  // decisions above; the runner itself already never throws, this covers the wiring around it.
+  if (shadow) {
+    try {
+      await runFadeRateShadow(
+        {
+          primary: primary.kind,
+          primaryRows: rows,
+          primaryResolution: primary.lastResolution?.(),
           realUpdates: updatedTimestamps,
           now,
-          score: async (rows) =>
+          score: async (shadowRows) =>
             calculateNewTimestamps(
               fillerTimestamps,
               getFillersFadeStats(
-                rows,
-                await extendFillerMapForRows(addressToFillerMap, rows, fillerEndpoints, fillerAddressRepo, log),
+                shadowRows,
+                await extendFillerMapForRows(addressToFillerMap, shadowRows, fillerEndpoints, fillerAddressRepo, log),
                 fillerTimestamps,
                 now
               ),
               now
             ),
-        });
-      } catch (e) {
-        metrics.putMetric(Metric.CIRCUIT_BREAKER_SHADOW_FAILURE, 1, Unit.Count);
-        log.error({ error: e instanceof Error ? e.message : e }, 'fade shadow wiring threw; real decisions unaffected');
-      }
+        },
+        {
+          shadow,
+          log: log.child({ shadow: shadow.kind }),
+          metrics,
+          compareSince: deps.shadowCompareSince,
+          budgetMs: deps.shadowBudgetMs,
+        }
+      );
+    } catch (e) {
+      metrics.putMetric(Metric.CIRCUIT_BREAKER_SHADOW_FAILURE, 1, Unit.Count);
+      log.error(
+        { error: e instanceof Error ? e.message : e },
+        'fade shadow wiring threw; primary decisions unaffected'
+      );
     }
   }
 }

--- a/lib/cron/fades-sources.ts
+++ b/lib/cron/fades-sources.ts
@@ -1,0 +1,78 @@
+import Logger from 'bunyan';
+
+import { FADES_SOURCE_ENV } from '../constants';
+import { V2FadesRowType } from '../repositories/fades-repository';
+import { OrderServiceFadesSource, ResolutionSummary } from './order-service-fades-source';
+
+/**
+ * The two places the fade circuit breaker can get its per-order rows from. Exactly one is the
+ * primary (its rows drive the block decisions that are written); the other runs as a shadow
+ * (rows scored, nothing written, differences reported). Which is which is configuration
+ * (FADES_SOURCE_ENV), so swapping back is a one-line config change, not a code revert.
+ */
+export type FadesSourceKind = 'order-service' | 'redshift';
+export const FADES_SOURCE_KINDS: readonly FadesSourceKind[] = ['order-service', 'redshift'];
+export const DEFAULT_FADES_SOURCE: FadesSourceKind = 'order-service';
+
+/**
+ * Reads the primary-source switch. Unset means the default. An unrecognised value also means the
+ * default, loudly: a typo in an env var must not take the breaker down (a failed cron leaves
+ * stale blocks expiring with nothing renewing them), but it must be visible in the logs.
+ */
+export function parseFadesSource(value: string | undefined, log?: Logger): FadesSourceKind {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return DEFAULT_FADES_SOURCE;
+  }
+  const kind = FADES_SOURCE_KINDS.find((k) => k === normalized);
+  if (!kind) {
+    log?.warn(
+      { [FADES_SOURCE_ENV]: value, fallback: DEFAULT_FADES_SOURCE },
+      'unrecognised fades source; using default'
+    );
+    return DEFAULT_FADES_SOURCE;
+  }
+  return kind;
+}
+
+/**
+ * A fades source as the cron consumes it, in either role. `fetchRows` produces rows in the
+ * shape of V2_FADE_RATE_SQL's result (see V2FadesRowType), including whatever preparation the
+ * source needs (Redshift: rebuilding its view; order service: resolving pending outcomes).
+ */
+export interface FadesScoringSource {
+  readonly kind: FadesSourceKind;
+  fetchRows(): Promise<V2FadesRowType[]>;
+  // Wallclock (ms) after which best-effort work stops, honoured when running as the shadow.
+  setDeadline?(deadlineMs: number): void;
+  // Outcome-resolution summary of the last fetchRows (order service only).
+  lastResolution?(): ResolutionSummary | undefined;
+}
+
+export type RedshiftFadesRepository = {
+  createFadesView(): Promise<void>;
+  getFades(): Promise<V2FadesRowType[]>;
+};
+
+/** The Redshift path exactly as the cron has always run it: rebuild the view, then query it. */
+export function redshiftScoringSource(repository: RedshiftFadesRepository): FadesScoringSource {
+  return {
+    kind: 'redshift',
+    fetchRows: async () => {
+      await repository.createFadesView();
+      return repository.getFades();
+    },
+  };
+}
+
+/** The GPA-owned path: resolve pending outcomes against the order service, then build rows. */
+export function orderServiceScoringSource(source: OrderServiceFadesSource): FadesScoringSource {
+  return {
+    kind: 'order-service',
+    fetchRows: () => source.getFades(),
+    setDeadline: (deadlineMs) => {
+      source.deadlineMs = deadlineMs;
+    },
+    lastResolution: () => source.lastResolution,
+  };
+}

--- a/lib/cron/order-service-fades-source.ts
+++ b/lib/cron/order-service-fades-source.ts
@@ -73,8 +73,8 @@ export type Classification =
  *   filled              | faded iff fillTimestamp > decayStartTime| faded iff fillBlock > decayStartBlock
  *   filled, no timing   | recorded, no verdict (see below)        | recorded, no verdict
  *   expired             | faded                                   | faded
- *   cancelled / insufficient-funds / error | recorded, no verdict (scored by policy flag; the SQL's
- *                       |   `fillTimestamp IS NULL` branch counts these as fades today)
+ *   cancelled / insufficient-funds / error | recorded, no verdict (scored by policy flag; excluded
+ *                       |   by default, as production's SQL effectively excludes them)
  *   open                | not terminal: stays pending             | stays pending
  *
  * A fill AT the decay-start block/time is not a fade: the exclusive filler still paid the
@@ -130,14 +130,15 @@ export function classifyOutcome(
 }
 
 export type FadeRowPolicy = {
-  // PARITY FLAG. The SQL scores every never-filled order as a fade (`fillTimestamp IS NULL`),
-  // which includes cancelled, insufficient-funds and error orders alongside expiries. `true`
-  // reproduces that; `false` drops those orders from the rows entirely (neither fade nor
-  // clean fill), which is the candidate behavior change to decide on after the shadow.
+  // PARITY FLAG for cancelled / insufficient-funds / error orders. The SQL reads as if it scored
+  // every never-filled order as a fade (`fillTimestamp IS NULL`), but in production those three
+  // never reach `archivedorders` with token columns, so the permissioned-token filter drops them
+  // and they contribute no row at all. `false` reproduces that (the default); `true` scores them
+  // as fades. Expiries are not governed by this flag: they always count as fades.
   countNeverFilledTerminalAsFade: boolean;
 };
 
-export const DEFAULT_FADE_ROW_POLICY: FadeRowPolicy = { countNeverFilledTerminalAsFade: true };
+export const DEFAULT_FADE_ROW_POLICY: FadeRowPolicy = { countNeverFilledTerminalAsFade: false };
 
 /**
  * The 0/1 the row builder scores an order as, or undefined when the order contributes no row

--- a/lib/cron/order-service-fades-source.ts
+++ b/lib/cron/order-service-fades-source.ts
@@ -60,8 +60,8 @@ export type Classification =
   // The order service still says `open` even though the deadline has passed: its status
   // poller has not caught up yet. Leave the row pending and ask again next run.
   | { kind: 'still-open' }
-  // A status we cannot score (unknown status string, a fill without timing, an unknown order
-  // type). Left pending so it is visible as a count; it expires with the row's TTL.
+  // A status we cannot score (unknown status string, unknown order type). Left pending so it is
+  // visible as a count; it expires with the row's TTL.
   | { kind: 'unclassifiable'; reason: string };
 
 /**
@@ -71,6 +71,7 @@ export type Classification =
  *   status              | Dutch_V2                                | Dutch_V3
  *   --------------------|-----------------------------------------|----------------------------------
  *   filled              | faded iff fillTimestamp > decayStartTime| faded iff fillBlock > decayStartBlock
+ *   filled, no timing   | recorded, no verdict (see below)        | recorded, no verdict
  *   expired             | faded                                   | faded
  *   cancelled / insufficient-funds / error | recorded, no verdict (scored by policy flag; the SQL's
  *                       |   `fillTimestamp IS NULL` branch counts these as fades today)
@@ -78,6 +79,12 @@ export type Classification =
  *
  * A fill AT the decay-start block/time is not a fade: the exclusive filler still paid the
  * undecayed price (the SQL's `fillTimeBlocks > 0` / `decayStartTime < fillTimestamp`).
+ *
+ * "Filled, no timing": when the order service fails to process a fill event it still marks the
+ * order `filled`, with `fillBlock: -1`, no fillTimestamp and an empty txHash (check-order-status
+ * catch path). Such a fill is terminal — so it is recorded and stops being re-fetched — but it
+ * carries no verdict: it is neither a fade nor a clean fill and contributes no row, which is
+ * also what the Redshift path sees (no Fill Info log is ever emitted for it).
  */
 export function classifyOutcome(
   record: PostedOrderRecord,
@@ -97,22 +104,25 @@ export function classifyOutcome(
     case ORDER_STATUS.ERROR:
       return { kind: 'resolved', resolution: { ...base, outcome: PostedOrderOutcome.ERROR } };
     case ORDER_STATUS.FILLED: {
-      const timing = { fillBlock: status.fillBlock, fillTimestamp: status.fillTimestamp };
+      if (record.orderType !== OrderType.Dutch_V3 && record.orderType !== OrderType.Dutch_V2) {
+        return { kind: 'unclassifiable', reason: `unknown order type ${record.orderType}` };
+      }
+      const fillBlock = status.fillBlock !== undefined && status.fillBlock >= 0 ? status.fillBlock : undefined;
+      const timing = { ...(fillBlock !== undefined && { fillBlock }), fillTimestamp: status.fillTimestamp };
+      const filled = { ...base, ...timing, outcome: PostedOrderOutcome.FILLED as const };
       if (record.orderType === OrderType.Dutch_V3) {
-        if (status.fillBlock === undefined || record.decayStartBlock === undefined) {
-          return { kind: 'unclassifiable', reason: 'Dutch_V3 fill without fillBlock/decayStartBlock' };
+        if (fillBlock === undefined || record.decayStartBlock === undefined) {
+          return { kind: 'resolved', resolution: filled }; // filled, no verdict
         }
-        const faded = status.fillBlock > record.decayStartBlock ? 1 : 0;
-        return { kind: 'resolved', resolution: { ...base, ...timing, outcome: PostedOrderOutcome.FILLED, faded } };
+        return { kind: 'resolved', resolution: { ...filled, faded: fillBlock > record.decayStartBlock ? 1 : 0 } };
       }
-      if (record.orderType === OrderType.Dutch_V2) {
-        if (status.fillTimestamp === undefined || record.decayStartTime === undefined) {
-          return { kind: 'unclassifiable', reason: 'Dutch_V2 fill without fillTimestamp/decayStartTime' };
-        }
-        const faded = status.fillTimestamp > record.decayStartTime ? 1 : 0;
-        return { kind: 'resolved', resolution: { ...base, ...timing, outcome: PostedOrderOutcome.FILLED, faded } };
+      if (status.fillTimestamp === undefined || record.decayStartTime === undefined) {
+        return { kind: 'resolved', resolution: filled }; // filled, no verdict
       }
-      return { kind: 'unclassifiable', reason: `unknown order type ${record.orderType}` };
+      return {
+        kind: 'resolved',
+        resolution: { ...filled, faded: status.fillTimestamp > record.decayStartTime ? 1 : 0 },
+      };
     }
     default:
       return { kind: 'unclassifiable', reason: `unknown order status ${status.orderStatus}` };
@@ -228,6 +238,9 @@ export type ResolutionSummary = {
   // GPA and the order service disagree about what was posted.
   notFound: number;
   unclassifiable: number;
+  // Terminal `filled` orders the service could not attach timing to (fillBlock -1): recorded,
+  // excluded from scoring. A rising count means the order service's fill processing is failing.
+  fillsWithoutVerdict: number;
   failedWrites: number;
   byOutcome: Partial<Record<PostedOrderOutcome, number>>;
 };
@@ -304,6 +317,7 @@ export class OrderServiceFadesSource implements FadesSource {
       stillOpen: 0,
       notFound: 0,
       unclassifiable: 0,
+      fillsWithoutVerdict: 0,
       failedWrites: 0,
       byOutcome: {},
     };
@@ -366,6 +380,13 @@ export class OrderServiceFadesSource implements FadesSource {
               await postedOrders.recordOutcome(record.orderHash, resolution);
               summary.resolved += 1;
               summary.byOutcome[resolution.outcome] = (summary.byOutcome[resolution.outcome] ?? 0) + 1;
+              if (resolution.outcome === PostedOrderOutcome.FILLED && resolution.faded === undefined) {
+                summary.fillsWithoutVerdict += 1;
+                log.warn(
+                  { orderHash: record.orderHash, status },
+                  'filled order without fill timing; recorded without verdict'
+                );
+              }
             } catch (e) {
               summary.failedWrites += 1;
               log.warn(

--- a/lib/entities/aws-metrics-logger.ts
+++ b/lib/entities/aws-metrics-logger.ts
@@ -139,9 +139,14 @@ export enum Metric {
   // Fillers with fade stats evaluated in a cron run (sample-health denominator)
   CIRCUIT_BREAKER_V2_FILLERS_EVALUATED = 'CIRCUIT_BREAKER_V2_FILLERS_EVALUATED',
 
-  // Shadow evaluation of the order-service fades source (lib/cron/fade-rate-shadow.ts). Runs
-  // after the Redshift path each cron, writes nothing. Exactly one of SUCCESS / FAILURE fires
-  // per run; DURATION is the wall time it added to the cron (budgeted, see the runner).
+  // 1 when the order-service/PostedOrders source produced this run's block decisions, 0 when
+  // Redshift did (FADES_SOURCE). Charts the switch position next to the decision metrics, whose
+  // EMF records also carry it as the `fadesSource` property.
+  CIRCUIT_BREAKER_PRIMARY_IS_ORDER_SERVICE = 'CIRCUIT_BREAKER_PRIMARY_IS_ORDER_SERVICE',
+
+  // Shadow evaluation of whichever fades source is NOT primary (lib/cron/fade-rate-shadow.ts).
+  // Runs after the primary path each cron, writes nothing. Exactly one of SUCCESS / FAILURE
+  // fires per run; DURATION is the wall time it added to the cron (budgeted, see the runner).
   CIRCUIT_BREAKER_SHADOW_SUCCESS = 'CIRCUIT_BREAKER_SHADOW_SUCCESS',
   CIRCUIT_BREAKER_SHADOW_FAILURE = 'CIRCUIT_BREAKER_SHADOW_FAILURE',
   CIRCUIT_BREAKER_SHADOW_DURATION = 'CIRCUIT_BREAKER_SHADOW_DURATION',

--- a/lib/repositories/posted-order-repository.ts
+++ b/lib/repositories/posted-order-repository.ts
@@ -138,10 +138,23 @@ type PostedOrderItem = PostedOrderRecord & {
   ttl: number;
 };
 
+// One page of a dynamodb-toolbox query: items plus a `next` that is present only while DynamoDB
+// reported a LastEvaluatedKey (i.e. the 1MB page or the Limit cut the result short).
+type QueryPage = { Items?: unknown[]; next?: () => Promise<QueryPage> };
+
+export type DynamoPostedOrderRepositoryOptions = {
+  // Items requested per DynamoDB page. Production leaves this unset (DynamoDB's 1MB page);
+  // tests set it small to exercise pagination without writing a megabyte of rows.
+  pageSize?: number;
+};
+
 export class DynamoPostedOrderRepository implements PostedOrderRepository {
   static PARTITION_KEY = 'orderHash';
 
-  static create(documentClient: DynamoDBDocumentClient = postedOrderDocumentClient()): PostedOrderRepository {
+  static create(
+    documentClient: DynamoDBDocumentClient = postedOrderDocumentClient(),
+    options: DynamoPostedOrderRepositoryOptions = {}
+  ): PostedOrderRepository {
     const table = new Table({
       name: DYNAMO_TABLE_NAME.POSTED_ORDERS,
       partitionKey: DynamoPostedOrderRepository.PARTITION_KEY,
@@ -182,10 +195,38 @@ export class DynamoPostedOrderRepository implements PostedOrderRepository {
       autoExecute: true,
     } as const);
 
-    return new DynamoPostedOrderRepository(entity);
+    return new DynamoPostedOrderRepository(entity, options.pageSize);
   }
 
-  private constructor(private readonly entity: Entity) {}
+  private constructor(private readonly entity: Entity, private readonly pageSize?: number) {}
+
+  /**
+   * Drains every page of an index query. A single DynamoDB page is at most 1MB (~1,600 of these
+   * rows), and a high-volume filler completes more than that in 24h — an unpaginated read would
+   * silently drop its most recent orders (deadline-ascending index), exactly the ones the
+   * breaker scores. `max` caps the total; DynamoDB's Limit alone cannot, because a Limit page can
+   * still be cut short by the size cap.
+   */
+  private async queryAll(
+    partitionKey: string,
+    options: Record<string, unknown>,
+    max?: number
+  ): Promise<PostedOrderItem[]> {
+    const pageLimit = this.pageSize ?? max;
+    const items: PostedOrderItem[] = [];
+    let page = (await this.entity.query(partitionKey, {
+      ...options,
+      ...(pageLimit !== undefined && { limit: pageLimit }),
+      execute: true,
+      parse: true,
+    })) as QueryPage;
+    for (;;) {
+      items.push(...((page.Items ?? []) as PostedOrderItem[]));
+      if (max !== undefined && items.length >= max) return items.slice(0, max);
+      if (!page.next) return items;
+      page = await page.next();
+    }
+  }
 
   public async putPostedOrder(record: PostedOrderRecord): Promise<void> {
     const item: PostedOrderItem = {
@@ -202,24 +243,17 @@ export class DynamoPostedOrderRepository implements PostedOrderRepository {
   }
 
   public async getPendingPastDeadline(now: number, limit?: number): Promise<PostedOrderRecord[]> {
-    const { Items } = await this.entity.query(PENDING_INDEX_KEY, {
-      index: POSTED_ORDERS_INDEX.PENDING_DEADLINE,
-      lt: now,
-      ...(limit !== undefined && { limit }),
-      execute: true,
-      parse: true,
-    });
-    return ((Items ?? []) as PostedOrderItem[]).map(toRecord);
+    const items = await this.queryAll(
+      PENDING_INDEX_KEY,
+      { index: POSTED_ORDERS_INDEX.PENDING_DEADLINE, lt: now },
+      limit
+    );
+    return items.map(toRecord);
   }
 
   public async getFillerOrdersByDeadline(filler: string, from: number, to: number): Promise<PostedOrderRecord[]> {
-    const { Items } = await this.entity.query(filler, {
-      index: POSTED_ORDERS_INDEX.FILLER_DEADLINE,
-      between: [from, to],
-      execute: true,
-      parse: true,
-    });
-    return ((Items ?? []) as PostedOrderItem[]).map(toRecord);
+    const items = await this.queryAll(filler, { index: POSTED_ORDERS_INDEX.FILLER_DEADLINE, between: [from, to] });
+    return items.map(toRecord);
   }
 
   public async recordOutcome(orderHash: string, resolution: PostedOrderResolution): Promise<void> {

--- a/test/crons/fade-rate-cron-run.test.ts
+++ b/test/crons/fade-rate-cron-run.test.ts
@@ -1,8 +1,8 @@
 import { createMetricsLogger, MetricsLogger, Unit } from 'aws-embedded-metrics';
 import Logger from 'bunyan';
 
-import { ShadowContext } from '../../lib/cron/fade-rate-shadow';
 import { BASE_BLOCK_SECS, FadeRateCronDeps, runFadeRateCron } from '../../lib/cron/fade-rate-v2';
+import { FadesScoringSource, FadesSourceKind } from '../../lib/cron/fades-sources';
 import { Metric } from '../../lib/entities';
 import {
   BaseTimestampRepository,
@@ -12,9 +12,6 @@ import {
 } from '../../lib/repositories';
 import { MockFillerAddressRepository } from '../../lib/repositories/filler-address-repository';
 import { UNBLOCKED_BLOCK_UNTIL_TIMESTAMP } from '../../lib/repositories/timestamp-repository';
-
-const log = Logger.createLogger({ name: 'test' });
-log.level(Logger.FATAL);
 
 const NOW = 1_800_000_000;
 const FILLER_A = 'https://filler-a.example/rfq';
@@ -29,16 +26,23 @@ const row = (fillerAddress: string, faded: 0 | 1, deadline: number): V2FadesRowT
   deadline,
 });
 
-// Redshift stand-in: the rows the real path scores, plus a call log proving the view is built.
-class FakeFadesRepository {
-  public calls: string[] = [];
-  constructor(private readonly rows: V2FadesRowType[]) {}
-  async createFadesView(): Promise<void> {
-    this.calls.push('createFadesView');
-  }
-  async getFades(): Promise<V2FadesRowType[]> {
-    this.calls.push('getFades');
+// A fades source in either role: canned rows or an error, and a call log with timing order.
+class FakeSource implements FadesScoringSource {
+  public calls = 0;
+  public deadlineMs?: number;
+  constructor(
+    public readonly kind: FadesSourceKind,
+    private readonly rows: V2FadesRowType[] | Error,
+    private readonly order?: string[]
+  ) {}
+  async fetchRows(): Promise<V2FadesRowType[]> {
+    this.calls += 1;
+    this.order?.push(`fetch:${this.kind}`);
+    if (this.rows instanceof Error) throw this.rows;
     return this.rows;
+  }
+  setDeadline(deadlineMs: number): void {
+    this.deadlineMs = deadlineMs;
   }
 }
 
@@ -56,8 +60,12 @@ class FakeWebhookProvider {
 // FillerCBTimestampsV2 stand-in: stored state in, every batch write recorded verbatim.
 class FakeTimestampRepository implements BaseTimestampRepository {
   public writes: ToUpdateTimestampRow[][] = [];
-  constructor(private readonly stored: Map<string, Omit<TimestampRepoRow, 'hash'>> = new Map()) {}
+  constructor(
+    private readonly stored: Map<string, Omit<TimestampRepoRow, 'hash'>> = new Map(),
+    private readonly order?: string[]
+  ) {}
   async updateTimestampsBatch(toUpdate: ToUpdateTimestampRow[]): Promise<void> {
+    this.order?.push('write');
     this.writes.push(toUpdate.map((r) => ({ ...r })));
   }
   async getFillerTimestamps(hash: string): Promise<TimestampRepoRow> {
@@ -80,22 +88,66 @@ class FakeTimestampRepository implements BaseTimestampRepository {
   }
 }
 
-function recordingMetrics(): { metrics: MetricsLogger; calls: Record<string, number[]> } {
+function recordingMetrics(): {
+  metrics: MetricsLogger;
+  calls: Record<string, number[]>;
+  properties: Record<string, unknown>;
+} {
   const metrics = createMetricsLogger();
   const calls: Record<string, number[]> = {};
-  const original = metrics.putMetric.bind(metrics);
+  const properties: Record<string, unknown> = {};
+  const originalPut = metrics.putMetric.bind(metrics);
   metrics.putMetric = (key: string, value: number, unit?: Unit | string) => {
     (calls[key] ??= []).push(value);
-    return original(key, value, unit);
+    return originalPut(key, value, unit);
   };
-  return { metrics, calls };
+  const originalProp = metrics.setProperty.bind(metrics);
+  metrics.setProperty = (key: string, value: unknown) => {
+    properties[key] = value;
+    return originalProp(key, value);
+  };
+  return { metrics, calls, properties };
+}
+
+// A bunyan logger writing to an in-memory ring so tests can inspect record fields.
+function recordingLog(): { log: Logger; records: Record<string, unknown>[] } {
+  const ring = new Logger.RingBuffer({ limit: 500 });
+  const log = Logger.createLogger({ name: 'test', streams: [{ type: 'raw', stream: ring, level: 'info' }] });
+  return { log, records: ring.records as Record<string, unknown>[] };
 }
 
 // Filler A fades 5 of 5 (blocks); filler B fills 5 of 5 (stays clear).
-const ROWS: V2FadesRowType[] = [
+const BLOCKING_ROWS: V2FadesRowType[] = [
   ...Array.from({ length: 5 }, (_, i) => row(ADDR_A, 1, NOW - 100 - i)),
   ...Array.from({ length: 5 }, (_, i) => row(ADDR_B, 0, NOW - 100 - i)),
 ];
+// Everybody clean.
+const CLEAN_ROWS: V2FadesRowType[] = BLOCKING_ROWS.map((r) => ({ ...r, faded: 0 }));
+
+const BLOCK_A_DECISIONS: ToUpdateTimestampRow[] = [
+  {
+    hash: FILLER_A,
+    lastExaminedTimestamp: NOW,
+    blockUntilTimestamp: NOW + BASE_BLOCK_SECS,
+    fadeWindowStart: NOW + BASE_BLOCK_SECS,
+    consecutiveBlocks: 1,
+    consecutiveCleanRuns: 0,
+  },
+  {
+    hash: FILLER_B,
+    lastExaminedTimestamp: NOW,
+    blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+    fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+    consecutiveBlocks: 0,
+    consecutiveCleanRuns: 0,
+  },
+];
+const ALL_CLEAN_DECISIONS: ToUpdateTimestampRow[] = BLOCK_A_DECISIONS.map((d) => ({
+  ...d,
+  blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+  fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
+  consecutiveBlocks: 0,
+}));
 
 async function fillerAddresses(): Promise<MockFillerAddressRepository> {
   const repo = new MockFillerAddressRepository();
@@ -104,200 +156,241 @@ async function fillerAddresses(): Promise<MockFillerAddressRepository> {
   return repo;
 }
 
-async function run(shadow?: FadeRateCronDeps['shadow']) {
-  const fades = new FakeFadesRepository(ROWS);
-  const webhooks = new FakeWebhookProvider([FILLER_A, FILLER_B]);
-  const timestamps = new FakeTimestampRepository();
-  const { metrics, calls } = recordingMetrics();
-  await runFadeRateCron(metrics, {
-    fadesRepository: fades,
+type RunOptions = {
+  primary: FadesSourceKind;
+  redshift: V2FadesRowType[] | Error;
+  orderService?: V2FadesRowType[] | Error | 'absent';
+  addresses?: MockFillerAddressRepository;
+  endpoints?: string[];
+};
+
+async function run(opts: RunOptions) {
+  const order: string[] = [];
+  const redshift = new FakeSource('redshift', opts.redshift, order);
+  const orderService =
+    opts.orderService === 'absent' || opts.orderService === undefined
+      ? undefined
+      : new FakeSource('order-service', opts.orderService, order);
+  const webhooks = new FakeWebhookProvider(opts.endpoints ?? [FILLER_A, FILLER_B]);
+  const timestamps = new FakeTimestampRepository(new Map(), order);
+  const { metrics, calls, properties } = recordingMetrics();
+  const { log, records } = recordingLog();
+  const addresses = opts.addresses ?? (await fillerAddresses());
+  const deps: FadeRateCronDeps = {
+    primary: opts.primary,
+    redshift,
+    orderService,
     webhookProvider: webhooks,
-    fillerAddressRepo: await fillerAddresses(),
+    fillerAddressRepo: addresses,
     timestampDB: timestamps,
-    shadow,
     now: () => NOW,
     log,
-  });
-  return { fades, webhooks, timestamps, calls };
+    shadowCompareSince: 0,
+  };
+  const result = await runFadeRateCron(metrics, deps);
+  return { result, redshift, orderService, webhooks, timestamps, calls, properties, records, order, addresses };
 }
 
 describe('runFadeRateCron', () => {
-  it('runs the Redshift path end to end: builds the view, scores, and writes the decisions', async () => {
-    const { fades, webhooks, timestamps, calls } = await run();
+  describe('primary = order-service (the default)', () => {
+    it('writes the decisions computed from the order-service rows; Redshift only shadows', async () => {
+      const r = await run({ primary: 'order-service', orderService: BLOCKING_ROWS, redshift: CLEAN_ROWS });
 
-    expect(fades.calls).toEqual(['createFadesView', 'getFades']);
-    expect(webhooks.fetched).toBe(1);
-    expect(timestamps.writes).toHaveLength(1);
-    expect(timestamps.writes[0]).toEqual([
-      {
-        hash: FILLER_A,
-        lastExaminedTimestamp: NOW,
-        blockUntilTimestamp: NOW + BASE_BLOCK_SECS,
-        fadeWindowStart: NOW + BASE_BLOCK_SECS,
-        consecutiveBlocks: 1,
-        consecutiveCleanRuns: 0,
-      },
-      {
-        hash: FILLER_B,
-        lastExaminedTimestamp: NOW,
-        blockUntilTimestamp: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-        fadeWindowStart: UNBLOCKED_BLOCK_UNTIL_TIMESTAMP,
-        consecutiveBlocks: 0,
-        consecutiveCleanRuns: 0,
-      },
-    ]);
-    expect(calls[Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS]).toEqual([1]);
-    expect(calls[Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS]).toEqual([1]);
-    expect(calls[Metric.CIRCUIT_BREAKER_V2_FILLERS_EVALUATED]).toEqual([2]);
-  });
-
-  it('the Redshift path writes and metrics are identical with a shadow, without one, and with a throwing shadow', async () => {
-    const baseline = await run();
-    const withShadow = await run(async () => undefined);
-    const withThrowingShadow = await run(async () => {
-      throw new Error('order service exploded');
+      expect(r.timestamps.writes).toEqual([BLOCK_A_DECISIONS]);
+      expect(r.orderService?.calls).toBe(1);
+      expect(r.redshift.calls).toBe(1);
+      expect(r.webhooks.fetched).toBe(1);
+      // The shadow (Redshift) disagreed — it saw no fades — yet nothing it did reached the table.
+      expect(r.calls[Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS]).toEqual([1]);
+      expect(r.calls[Metric.CIRCUIT_BREAKER_V2_ACTIVE_BLOCKS]).toEqual([1]);
+      expect(r.calls[Metric.CIRCUIT_BREAKER_SHADOW_SUCCESS]).toEqual([1]);
+      expect(r.calls[Metric.CIRCUIT_BREAKER_SHADOW_DECISION_DISAGREE]).toEqual([1]);
+      expect(r.calls[Metric.CIRCUIT_BREAKER_SHADOW_WOULD_BLOCK]).toEqual([0]);
     });
-    const withRejectingShadow = await run(() => Promise.reject(new TypeError('classification bug')));
 
-    for (const variant of [withShadow, withThrowingShadow, withRejectingShadow]) {
-      expect(variant.timestamps.writes).toEqual(baseline.timestamps.writes);
-      expect(variant.fades.calls).toEqual(baseline.fades.calls);
-      // Every real-path metric is the same; the throwing variants add exactly the failure marker.
-      const { [Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]: failure, ...realPathMetrics } = variant.calls;
-      expect(realPathMetrics).toEqual(baseline.calls);
-      expect(failure ?? []).toEqual(variant === withShadow ? [] : [1]);
-    }
-    expect(baseline.calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toBeUndefined();
+    it('runs the Redshift shadow only after the primary decisions are written, under a deadline', async () => {
+      const r = await run({ primary: 'order-service', orderService: BLOCKING_ROWS, redshift: CLEAN_ROWS });
+      expect(r.order).toEqual(['fetch:order-service', 'write', 'fetch:redshift']);
+      // The shadow, whichever it is, is handed the budget deadline; the primary never is.
+      expect(r.redshift.deadlineMs).toBeDefined();
+      expect(r.orderService?.deadlineMs).toBeUndefined();
+    });
+
+    it('a Redshift shadow failure (e.g. endpoint not connectable) leaves the primary writes intact and does not fail the cron', async () => {
+      const failing = await run({
+        primary: 'order-service',
+        orderService: BLOCKING_ROWS,
+        redshift: new Error('Redshift endpoint is not connectable'),
+      });
+      const healthy = await run({ primary: 'order-service', orderService: BLOCKING_ROWS, redshift: BLOCKING_ROWS });
+
+      expect(failing.timestamps.writes).toEqual(healthy.timestamps.writes);
+      expect(failing.timestamps.writes).toEqual([BLOCK_A_DECISIONS]);
+      expect(failing.calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toEqual([1]);
+      expect(failing.calls[Metric.CIRCUIT_BREAKER_SHADOW_SUCCESS]).toBeUndefined();
+      // Every primary-path metric is identical between the two runs.
+      const primaryMetrics = (calls: Record<string, number[]>) =>
+        Object.fromEntries(Object.entries(calls).filter(([k]) => !k.startsWith('CIRCUIT_BREAKER_SHADOW_')));
+      expect(primaryMetrics(failing.calls)).toEqual(primaryMetrics(healthy.calls));
+    });
+
+    it('a primary (order-service) failure is a real cron failure: nothing is written', async () => {
+      const timestamps = new FakeTimestampRepository();
+      const { metrics } = recordingMetrics();
+      await expect(
+        runFadeRateCron(metrics, {
+          primary: 'order-service',
+          orderService: new FakeSource('order-service', new Error('order service unavailable')),
+          redshift: new FakeSource('redshift', CLEAN_ROWS),
+          webhookProvider: new FakeWebhookProvider([FILLER_A, FILLER_B]),
+          fillerAddressRepo: await fillerAddresses(),
+          timestampDB: timestamps,
+          now: () => NOW,
+        })
+      ).rejects.toThrow('order service unavailable');
+      expect(timestamps.writes).toEqual([]);
+    });
+
+    it('refuses to run with the order-service primary unavailable rather than silently using Redshift', async () => {
+      const timestamps = new FakeTimestampRepository();
+      const redshift = new FakeSource('redshift', BLOCKING_ROWS);
+      const { metrics } = recordingMetrics();
+      await expect(
+        runFadeRateCron(metrics, {
+          primary: 'order-service',
+          redshift,
+          webhookProvider: new FakeWebhookProvider([FILLER_A, FILLER_B]),
+          fillerAddressRepo: await fillerAddresses(),
+          timestampDB: timestamps,
+          now: () => NOW,
+        })
+      ).rejects.toThrow(/order-service/);
+      expect(redshift.calls).toBe(0);
+      expect(timestamps.writes).toEqual([]);
+    });
   });
 
-  it('resolves fillers by the addresses in the rows and drops mappings to endpoints no longer configured', async () => {
+  describe('primary = redshift (the revert position)', () => {
+    it('writes the decisions computed from the Redshift rows; the order service only shadows', async () => {
+      const r = await run({ primary: 'redshift', redshift: BLOCKING_ROWS, orderService: CLEAN_ROWS });
+
+      expect(r.timestamps.writes).toEqual([BLOCK_A_DECISIONS]);
+      expect(r.order).toEqual(['fetch:redshift', 'write', 'fetch:order-service']);
+      expect(r.orderService?.deadlineMs).toBeDefined();
+      expect(r.calls[Metric.CIRCUIT_BREAKER_SHADOW_SUCCESS]).toEqual([1]);
+      expect(r.calls[Metric.CIRCUIT_BREAKER_SHADOW_DECISION_DISAGREE]).toEqual([1]);
+    });
+
+    it('an order-service shadow failure leaves the Redshift writes intact', async () => {
+      const r = await run({ primary: 'redshift', redshift: BLOCKING_ROWS, orderService: new Error('timeout') });
+      expect(r.timestamps.writes).toEqual([BLOCK_A_DECISIONS]);
+      expect(r.calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toEqual([1]);
+    });
+
+    it('a Redshift primary failure is a real cron failure', async () => {
+      await expect(
+        run({
+          primary: 'redshift',
+          redshift: new Error('Redshift endpoint is not connectable'),
+          orderService: CLEAN_ROWS,
+        })
+      ).rejects.toThrow('not connectable');
+    });
+
+    it('runs without any shadow when the order service is not configured', async () => {
+      const r = await run({ primary: 'redshift', redshift: CLEAN_ROWS, orderService: 'absent' });
+      expect(r.timestamps.writes).toEqual([ALL_CLEAN_DECISIONS]);
+      expect(Object.keys(r.calls).some((k) => k.startsWith('CIRCUIT_BREAKER_SHADOW_'))).toBe(false);
+    });
+  });
+
+  describe('filler attribution', () => {
     const ADDR_C = '0x00000000000000000000000000000000000000C1';
-    const REMOVED_FILLER = 'https://removed.example/rfq';
-    const addresses = await fillerAddresses();
-    await addresses.recordWinningAddress(ADDR_C, REMOVED_FILLER);
-    const rows = [...ROWS, ...Array.from({ length: 5 }, (_, i) => row(ADDR_C, 1, NOW - 100 - i))];
-    const timestamps = new FakeTimestampRepository();
-    const { metrics } = recordingMetrics();
-
-    await runFadeRateCron(metrics, {
-      fadesRepository: new FakeFadesRepository(rows),
-      webhookProvider: new FakeWebhookProvider([FILLER_A, FILLER_B]),
-      fillerAddressRepo: addresses,
-      timestampDB: timestamps,
-      now: () => NOW,
-      log,
-    });
-
-    // exactly the distinct addresses in the rows were looked up (no per-endpoint scan)
-    expect(addresses.requestedAddresses).toEqual([[ADDR_A, ADDR_B, ADDR_C]]);
-    // ADDR_C's filler is not in the webhook config, so its fades bench nobody
-    const written = timestamps.writes.flat().map((w) => w.hash);
-    expect(written).toEqual([FILLER_A, FILLER_B]);
-  });
-
-  it('a throwing shadow does not fail the cron', async () => {
-    await expect(
-      run(async () => {
-        throw new Error('boom');
-      })
-    ).resolves.toBeDefined();
-  });
-
-  it('invokes the shadow only after the real decisions are written, with those decisions and the rows', async () => {
-    const order: string[] = [];
-    let received: ShadowContext | undefined;
-    const fades = new FakeFadesRepository(ROWS);
-    const timestamps = new FakeTimestampRepository();
-    const realWrite = timestamps.updateTimestampsBatch.bind(timestamps);
-    timestamps.updateTimestampsBatch = async (rows) => {
-      order.push('write');
-      return realWrite(rows);
-    };
-    const { metrics } = recordingMetrics();
-
-    await runFadeRateCron(metrics, {
-      fadesRepository: fades,
-      webhookProvider: new FakeWebhookProvider([FILLER_A, FILLER_B]),
-      fillerAddressRepo: await fillerAddresses(),
-      timestampDB: timestamps,
-      shadow: async (ctx) => {
-        order.push('shadow');
-        received = ctx;
-      },
-      now: () => NOW,
-      log,
-    });
-
-    expect(order).toEqual(['write', 'shadow']);
-    expect(received?.redshiftRows).toEqual(ROWS);
-    expect(received?.realUpdates).toEqual(timestamps.writes[0]);
-    expect(received?.now).toBe(NOW);
-    // The scorer the shadow gets is the production scoring closed over the same stored state:
-    // re-scoring the Redshift rows reproduces the real decisions exactly, and scoring a clean
-    // set produces no block — while the write log still shows exactly one real write.
-    expect(await received?.score(ROWS)).toEqual(timestamps.writes[0]);
-    const clean = await received?.score(ROWS.map((r) => ({ ...r, faded: 0 })));
-    expect(clean?.every((r) => r.blockUntilTimestamp === UNBLOCKED_BLOCK_UNTIL_TIMESTAMP)).toBe(true);
-    expect(timestamps.writes).toHaveLength(1);
-  });
-
-  it("the shadow's scorer resolves addresses its rows name that the Redshift rows do not", async () => {
-    // Filler C won only orders Redshift has not loaded yet: its address is absent from ROWS,
-    // so the real run never looked it up. The shadow's rows do carry it, and its 5/5 fades
-    // must produce a block decision for C, not vanish for want of an address mapping.
     const FILLER_C = 'https://filler-c.example/rfq';
-    const ADDR_C = '0x00000000000000000000000000000000000000C1';
-    const addresses = await fillerAddresses();
-    await addresses.recordWinningAddress(ADDR_C, FILLER_C);
-    let received: ShadowContext | undefined;
-    const { metrics } = recordingMetrics();
+    const rowsWithC = (rows: V2FadesRowType[]) => [
+      ...rows,
+      ...Array.from({ length: 5 }, (_, i) => row(ADDR_C, 1, NOW - 100 - i)),
+    ];
 
-    await runFadeRateCron(metrics, {
-      fadesRepository: new FakeFadesRepository(ROWS),
-      webhookProvider: new FakeWebhookProvider([FILLER_A, FILLER_B, FILLER_C]),
-      fillerAddressRepo: addresses,
-      timestampDB: new FakeTimestampRepository(),
-      shadow: async (ctx) => {
-        received = ctx;
-      },
-      now: () => NOW,
-      log,
+    it('resolves fillers by the addresses in the primary rows and drops mappings to endpoints no longer configured', async () => {
+      const addresses = await fillerAddresses();
+      await addresses.recordWinningAddress(ADDR_C, 'https://removed.example/rfq');
+
+      const r = await run({
+        primary: 'order-service',
+        orderService: rowsWithC(BLOCKING_ROWS),
+        redshift: CLEAN_ROWS,
+        addresses,
+      });
+
+      // exactly the distinct addresses in the rows were looked up (no per-endpoint scan)
+      expect(r.addresses.requestedAddresses[0]).toEqual([ADDR_A, ADDR_B, ADDR_C]);
+      // ADDR_C's filler is not in the webhook config, so its fades bench nobody
+      expect(r.timestamps.writes.flat().map((w) => w.hash)).toEqual([FILLER_A, FILLER_B]);
     });
 
-    const shadowRows = [...ROWS, ...Array.from({ length: 5 }, (_, i) => row(ADDR_C, 1, NOW - 100 - i))];
-    const decisions = await received?.score(shadowRows);
-    expect(decisions?.map((d) => d.hash).sort()).toEqual([FILLER_A, FILLER_B, FILLER_C].sort());
-    expect(decisions?.find((d) => d.hash === FILLER_C)?.blockUntilTimestamp).toEqual(NOW + BASE_BLOCK_SECS);
-    // The real run looked up exactly the Redshift addresses; the shadow added exactly the one
-    // it was missing, and re-scoring Redshift rows alone asks for nothing more.
-    await received?.score(ROWS);
-    expect(addresses.requestedAddresses).toEqual([[ADDR_A, ADDR_B], [ADDR_C]]);
+    it("the shadow's scorer resolves addresses its rows name that the primary rows do not", async () => {
+      // A filler whose only orders the primary source has not seen: its address is absent from
+      // the primary rows, so the primary run never looked it up. The shadow's rows do carry it,
+      // and its 5/5 fades must produce a would-block decision, not vanish for want of a mapping.
+      const addresses = await fillerAddresses();
+      await addresses.recordWinningAddress(ADDR_C, FILLER_C);
+
+      const r = await run({
+        primary: 'order-service',
+        orderService: BLOCKING_ROWS,
+        redshift: rowsWithC(BLOCKING_ROWS),
+        addresses,
+        endpoints: [FILLER_A, FILLER_B, FILLER_C],
+      });
+
+      // Primary looked up exactly its own addresses; the shadow added exactly the one it lacked,
+      // once per scoring pass (its rows are scored in full and again above the comparison floor).
+      expect(r.addresses.requestedAddresses).toEqual([[ADDR_A, ADDR_B], [ADDR_C], [ADDR_C]]);
+      const report = r.records.find((rec) => rec.msg === 'fade circuit breaker shadow report') as
+        | { decisionsVsProduction: { onlyShadow: string[] }; wouldBlock: number }
+        | undefined;
+      expect(report?.decisionsVsProduction.onlyShadow).toEqual([FILLER_C]);
+      expect(report?.wouldBlock).toBe(2);
+      // and nothing about C reached the table
+      expect(r.timestamps.writes.flat().map((w) => w.hash)).toEqual([FILLER_A, FILLER_B]);
+    });
   });
 
-  it('the shadow context carries no handle to the timestamp repository', async () => {
-    let received: ShadowContext | undefined;
-    await run(async (ctx) => {
-      received = ctx;
+  describe('the two positions are symmetric', () => {
+    it('the same rows produce the same writes whichever source supplies them', async () => {
+      const viaOrderService = await run({
+        primary: 'order-service',
+        orderService: BLOCKING_ROWS,
+        redshift: CLEAN_ROWS,
+      });
+      const viaRedshift = await run({ primary: 'redshift', redshift: BLOCKING_ROWS, orderService: CLEAN_ROWS });
+      expect(viaOrderService.timestamps.writes).toEqual(viaRedshift.timestamps.writes);
+      expect(viaOrderService.calls[Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS]).toEqual(
+        viaRedshift.calls[Metric.CIRCUIT_BREAKER_V2_NEW_BLOCKS]
+      );
     });
-    expect(Object.keys(received ?? {}).sort()).toEqual(['now', 'realUpdates', 'redshiftRows', 'score']);
   });
 
-  it('skips the write and still runs the shadow when there is nothing to update', async () => {
-    let shadowRan = false;
-    const timestamps = new FakeTimestampRepository();
-    const { metrics } = recordingMetrics();
-    await runFadeRateCron(metrics, {
-      fadesRepository: new FakeFadesRepository([row('0x00000000000000000000000000000000000000C1', 1, NOW - 10)]),
-      webhookProvider: new FakeWebhookProvider([FILLER_A]),
-      fillerAddressRepo: await fillerAddresses(),
-      timestampDB: timestamps,
-      shadow: async () => {
-        shadowRan = true;
-      },
-      now: () => NOW,
-      log,
-    });
-    expect(timestamps.writes).toEqual([]);
-    expect(shadowRan).toBe(true);
+  describe('observability', () => {
+    it.each<FadesSourceKind>(['order-service', 'redshift'])(
+      'tags the run with the primary source: %s',
+      async (primary) => {
+        const r = await run({ primary, orderService: BLOCKING_ROWS, redshift: BLOCKING_ROWS });
+
+        expect(r.properties.fadesSource).toBe(primary);
+        expect(r.calls[Metric.CIRCUIT_BREAKER_PRIMARY_IS_ORDER_SERVICE]).toEqual([primary === 'order-service' ? 1 : 0]);
+        // Every block-decision log line carries the source; the shadow's lines say so too.
+        const blockLines = r.records.filter((rec) => String(rec.msg).startsWith('Blocking filler'));
+        expect(blockLines.length).toBeGreaterThan(0);
+        expect(blockLines.every((rec) => rec.fadesSource === primary && rec.shadow === undefined)).toBe(true);
+        const shadowReport = r.records.find((rec) => rec.msg === 'fade circuit breaker shadow report');
+        expect(shadowReport).toMatchObject({
+          fadesSource: primary,
+          primary,
+          shadow: primary === 'order-service' ? 'redshift' : 'order-service',
+        });
+      }
+    );
   });
 });

--- a/test/crons/fade-rate-shadow.test.ts
+++ b/test/crons/fade-rate-shadow.test.ts
@@ -9,7 +9,8 @@ import {
   SHADOW_TIME_BUDGET_MS,
   ShadowContext,
 } from '../../lib/cron/fade-rate-shadow';
-import { OrderServiceFadesSource } from '../../lib/cron/order-service-fades-source';
+import { FadesScoringSource, FadesSourceKind, orderServiceScoringSource } from '../../lib/cron/fades-sources';
+import { OrderServiceFadesSource, ResolutionSummary } from '../../lib/cron/order-service-fades-source';
 import { Metric } from '../../lib/entities';
 import { MockOrderStatusProvider } from '../../lib/providers/order';
 import { ToUpdateTimestampRow, V2FadesRowType } from '../../lib/repositories';
@@ -162,45 +163,74 @@ describe('fade-rate shadow', () => {
   });
 
   describe('runFadeRateShadow', () => {
-    const emptySource = () =>
-      new OrderServiceFadesSource({
-        postedOrders: new MockPostedOrderRepository(),
-        orderStatus: new MockOrderStatusProvider(),
-        fillerEndpoints: () => [],
-        log,
-        now: () => NOW,
-      });
+    // A shadow source stand-in: canned rows (or an error / a hang), records the deadline it was given.
+    class FakeShadowSource implements FadesScoringSource {
+      public deadlineMs?: number;
+      constructor(
+        public readonly kind: FadesSourceKind,
+        private readonly rows: V2FadesRowType[] | Error | 'hang',
+        private readonly resolution?: ResolutionSummary
+      ) {}
+      fetchRows(): Promise<V2FadesRowType[]> {
+        if (this.rows === 'hang') return new Promise<never>(() => undefined);
+        if (this.rows instanceof Error) return Promise.reject(this.rows);
+        return Promise.resolve(this.rows);
+      }
+      setDeadline(deadlineMs: number): void {
+        this.deadlineMs = deadlineMs;
+      }
+      lastResolution(): ResolutionSummary | undefined {
+        return this.resolution;
+      }
+    }
+    const resolutionSummary = (): ResolutionSummary => ({
+      pendingPastDeadline: 3,
+      batches: 1,
+      failedBatches: 0,
+      skippedBatches: 0,
+      resolved: 3,
+      stillOpen: 0,
+      notFound: 0,
+      unclassifiable: 0,
+      fillsWithoutVerdict: 0,
+      failedWrites: 0,
+      byOutcome: {},
+    });
+
+    // Scorer stand-in: one filler, blocked iff any fade in the rows it is given.
+    const score = async (rows: V2FadesRowType[]) =>
+      rows.length === 0
+        ? []
+        : [
+            update(
+              'fillerA',
+              rows.some((r) => r.faded) ? { blockUntilTimestamp: NOW + 900, consecutiveBlocks: 1 } : {}
+            ),
+          ];
 
     const ctx = (overrides: Partial<ShadowContext> = {}): ShadowContext => ({
-      redshiftRows: [row(ADDR_A, 1, NOW - 100, SINCE + 1), row(ADDR_A, 1, NOW - 50, SINCE - 1)],
+      primary: 'redshift',
+      primaryRows: [row(ADDR_A, 1, NOW - 100, SINCE + 1), row(ADDR_A, 1, NOW - 50, SINCE - 1)],
       realUpdates: [update('fillerA', { blockUntilTimestamp: NOW + 900, consecutiveBlocks: 1 })],
-      // Scorer stand-in: one filler, blocked iff any fade in the rows it is given.
-      score: async (rows) =>
-        rows.length === 0
-          ? []
-          : [
-              update(
-                'fillerA',
-                rows.some((r) => r.faded) ? { blockUntilTimestamp: NOW + 900, consecutiveBlocks: 1 } : {}
-              ),
-            ],
+      score,
       now: NOW,
       ...overrides,
     });
 
     it('emits the comparison metrics and a success marker, and returns the report', async () => {
       const { metrics, calls } = recordingMetrics();
-      // The new side has no rows (nothing in PostedOrders): the shadow scorer emits nothing, so
-      // production's block is "only real"; restricted to the floor the old side has one fade.
-      const report = await runFadeRateShadow(ctx(), { source: emptySource(), log, metrics, compareSince: SINCE });
+      // The shadow (order service) has no rows: its scorer emits nothing, so production's block
+      // is "only real"; restricted to the floor the primary side has one fade.
+      const shadow = new FakeShadowSource('order-service', [], resolutionSummary());
+      const report = await runFadeRateShadow(ctx(), { shadow, log, metrics, compareSince: SINCE });
 
-      expect(report).toBeDefined();
+      expect(report).toMatchObject({ primary: 'redshift', shadow: 'order-service' });
       expect(report?.rows).toMatchObject({ oldRows: 1, newRows: 0, oldFades: 1, newFades: 0, onlyNew: [] });
       expect(report?.rows.onlyOld).toEqual([`${ADDR_A.toLowerCase()}:${NOW - 100}`]);
       expect(report?.decisionsVsProduction).toMatchObject({ agree: 0, disagree: 0, onlyReal: ['fillerA'] });
       expect(report?.decisionsVsRestricted).toMatchObject({ agree: 0, disagree: 0, onlyReal: ['fillerA'] });
       expect(report?.wouldBlock).toBe(0);
-      expect(report?.resolution).toMatchObject({ pendingPastDeadline: 0, resolved: 0 });
+      expect(report?.resolution).toMatchObject({ pendingPastDeadline: 3, resolved: 3 });
 
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_SUCCESS]).toEqual([1]);
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toBeUndefined();
@@ -211,16 +241,51 @@ describe('fade-rate shadow', () => {
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_DECISION_AGREE]).toEqual([0]);
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_DECISION_DISAGREE]).toEqual([0]);
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_WOULD_BLOCK]).toEqual([0]);
-      expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_PENDING_PAST_DEADLINE]).toEqual([0]);
+      expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_PENDING_PAST_DEADLINE]).toEqual([3]);
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_DURATION]).toHaveLength(1);
     });
 
-    it('scores the new rows with the injected production scorer and compares against both baselines', async () => {
-      const { metrics } = recordingMetrics();
-      const source = emptySource();
-      source.getFades = async () => [row(ADDR_A, 1, NOW - 100, SINCE + 1)];
+    it('keeps "old" = Redshift and "new" = order service when the roles are swapped', async () => {
+      const { metrics, calls } = recordingMetrics();
+      const primaryRows = [row(ADDR_A, 0, NOW - 100, SINCE + 1)]; // order-service primary: clean
+      const redshiftShadow = new FakeShadowSource('redshift', [row(ADDR_A, 1, NOW - 100, SINCE + 1)]);
+      const resolution = resolutionSummary();
 
-      const report = await runFadeRateShadow(ctx(), { source, log, metrics, compareSince: SINCE });
+      const report = await runFadeRateShadow(
+        ctx({
+          primary: 'order-service',
+          primaryRows,
+          primaryResolution: resolution,
+          realUpdates: await score(primaryRows),
+        }),
+        { shadow: redshiftShadow, log, metrics, compareSince: SINCE }
+      );
+
+      expect(report).toMatchObject({ primary: 'order-service', shadow: 'redshift' });
+      // Redshift saw a fade the order service did not: reported as an old-side fade.
+      expect(report?.rows).toMatchObject({
+        oldRows: 1,
+        newRows: 1,
+        oldFades: 1,
+        newFades: 0,
+        onlyOld: [],
+        onlyNew: [],
+      });
+      expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_FADES_OLD]).toEqual([1]);
+      expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_FADES_NEW]).toEqual([0]);
+      // Shadow (Redshift) would block, production (order service) did not.
+      expect(report?.decisionsVsProduction).toMatchObject({ agree: 0, disagree: 1 });
+      expect(report?.decisionsVsRestricted).toMatchObject({ agree: 0, disagree: 1 });
+      expect(report?.wouldBlock).toBe(1);
+      // The resolution summary is the primary's (order service) when it is primary.
+      expect(report?.resolution).toBe(resolution);
+    });
+
+    it('scores the shadow rows with the injected production scorer and compares against both baselines', async () => {
+      const { metrics } = recordingMetrics();
+      const shadow = new FakeShadowSource('order-service', [row(ADDR_A, 1, NOW - 100, SINCE + 1)]);
+
+      const report = await runFadeRateShadow(ctx(), { shadow, log, metrics, compareSince: SINCE });
 
       expect(report?.rows).toMatchObject({ oldRows: 1, newRows: 1, onlyOld: [], onlyNew: [] });
       expect(report?.decisionsVsProduction).toMatchObject({ agree: 1, disagree: 0 });
@@ -233,25 +298,40 @@ describe('fade-rate shadow', () => {
       expect(SHADOW_TIME_BUDGET_MS).toBe(60_000);
     });
 
-    it('hands the source a wallclock deadline derived from the budget', async () => {
+    it('hands the shadow source a wallclock deadline derived from the budget', async () => {
       const { metrics } = recordingMetrics();
-      const source = emptySource();
+      const shadow = new FakeShadowSource('order-service', []);
       const before = Date.now();
 
-      await runFadeRateShadow(ctx(), { source, log, metrics, budgetMs: 1234 });
+      await runFadeRateShadow(ctx(), { shadow, log, metrics, budgetMs: 1234 });
 
-      expect(source.deadlineMs).toBeGreaterThanOrEqual(before + 1234);
-      expect(source.deadlineMs).toBeLessThanOrEqual(Date.now() + 1234);
+      expect(shadow.deadlineMs).toBeGreaterThanOrEqual(before + 1234);
+      expect(shadow.deadlineMs).toBeLessThanOrEqual(Date.now() + 1234);
     });
 
-    it('a throwing source is logged and counted as a failure, never thrown', async () => {
-      const { metrics, calls } = recordingMetrics();
-      const source = emptySource();
-      source.getFades = async () => {
-        throw new Error('DynamoDB unavailable');
-      };
+    it('propagates the deadline into a real OrderServiceFadesSource through its adapter', async () => {
+      const { metrics } = recordingMetrics();
+      const source = new OrderServiceFadesSource({
+        postedOrders: new MockPostedOrderRepository(),
+        orderStatus: new MockOrderStatusProvider(),
+        fillerEndpoints: () => [],
+        log,
+        now: () => NOW,
+      });
+      const before = Date.now();
 
-      await expect(runFadeRateShadow(ctx(), { source, log, metrics })).resolves.toBeUndefined();
+      await runFadeRateShadow(ctx(), { shadow: orderServiceScoringSource(source), log, metrics, budgetMs: 500 });
+
+      expect(source.deadlineMs).toBeGreaterThanOrEqual(before + 500);
+    });
+
+    it('a throwing shadow source (e.g. Redshift not connectable) is logged and counted, never thrown', async () => {
+      const { metrics, calls } = recordingMetrics();
+      const shadow = new FakeShadowSource('redshift', new Error('Redshift endpoint is not connectable'));
+
+      await expect(
+        runFadeRateShadow(ctx({ primary: 'order-service' }), { shadow, log, metrics })
+      ).resolves.toBeUndefined();
 
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toEqual([1]);
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_SUCCESS]).toBeUndefined();
@@ -267,17 +347,18 @@ describe('fade-rate shadow', () => {
         },
       });
 
-      await expect(runFadeRateShadow(context, { source: emptySource(), log, metrics })).resolves.toBeUndefined();
+      await expect(
+        runFadeRateShadow(context, { shadow: new FakeShadowSource('order-service', []), log, metrics })
+      ).resolves.toBeUndefined();
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toEqual([1]);
     });
 
-    it('a source that hangs is cut off at the budget and counted as a failure', async () => {
+    it('a shadow source that hangs is cut off at the budget and counted as a failure', async () => {
       const { metrics, calls } = recordingMetrics();
-      const source = emptySource();
-      source.getFades = () => new Promise<never>(() => undefined);
+      const shadow = new FakeShadowSource('redshift', 'hang');
 
       const started = Date.now();
-      await expect(runFadeRateShadow(ctx(), { source, log, metrics, budgetMs: 30 })).resolves.toBeUndefined();
+      await expect(runFadeRateShadow(ctx(), { shadow, log, metrics, budgetMs: 30 })).resolves.toBeUndefined();
 
       expect(Date.now() - started).toBeLessThan(1000);
       expect(calls[Metric.CIRCUIT_BREAKER_SHADOW_FAILURE]).toEqual([1]);

--- a/test/crons/fades-sources.test.ts
+++ b/test/crons/fades-sources.test.ts
@@ -1,0 +1,98 @@
+import Logger from 'bunyan';
+
+import {
+  DEFAULT_FADES_SOURCE,
+  FADES_SOURCE_KINDS,
+  orderServiceScoringSource,
+  parseFadesSource,
+  redshiftScoringSource,
+} from '../../lib/cron/fades-sources';
+import { OrderServiceFadesSource } from '../../lib/cron/order-service-fades-source';
+import { MockOrderStatusProvider } from '../../lib/providers/order';
+import { V2FadesRowType } from '../../lib/repositories';
+import { MockPostedOrderRepository } from '../../lib/repositories/posted-order-repository';
+
+const log = Logger.createLogger({ name: 'test' });
+log.level(Logger.FATAL);
+
+describe('fades sources', () => {
+  describe('parseFadesSource', () => {
+    it('defaults to the order service', () => {
+      expect(DEFAULT_FADES_SOURCE).toBe('order-service');
+      expect(parseFadesSource(undefined)).toBe('order-service');
+      expect(parseFadesSource('')).toBe('order-service');
+    });
+
+    it('accepts both kinds, case- and whitespace-insensitively', () => {
+      expect(FADES_SOURCE_KINDS).toEqual(['order-service', 'redshift']);
+      expect(parseFadesSource('redshift')).toBe('redshift');
+      expect(parseFadesSource(' Redshift ')).toBe('redshift');
+      expect(parseFadesSource('ORDER-SERVICE')).toBe('order-service');
+    });
+
+    it('falls back to the default on an unrecognised value instead of failing the cron', () => {
+      const warnings: unknown[] = [];
+      const warnLog = Logger.createLogger({ name: 'test' });
+      warnLog.level(Logger.FATAL);
+      warnLog.warn = ((...args: unknown[]) => {
+        warnings.push(args);
+        return true;
+      }) as typeof warnLog.warn;
+
+      expect(parseFadesSource('redshfit', warnLog)).toBe('order-service');
+      expect(warnings).toHaveLength(1);
+    });
+  });
+
+  describe('redshiftScoringSource', () => {
+    it('rebuilds the view and then queries it, in that order', async () => {
+      const calls: string[] = [];
+      const rows: V2FadesRowType[] = [{ fillerAddress: '0x1', faded: 1, postTimestamp: 1, deadline: 2 }];
+      const source = redshiftScoringSource({
+        createFadesView: async () => {
+          calls.push('createFadesView');
+        },
+        getFades: async () => {
+          calls.push('getFades');
+          return rows;
+        },
+      });
+
+      expect(source.kind).toBe('redshift');
+      expect(await source.fetchRows()).toEqual(rows);
+      expect(calls).toEqual(['createFadesView', 'getFades']);
+      expect(source.setDeadline).toBeUndefined();
+      expect(source.lastResolution).toBeUndefined();
+    });
+
+    it('propagates a Redshift failure to the caller (the caller decides whether it is fatal)', async () => {
+      const source = redshiftScoringSource({
+        createFadesView: async () => {
+          throw new Error('Redshift endpoint is not connectable');
+        },
+        getFades: async () => [],
+      });
+      await expect(source.fetchRows()).rejects.toThrow('not connectable');
+    });
+  });
+
+  describe('orderServiceScoringSource', () => {
+    it('adapts deadline and resolution summary onto the source', async () => {
+      const inner = new OrderServiceFadesSource({
+        postedOrders: new MockPostedOrderRepository(),
+        orderStatus: new MockOrderStatusProvider(),
+        fillerEndpoints: () => [],
+        log,
+        now: () => 1_800_000_000,
+      });
+      const source = orderServiceScoringSource(inner);
+
+      expect(source.kind).toBe('order-service');
+      expect(source.lastResolution?.()).toBeUndefined();
+      source.setDeadline?.(123_456);
+      expect(inner.deadlineMs).toBe(123_456);
+      expect(await source.fetchRows()).toEqual([]);
+      expect(source.lastResolution?.()).toMatchObject({ pendingPastDeadline: 0, resolved: 0 });
+    });
+  });
+});

--- a/test/crons/order-service-fades-source.test.ts
+++ b/test/crons/order-service-fades-source.test.ts
@@ -124,10 +124,12 @@ describe('OrderServiceFadesSource', () => {
         faded: 1,
       },
       {
-        name: 'V2 filled without fillTimestamp -> unclassifiable',
+        name: 'V2 filled without fillTimestamp -> recorded FILLED, no verdict',
         record: v2(),
         status: status('h', ORDER_STATUS.FILLED, { fillBlock: 1 }),
-        expected: 'unclassifiable',
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
       },
       // Dutch_V3 fills decay by block: fillTimeBlocks = fillBlock - decayStartBlock must be > 0.
       {
@@ -163,16 +165,28 @@ describe('OrderServiceFadesSource', () => {
         faded: 0,
       },
       {
-        name: 'V3 filled without fillBlock -> unclassifiable',
+        name: 'V3 filled without fillBlock -> recorded FILLED, no verdict',
         record: v3(),
         status: status('h', ORDER_STATUS.FILLED, { fillTimestamp: NOW }),
-        expected: 'unclassifiable',
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
       },
       {
-        name: 'V3 record missing decayStartBlock -> unclassifiable',
+        name: 'V3 filled with the order service fillBlock -1 sentinel (fill event unprocessed) -> no verdict, not a clean fill',
+        record: v3(),
+        status: status('h', ORDER_STATUS.FILLED, { fillBlock: -1 }),
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
+      },
+      {
+        name: 'V3 record missing decayStartBlock -> recorded FILLED, no verdict',
         record: v3({ decayStartBlock: undefined }),
         status: status('h', ORDER_STATUS.FILLED, { fillBlock: DECAY_START_BLOCK + 5 }),
-        expected: 'unclassifiable',
+        expected: 'resolved',
+        outcome: PostedOrderOutcome.FILLED,
+        faded: undefined,
       },
       {
         name: 'unknown order type fill -> unclassifiable',
@@ -244,7 +258,10 @@ describe('OrderServiceFadesSource', () => {
         expect(classification.resolution.faded).toBe(faded);
         expect(classification.resolution.orderStatus).toBe(status.orderStatus);
         expect(classification.resolution.resolvedAt).toBe(NOW);
-        expect(classification.resolution.fillBlock).toBe(status.fillBlock);
+        // the -1 sentinel is not real timing and is not persisted as such
+        expect(classification.resolution.fillBlock).toBe(
+          status.fillBlock !== undefined && status.fillBlock >= 0 ? status.fillBlock : undefined
+        );
         expect(classification.resolution.fillTimestamp).toBe(status.fillTimestamp);
       }
     });
@@ -506,13 +523,29 @@ describe('OrderServiceFadesSource', () => {
     });
 
     it('leaves unclassifiable orders pending and counts them', async () => {
-      const [fillNoTiming] = await seed(v3());
-      service.seed(status(fillNoTiming.orderHash, ORDER_STATUS.FILLED));
+      const [weird] = await seed(v3());
+      service.seed(status(weird.orderHash, 'settling'));
 
       const summary = await source.resolvePendingOutcomes(NOW);
 
       expect(summary).toMatchObject({ resolved: 0, unclassifiable: 1 });
-      expect(await repo.getPostedOrder(fillNoTiming.orderHash)).toMatchObject({ outcome: PostedOrderOutcome.PENDING });
+      expect(await repo.getPostedOrder(weird.orderHash)).toMatchObject({ outcome: PostedOrderOutcome.PENDING });
+    });
+
+    it('records a fill without timing as FILLED with no verdict, counts it, and never scores it', async () => {
+      const [sentinel] = await seed(v3({ deadline: NOW - 500 }));
+      service.seed(status(sentinel.orderHash, ORDER_STATUS.FILLED, { fillBlock: -1 }));
+
+      const rows = await source.getFades();
+
+      expect(source.lastResolution).toMatchObject({ resolved: 1, fillsWithoutVerdict: 1, unclassifiable: 0 });
+      const stored = await repo.getPostedOrder(sentinel.orderHash);
+      expect(stored).toMatchObject({ outcome: PostedOrderOutcome.FILLED, orderStatus: 'filled' });
+      expect(stored).not.toHaveProperty('faded');
+      expect(stored).not.toHaveProperty('fillBlock');
+      expect(rows).toEqual([]);
+      // Not re-fetched next run.
+      expect(await repo.getPendingPastDeadline(NOW)).toEqual([]);
     });
 
     it('batches at the order service cap and never exceeds it', async () => {

--- a/test/crons/order-service-fades-source.test.ts
+++ b/test/crons/order-service-fades-source.test.ts
@@ -11,6 +11,7 @@ import {
   buildFadeRows,
   Classification,
   classifyOutcome,
+  DEFAULT_FADE_ROW_POLICY,
   EXCLUDED_TESTNET_CHAIN_IDS,
   FADE_WINDOW_SECS,
   fadedForScoring,
@@ -263,6 +264,37 @@ describe('OrderServiceFadesSource', () => {
           status.fillBlock !== undefined && status.fillBlock >= 0 ? status.fillBlock : undefined
         );
         expect(classification.resolution.fillTimestamp).toBe(status.fillTimestamp);
+      }
+    });
+  });
+
+  describe('terminal-status policy (production parity)', () => {
+    const rowsFor = (record: PostedOrderRecord) => buildFadeRows([record], { now: NOW });
+
+    it('defaults to NOT counting cancelled / insufficient-funds / error as fades', () => {
+      expect(DEFAULT_FADE_ROW_POLICY).toEqual({ countNeverFilledTerminalAsFade: false });
+      for (const s of [ORDER_STATUS.CANCELLED, ORDER_STATUS.INSUFFICIENT_FUNDS, ORDER_STATUS.ERROR]) {
+        expect(rowsFor(resolved(v2(), status('h', s)))).toEqual([]);
+        expect(rowsFor(resolved(v3(), status('h', s)))).toEqual([]);
+      }
+    });
+
+    it('always counts an expiry as a fade, for both order types', () => {
+      for (const policy of [{ countNeverFilledTerminalAsFade: false }, { countNeverFilledTerminalAsFade: true }]) {
+        for (const record of [
+          resolved(v2(), status('h', ORDER_STATUS.EXPIRED)),
+          resolved(v3(), status('h', ORDER_STATUS.EXPIRED)),
+        ]) {
+          expect(buildFadeRows([record], { now: NOW, policy }).map((r) => r.faded)).toEqual([1]);
+        }
+      }
+    });
+
+    it('a fill without timing contributes no row under either policy', () => {
+      for (const policy of [{ countNeverFilledTerminalAsFade: false }, { countNeverFilledTerminalAsFade: true }]) {
+        expect(
+          buildFadeRows([resolved(v3(), status('h', ORDER_STATUS.FILLED, { fillBlock: -1 }))], { now: NOW, policy })
+        ).toEqual([]);
       }
     });
   });

--- a/test/repositories/posted-order-repository.test.ts
+++ b/test/repositories/posted-order-repository.test.ts
@@ -190,4 +190,38 @@ describe('DynamoPostedOrderRepository', () => {
       expect(await repo.getPostedOrder('0xdoesnotexist')).toBeUndefined();
     });
   });
+
+  describe('pagination', () => {
+    // A 2-item page stands in for DynamoDB's 1MB page: production hit this with a filler that
+    // completes >1,600 orders in 24h, whose newest rows fell off the (deadline-ascending) first
+    // page and were silently missing from the fade rows.
+    const paged = DynamoPostedOrderRepository.create(documentClient, { pageSize: 2 });
+    const FILLER_P = 'https://filler-paged.example/rfq';
+    const rows = Array.from({ length: 7 }, (_, i) =>
+      record({ orderHash: `0xp${i}`, filler: FILLER_P, fillerName: 'paged', deadline: NOW - 1_000 + i })
+    );
+
+    beforeAll(async () => {
+      for (const r of rows) await paged.putPostedOrder(r);
+    });
+
+    it('getFillerOrdersByDeadline drains every page', async () => {
+      const got = await paged.getFillerOrdersByDeadline(FILLER_P, NOW - 1_000, NOW - 994);
+      expect(got.map((r) => r.orderHash)).toEqual(rows.map((r) => r.orderHash));
+    });
+
+    it('getPendingPastDeadline drains pages up to the requested limit, oldest first', async () => {
+      const got = await paged.getPendingPastDeadline(NOW - 990, 5);
+      const mine = got.filter((r) => r.filler === FILLER_P);
+      expect(got.length).toBeLessThanOrEqual(5);
+      // Every returned row precedes every omitted one (ascending deadline across pages).
+      const omitted = rows.filter((r) => !mine.some((g) => g.orderHash === r.orderHash));
+      expect(Math.max(...mine.map((r) => r.deadline))).toBeLessThan(Math.min(...omitted.map((r) => r.deadline)));
+    });
+
+    it('getPendingPastDeadline without a limit returns everything across pages', async () => {
+      const got = (await paged.getPendingPastDeadline(NOW - 990)).filter((r) => r.filler === FILLER_P);
+      expect(got).toHaveLength(7);
+    });
+  });
 });


### PR DESCRIPTION
Two commits, reviewable separately. Supersedes #503 (its commit is commit 1 here, rebased).

## Commit 1 — `fix(fades)`: paginate PostedOrders index queries; fills without timing carry no verdict

Two defects found by reading the first days of the #496 shadow.

1. **Unpaginated index reads dropped the newest rows for high-volume fillers.** `getFillerOrdersByDeadline` / `getPendingPastDeadline` read one DynamoDB page (1 MB, on the order of 1,500–1,700 of these rows). A filler that completes more than that in 24 h lost its most recent rows, because the index is deadline-ascending — exactly the rows the breaker scores. Both reads now drain every page; the pending read honours its limit across pages. `pageSize` is a test-only option that exercises the pagination path against DynamoDB Local.
2. **`fillBlock: -1` sentinel scored as a clean fill.** When the order service fails to process a fill event it still marks the order `filled` with `fillBlock: -1`, no `fillTimestamp` and an empty `txHash`. These are now recorded as `FILLED` with **no verdict**: terminal (no re-fetch), excluded from the rows (the Redshift path never sees them either), counted as `fillsWithoutVerdict` in the report.

## Commit 2 — `feat(cron)`: promote the order-service fades source to primary; Redshift becomes the shadow

The breaker's block decisions are now computed from GPA-owned data (PostedOrders + the order service's status and fill timing). The Redshift path is demoted to a shadow. **Nothing is removed**: the Redshift repository, view management and query all stay, and the comparison report keeps running with the roles swapped. No tuning constants change (thresholds, backoff, finality lag are separate decisions).

### The switch and the revert procedure

`FADES_SOURCE` on the fade cron Lambda selects the primary: `order-service` (set explicitly in `cron-stack.ts`) or `redshift`. The other source runs as the shadow.

**Revert** = change that one value to `redshift` in `bin/stacks/cron-stack.ts` and deploy. No code revert; the Redshift path is unchanged and still exercised on every run as the shadow. An unrecognised value logs a warning and uses the default; `order-service` without `ORDER_SERVICE_URL` is a hard cron failure rather than a silent fallback to Redshift.

### Behavior change: expiries count as fades

Orders that reach their deadline unfilled (`expired`) now count as fades. They have **not** counted in production since March 2025: the Redshift path only receives archived rows for `filled` and `cancelled` orders, and the fade SQL's permissioned-token filter drops any order without an archived row, so expiries fell out of the query entirely. The shadow week confirmed it: every persistent disagreement between the two sources was a filler with recent expiries, and the shadow led production on one block by close to an hour. This affects fillers with high expiry rates; the scoring threshold and backoff are unchanged.

### Parity flag

`FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE` (renamed from `FADE_SHADOW_NEVER_FILLED_TERMINAL_AS_FADE`, since it no longer describes a shadow) is set to `false`: cancelled / insufficient-funds / error orders contribute no row, matching what production effectively does today. The earlier default of `true` assumed those were null-fill rows in Redshift; they are not — they never reach `archivedorders` with token columns. `true` would score them as fades; that is a separate decision.

### Isolation, now the other way

The Redshift shadow runs strictly after the primary has written, under the existing 60 s budget, with no handle to the timestamp table. A Redshift failure (connectivity errors have occurred) is logged and counted as `CIRCUIT_BREAKER_SHADOW_FAILURE` and cannot fail the cron or alter the write. A primary failure is a real cron failure, as before.

### Observability

- Every decision log line and EMF record carries `fadesSource`; `CIRCUIT_BREAKER_PRIMARY_IS_ORDER_SERVICE` (1/0) charts the switch position.
- Shadow metrics keep their meaning across the flip: `ROWS_OLD` / `FADES_OLD` are always the Redshift side, `ROWS_NEW` / `FADES_NEW` always the order-service side; `DECISION_AGREE/DISAGREE` compare the shadow's decisions to what was written; the `_RESTRICTED` pair re-scores both sides above the comparison floor (unchanged).
- No dashboard or alarm changes.

### What to watch for the next few days

- `CIRCUIT_BREAKER_PRIMARY_IS_ORDER_SERVICE` = 1 on every run; cron `Errors` = 0.
- `CIRCUIT_BREAKER_SHADOW_FAILURE` (now the Redshift shadow) vs. cron `Errors`: a Redshift outage must appear in the former only.
- `CIRCUIT_BREAKER_SHADOW_DECISION_DISAGREE_RESTRICTED`: expected to be non-zero only while a filler has recent expiries (the Redshift shadow cannot see them); any other disagreement is worth a look.
- `CIRCUIT_BREAKER_SHADOW_ROWS_ONLY_OLD` should stay near zero now that reads are paginated; `_ONLY_NEW` = expiries plus fills without timing.
- Cron `Duration`: primary + shadow should stay well inside the 240 s timeout.
- `CIRCUIT_BREAKER_SHADOW_NOT_FOUND` / `_UNCLASSIFIABLE` at zero; `_STILL_OPEN` small and transient.

## Verification

- `yarn build` ✅ · `yarn test:unit` ✅ 42 suites / 455 tests · `yarn lint` ✅ 0 errors (pre-existing warnings unchanged)
- New/updated tests (fakes, no `jest.mock`): both switch positions; primary writes and shadow does not, in each; Redshift shadow failure leaves the primary's writes and metrics intact; primary failure fails the run with nothing written; unavailable primary refuses to run; source tag on every decision log line and on the EMF properties; parity policy pinned (cancelled / insufficient-funds / error excluded, expiries always fades, no-verdict fills excluded); pagination against DynamoDB Local; sentinel classification.
- `npx cdk synth` vs main, compared semantically: the only delta is the two env vars on the fade cron (`FADES_SOURCE`, `FADES_COUNT_NEVER_FILLED_TERMINAL_AS_FADE`); everything else is asset-hash / deploy-marker noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
