### PR TITLE
refactor: explicit per-request observability Context for the quote handler layer (1/3)

### DIFF
--- a/lib/handlers/hard-quote/handler.ts
+++ b/lib/handlers/hard-quote/handler.ts
@@ -1,7 +1,6 @@
 import { KMSClient } from '@aws-sdk/client-kms';
 import { TradeType } from '@uniswap/sdk-core';
 import { KmsSigner } from '@uniswap/signer';
-import { MetricLoggerUnit } from '@uniswap/smart-order-router';
 import {
   CosignedV2DutchOrder,
   CosignedV3DutchOrder,
@@ -49,7 +48,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     params: APIHandleRequestParams<ContainerInjected, RequestInjected, HardQuoteRequestBody, void>
   ): Promise<ErrorResponse | Response<HardQuoteResponseData>> {
     const {
-      requestInjected: { log, metric },
+      requestInjected: { ctx, log, metric },
       containerInjected: {
         quoters,
         orderServiceProvider,
@@ -59,9 +58,10 @@ export class QuoteHandler extends APIGLambdaHandler<
       },
       requestBody,
     } = params;
+    const { logger, metrics } = ctx;
     const start = Date.now();
 
-    metric.putMetric(Metric.QUOTE_REQUESTED, 1, MetricLoggerUnit.Count);
+    metrics.increment(Metric.QUOTE_REQUESTED);
 
     // QUOTE_LATENCY below fires only on successful order posts (and is alarmed on). The
     // finally makes this metric cover every exit path — no-quote throws, cosigner
@@ -84,12 +84,12 @@ export class QuoteHandler extends APIGLambdaHandler<
 
       // we dont have access to the cosigner key, throw
       if (request.order.info.cosigner !== cosignerAddress) {
-        log.error({ cosignerInReq: request.order.info.cosigner, expected: cosignerAddress }, 'Unknown cosigner');
+        logger.error({ cosignerInReq: request.order.info.cosigner, expected: cosignerAddress }, 'Unknown cosigner');
         throw new UnknownOrderCosignerError();
       }
       // Instead of decoding the order, we rely on frontend passing in the requestId
       //   from indicative quote
-      log.info({
+      logger.info({
         eventType: 'HardRequest',
         body: {
           requestId: request.requestId,
@@ -110,6 +110,9 @@ export class QuoteHandler extends APIGLambdaHandler<
 
       let bestQuote;
       if (!requestBody.forceOpenOrder) {
+        // The quote path below the handler still takes the bunyan logger and the
+        // smart-order-router IMetric positionally (moved to ctx in a later PR); both are the
+        // same objects ctx wraps, so its logs and metrics are unchanged.
         const result = await getBestQuote(quoters, request.toQuoteRequest(), log, metric, provider, RESPONSE_LOG_TYPE);
         bestQuote = result.bestQuote;
         if (!bestQuote && !requestBody.allowNoQuote) {
@@ -122,17 +125,17 @@ export class QuoteHandler extends APIGLambdaHandler<
       let cosignerData: CosignerData | V3CosignerData;
       if (bestQuote) {
         cosignerData = await getCosignerData(request, bestQuote, orderType, provider);
-        log.info({ bestQuote: bestQuote }, 'bestQuote');
+        logger.info({ bestQuote: bestQuote }, 'bestQuote');
       } else {
         cosignerData = await getDefaultCosignerData(request, orderType, provider);
-        log.info({ cosignerData: cosignerData }, 'open order with default cosignerData');
+        logger.info({ cosignerData: cosignerData }, 'open order with default cosignerData');
       }
 
       const cosignedOrder = await createCosignedOrder(cosigner, request, cosignerData);
       // if no quote and creating open order, create random new quoteId
       const postedQuoteId = bestQuote?.quoteId ?? request.quoteId ?? request.requestId;
       try {
-        metric.putMetric(Metric.QUOTE_POST_ATTEMPT, 1, MetricLoggerUnit.Count);
+        metrics.increment(Metric.QUOTE_POST_ATTEMPT);
         const response = await orderServiceProvider.postOrder({
           order: cosignedOrder,
           signature: request.innerSig,
@@ -140,7 +143,7 @@ export class QuoteHandler extends APIGLambdaHandler<
           requestId: request.requestId,
         });
         if (response.statusCode == 200 || response.statusCode == 201) {
-          metric.putMetric(Metric.QUOTE_200, 1, MetricLoggerUnit.Count);
+          metrics.increment(Metric.QUOTE_200);
           // 200 and 201 (the latter also covers a post whose timeout was reconciled as
           // accepted) are the only confirmed posts, so this is the only place the
           // fade-breaker bookkeeping rows are written: the PostedOrders row and, for the
@@ -154,15 +157,14 @@ export class QuoteHandler extends APIGLambdaHandler<
             quote: bestQuote ?? undefined,
             quoteId: postedQuoteId,
             requestId: request.requestId,
-            log,
-            metric,
+            ctx,
           });
-          metric.putMetric(Metric.QUOTE_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+          metrics.histogram(Metric.QUOTE_LATENCY, Date.now() - start);
           const hardResponse = createHardQuoteResponse(request, cosignedOrder);
           if (!bestQuote) {
             // The RFQ responses are logged in getBestQuote()
             // we log the Open Orders here
-            log.info({
+            logger.info({
               eventType: RESPONSE_LOG_TYPE,
               body: {
                 ...hardResponse.toLog(),
@@ -176,11 +178,11 @@ export class QuoteHandler extends APIGLambdaHandler<
           };
         } else {
           const error = response as ErrorResponse;
-          log.error({ error: error }, 'Error posting order');
+          logger.error({ error: error }, 'Error posting order');
 
           // user error should not be alerted on
           if (error.detail != POST_ORDER_ERROR_REASON.INSUFFICIENT_FUNDS) {
-            metric.putMetric(Metric.QUOTE_POST_ERROR, 1, MetricLoggerUnit.Count);
+            metrics.increment(Metric.QUOTE_POST_ERROR);
           }
           // Only a 4xx from the order service is a genuine rejection of the
           // order. Anything else (timeouts, 5xx) is indeterminate — the order
@@ -188,13 +190,13 @@ export class QuoteHandler extends APIGLambdaHandler<
           // rewriting it to 400 makes clients treat a live, fillable order as
           // rejected.
           if (error.statusCode >= 400 && error.statusCode < 500) {
-            metric.putMetric(Metric.QUOTE_400, 1, MetricLoggerUnit.Count);
+            metrics.increment(Metric.QUOTE_400);
             return {
               ...error,
               statusCode: 400,
             };
           }
-          metric.putMetric(Metric.QUOTE_500, 1, MetricLoggerUnit.Count);
+          metrics.increment(Metric.QUOTE_500);
           return {
             ...error,
             statusCode: 500,
@@ -204,7 +206,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         throw new OrderPostError((e as Error).message);
       }
     } finally {
-      metric.putMetric(Metric.QUOTE_E2E_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+      metrics.histogram(Metric.QUOTE_E2E_LATENCY, Date.now() - start);
     }
   }
 

--- a/lib/handlers/hard-quote/posted-order-recorder.ts
+++ b/lib/handlers/hard-quote/posted-order-recorder.ts
@@ -1,11 +1,10 @@
-import { IMetric, MetricLoggerUnit } from '@uniswap/smart-order-router';
 import { CosignedV2DutchOrder, CosignedV3DutchOrder, OrderType } from '@uniswap/uniswapx-sdk';
-import Logger from 'bunyan';
 import { ethers } from 'ethers';
 import { getAddress } from 'ethers/lib/utils';
 
 import { Metric } from '../../entities/aws-metrics-logger';
 import { QuoteResponse } from '../../entities/QuoteResponse';
+import { Context } from '../../observability';
 import { FillerAddressRepository } from '../../repositories/filler-address-repository';
 import {
   PostedOrderOutcome,
@@ -34,9 +33,10 @@ export interface RecordPostedOrderArgs {
   // The quoteId actually sent to the order service (may differ from quote.quoteId only when
   // there was no quote, in which case nothing is recorded anyway).
   quoteId: string;
+  // The order's requestId (from the request body, echoed in the row), not ctx.requestId (the
+  // Lambda invocation id).
   requestId: string;
-  log: Logger;
-  metric: IMetric;
+  ctx: Context;
   timeoutMs?: number;
 }
 
@@ -100,7 +100,8 @@ export function buildPostedOrderRecord(args: BuildPostedOrderRecordArgs): Posted
  * to inspect the result.
  */
 export async function recordPostedOrder(args: RecordPostedOrderArgs): Promise<void> {
-  const { repository, fillerAddressRepository, order, quote, quoteId, requestId, log, metric } = args;
+  const { repository, fillerAddressRepository, order, quote, quoteId, requestId, ctx } = args;
+  const { logger, metrics } = ctx;
   const timeoutMs = args.timeoutMs ?? POSTED_ORDER_WRITE_TIMEOUT_MS;
 
   if (!quote || !exclusiveFillerOf(order)) {
@@ -124,15 +125,15 @@ export async function recordPostedOrder(args: RecordPostedOrderArgs): Promise<vo
       ),
     ]);
     if (posted.status === 'fulfilled') {
-      metric.putMetric(Metric.POSTED_ORDER_RECORDED, 1, MetricLoggerUnit.Count);
-      log.info({ orderHash, filler: record.filler, fillerAddress: record.fillerAddress }, 'Recorded posted order');
+      metrics.increment(Metric.POSTED_ORDER_RECORDED);
+      logger.info({ orderHash, filler: record.filler, fillerAddress: record.fillerAddress }, 'Recorded posted order');
     } else {
-      metric.putMetric(Metric.POSTED_ORDER_RECORD_FAILED, 1, MetricLoggerUnit.Count);
-      log.error({ orderHash, error: errorMessage(posted.reason) }, 'Failed to record posted order');
+      metrics.increment(Metric.POSTED_ORDER_RECORD_FAILED);
+      logger.error({ orderHash, error: errorMessage(posted.reason) }, 'Failed to record posted order');
     }
     if (attributed.status === 'rejected') {
-      metric.putMetric(Metric.FILLER_ADDRESS_RECORD_FAILED, 1, MetricLoggerUnit.Count);
-      log.warn(
+      metrics.increment(Metric.FILLER_ADDRESS_RECORD_FAILED);
+      logger.warn(
         {
           orderHash,
           filler: record.filler,
@@ -144,8 +145,8 @@ export async function recordPostedOrder(args: RecordPostedOrderArgs): Promise<vo
     } else if (attributed.value.outcome === 'owned_by_other') {
       // The write itself succeeded in reaching DynamoDB; the address stays with its first
       // owner, so this filler's fades on it bench nobody until that row expires or is deleted.
-      metric.putMetric(Metric.FILLER_ADDRESS_CLAIM_REJECTED, 1, MetricLoggerUnit.Count);
-      log.warn(
+      metrics.increment(Metric.FILLER_ADDRESS_CLAIM_REJECTED);
+      logger.warn(
         {
           orderHash,
           filler: record.filler,
@@ -157,10 +158,10 @@ export async function recordPostedOrder(args: RecordPostedOrderArgs): Promise<vo
     }
   } catch (e) {
     // Only buildPostedOrderRecord can throw here; the writes are settled above.
-    metric.putMetric(Metric.POSTED_ORDER_RECORD_FAILED, 1, MetricLoggerUnit.Count);
-    log.error({ orderHash, error: errorMessage(e) }, 'Failed to record posted order');
+    metrics.increment(Metric.POSTED_ORDER_RECORD_FAILED);
+    logger.error({ orderHash, error: errorMessage(e) }, 'Failed to record posted order');
   } finally {
-    metric.putMetric(Metric.POSTED_ORDER_RECORD_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+    metrics.histogram(Metric.POSTED_ORDER_RECORD_LATENCY, Date.now() - start);
   }
 }
 

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -1,5 +1,4 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { MetricLoggerUnit } from '@uniswap/smart-order-router';
 import Joi from 'joi';
 
 import { Metric, QuoteRequest } from '../../entities';
@@ -27,13 +26,14 @@ export class QuoteHandler extends APIGLambdaHandler<
     params: APIHandleRequestParams<ContainerInjected, RequestInjected, PostQuoteRequestBody, void>
   ): Promise<ErrorResponse | Response<PostQuoteResponseWithAllQuotes>> {
     const {
-      requestInjected: { log, metric },
+      requestInjected: { ctx, log, metric },
       requestBody,
       containerInjected: { quoters, chainIdRpcMap },
     } = params;
+    const { logger, metrics } = ctx;
     const start = Date.now();
 
-    metric.putMetric(Metric.QUOTE_REQUESTED, 1, MetricLoggerUnit.Count);
+    metrics.increment(Metric.QUOTE_REQUESTED);
 
     // QUOTE_LATENCY below fires only on 200s (and is alarmed on), so it cannot see slow
     // 404s — which take the full webhook fan-out just like successes. The finally makes
@@ -42,7 +42,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       const provider = chainIdRpcMap.get(requestBody.tokenInChainId);
 
       const request = QuoteRequest.fromRequestBody(requestBody);
-      log.info({
+      logger.info({
         eventType: 'QuoteRequest',
         body: {
           requestId: request.requestId,
@@ -59,16 +59,19 @@ export class QuoteHandler extends APIGLambdaHandler<
         },
       });
 
+      // The quote path below the handler still takes the bunyan logger and the
+      // smart-order-router IMetric positionally (moved to ctx in a later PR); both are the
+      // same objects ctx wraps, so its logs and metrics are unchanged.
       const { bestQuote, allQuotes } = await getBestQuote(quoters, request, log, metric, provider);
       if (!bestQuote) {
-        metric.putMetric(Metric.QUOTE_404, 1, MetricLoggerUnit.Count);
+        metrics.increment(Metric.QUOTE_404);
         throw new NoQuotesAvailable();
       }
 
-      log.info({ bestQuote: bestQuote }, 'bestQuote');
+      logger.info({ bestQuote: bestQuote }, 'bestQuote');
 
-      metric.putMetric(Metric.QUOTE_200, 1, MetricLoggerUnit.Count);
-      metric.putMetric(Metric.QUOTE_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+      metrics.increment(Metric.QUOTE_200);
+      metrics.histogram(Metric.QUOTE_LATENCY, Date.now() - start);
       return {
         statusCode: 200,
         body: {
@@ -77,7 +80,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         },
       };
     } finally {
-      metric.putMetric(Metric.QUOTE_E2E_LATENCY, Date.now() - start, MetricLoggerUnit.Milliseconds);
+      metrics.histogram(Metric.QUOTE_E2E_LATENCY, Date.now() - start);
     }
   }
 

--- a/lib/handlers/shared/quote-injector.ts
+++ b/lib/handlers/shared/quote-injector.ts
@@ -1,11 +1,12 @@
 import { IMetric, setGlobalLogger, setGlobalMetric } from '@uniswap/smart-order-router';
 import { MetricsLogger } from 'aws-embedded-metrics';
-import { Context } from 'aws-lambda';
+import { Context as LambdaContext } from 'aws-lambda';
 import { default as bunyan, default as Logger } from 'bunyan';
 
 import { ethers } from 'ethers';
 import { BETA_S3_KEY, PRODUCTION_S3_KEY, RPC_HEADERS, WEBHOOK_CONFIG_BUCKET } from '../../constants';
 import { AWSMetricsLogger } from '../../entities/aws-metrics-logger';
+import { Context, EmfMetrics } from '../../observability';
 import { S3WebhookConfigurationProvider } from '../../providers';
 import { FirehoseLogger } from '../../providers/analytics';
 import { DynamoCircuitBreakerConfigurationProvider } from '../../providers/circuit-breaker/dynamo';
@@ -23,7 +24,12 @@ export interface BaseQuoteContainerInjected {
 
 /** Per-request state shared by both quote Lambdas. */
 export interface BaseQuoteRequestInjected extends ApiRInj {
+  // Still consumed by the quote path (getBestQuote and below), which is moved to `ctx` in a
+  // later PR; the handlers themselves no longer read it.
   metric: IMetric;
+  // The explicit per-request logger/metrics the handler layer uses. Same underlying bunyan
+  // child and MetricsLogger as `log`/`metric`, so nothing is emitted twice.
+  ctx: Context;
 }
 
 /**
@@ -98,13 +104,20 @@ export function buildQuoteContainerInjected(log: Logger, stage: string | undefin
  * argument would make easy to swap silently.
  *
  * The call order is load-bearing: `setDimensions` REPLACES the dimension-set list while
- * `putDimensions` APPENDS one, so the per-chain set must be added second. `setGlobalMetric`
- * must run because WebhookQuoter emits every RFQ_* metric through the smart-order-router
- * module global rather than the injected IMetric.
+ * `putDimensions` APPENDS one, so the per-chain set must be added second.
+ *
+ * Two views of the same request-scoped state are returned, deliberately:
+ * - `ctx` is the explicit per-request Context the handler layer reads. It is the seam for
+ *   the concurrent (ECS) runtime, where a module global holding request state is a
+ *   cross-request leak.
+ * - `setGlobalLogger`/`setGlobalMetric` must still run because WebhookQuoter and the S3
+ *   webhook config provider read the smart-order-router module globals, and getBestQuote
+ *   takes the bunyan logger and IMetric positionally. Those consumers move to `ctx` in the
+ *   follow-up PRs; only then do the globals go.
  */
 export function buildQuoteRequestInjected<ReqBody extends { tokenInChainId: number }>(params: {
   requestBody: ReqBody;
-  context: Context;
+  context: LambdaContext;
   log: Logger;
   metricsLogger: MetricsLogger;
   metricDimension: Record<string, string>;
@@ -135,9 +148,18 @@ export function buildQuoteRequestInjected<ReqBody extends { tokenInChainId: numb
   const metric = new AWSMetricsLogger(metricsLogger);
   setGlobalMetric(metric);
 
+  // Same child logger and the same, already-dimensioned MetricsLogger as the globals above:
+  // a handler metric lands in the same EMF blob under the same dimension sets as before.
+  const ctx: Context = {
+    logger: log,
+    metrics: new EmfMetrics(metricsLogger, log),
+    requestId,
+  };
+
   return {
     log,
     metric,
     requestId,
+    ctx,
   };
 }

--- a/lib/observability/context.ts
+++ b/lib/observability/context.ts
@@ -1,0 +1,17 @@
+import { Logger } from './logger';
+import { Metrics } from './metrics';
+
+/**
+ * Per-request observability handles, passed explicitly instead of read from module globals.
+ * A module global holding request-scoped state is safe only while one container serves one
+ * request at a time (Lambda); on a concurrent runtime (ECS) it is a cross-request leak. Field
+ * names match the monorepo's ctx so handlers port without renames.
+ *
+ * `requestId` is the Lambda invocation id (context.awsRequestId), the value already bound onto
+ * `logger` — not the client-supplied requestId in a quote body.
+ */
+export interface Context {
+  logger: Logger;
+  metrics: Metrics;
+  requestId: string;
+}

--- a/lib/observability/emf-metrics.ts
+++ b/lib/observability/emf-metrics.ts
@@ -1,0 +1,45 @@
+import { MetricsLogger, Unit } from 'aws-embedded-metrics';
+
+import { Logger } from './logger';
+import { Metrics, MetricTags } from './metrics';
+
+/**
+ * Metrics over the request's existing aws-embedded-metrics logger.
+ *
+ * Delegation, not a new sink: the MetricsLogger passed in is the one the injector has already
+ * configured (namespace, the Service / Service+ChainId / dimensionless dimension sets), so a
+ * metric emitted here lands in the same EMF blob, under the same dimension sets, as one emitted
+ * through the smart-order-router global — and every (name, value, unit) tuple is the one the
+ * handlers emitted before the switch: increment -> Count, histogram -> Milliseconds,
+ * gauge -> None.
+ *
+ * Tags are accepted and dropped. EMF has no per-metric tags: dimensions are the injector's and
+ * out of scope here, and EMF properties are per-blob, so two metrics in one request carrying
+ * different `status` tags would overwrite each other. The StatsD sink honours them.
+ *
+ * Never throws. aws-embedded-metrics validates on putMetric (non-finite value, bad name or
+ * unit) and today that exception surfaces as a 500 on the quote; here it is logged and dropped.
+ */
+export class EmfMetrics implements Metrics {
+  constructor(private readonly emf: MetricsLogger, private readonly logger: Logger) {}
+
+  public increment(name: string, value = 1, _tags?: MetricTags): void {
+    this.put(name, value, Unit.Count);
+  }
+
+  public gauge(name: string, value: number, _tags?: MetricTags): void {
+    this.put(name, value, Unit.None);
+  }
+
+  public histogram(name: string, value: number, _tags?: MetricTags): void {
+    this.put(name, value, Unit.Milliseconds);
+  }
+
+  private put(name: string, value: number, unit: Unit): void {
+    try {
+      this.emf.putMetric(name, value, unit);
+    } catch (err) {
+      this.logger.warn({ err, metric: name, value, unit }, 'Dropped metric rejected by aws-embedded-metrics');
+    }
+  }
+}

--- a/lib/observability/index.ts
+++ b/lib/observability/index.ts
@@ -1,0 +1,4 @@
+export * from './context';
+export * from './emf-metrics';
+export * from './logger';
+export * from './metrics';

--- a/lib/observability/logger.ts
+++ b/lib/observability/logger.ts
@@ -1,0 +1,25 @@
+/**
+ * The two call shapes bunyan and pino share: a message with format args, or a fields object
+ * with an optional message. Bunyan's overload set is a superset of this, so the bunyan logger
+ * the injector builds satisfies the type structurally, with no adapter.
+ */
+export interface LogFn {
+  (msg: string, ...args: unknown[]): void;
+  (fields: object, msg?: string, ...args: unknown[]): void;
+}
+
+/**
+ * The logging surface the request path is allowed to depend on: the level methods and
+ * `child`, i.e. the intersection of bunyan and pino. Everything else on the concrete logger
+ * (level(), streams, serializers) belongs to the injector that creates it.
+ */
+export interface Logger {
+  trace: LogFn;
+  debug: LogFn;
+  info: LogFn;
+  warn: LogFn;
+  error: LogFn;
+  fatal: LogFn;
+  /** A logger that adds `bindings` to every line it, and its own children, emit. */
+  child(bindings: Record<string, unknown>): Logger;
+}

--- a/lib/observability/metrics.ts
+++ b/lib/observability/metrics.ts
@@ -1,0 +1,44 @@
+/** Outcome tag, reserved so success/failure is spelled one way across every metric. */
+export type MetricStatus = 'success' | 'failure';
+
+/**
+ * Why a `failure` fired. A closed set — extend the enum rather than passing an ad-hoc string —
+ * so a per-reason breakdown stays enumerable on a dashboard. Grounded in the request path's
+ * existing failure exits: no RFQ quote came back; the swapper's order failed validation
+ * (unknown cosigner, deadline too close); a dependency timed out; a dependency refused the
+ * request (order-service 4xx, a FillerAddress claim owned by another endpoint); a dependency
+ * failed (order-service 5xx, a DynamoDB error).
+ */
+export enum MetricReason {
+  NoQuotes = 'no_quotes',
+  Validation = 'validation',
+  Timeout = 'timeout',
+  Rejected = 'rejected',
+  Upstream = 'upstream',
+}
+
+/**
+ * StatsD/Datadog-style tags. `status` and `reason` are reserved with fixed vocabularies; any
+ * other key is free-form. The EMF adapter drops tags (see EmfMetrics for why); the StatsD sink
+ * that replaces it on ECS honours them.
+ */
+export interface MetricTags {
+  status?: MetricStatus;
+  reason?: MetricReason;
+  [tag: string]: string | undefined;
+}
+
+/**
+ * The metrics surface the request path depends on, shaped like a StatsD/Datadog client so the
+ * sink can change without touching call sites. The three kinds are exactly the EMF units the
+ * handlers emit today (see EmfMetrics): increment -> Count, histogram -> Milliseconds,
+ * gauge -> None.
+ */
+export interface Metrics {
+  /** Count an occurrence; `value` defaults to 1. */
+  increment(name: string, value?: number, tags?: MetricTags): void;
+  /** Record a point-in-time level (unitless). */
+  gauge(name: string, value: number, tags?: MetricTags): void;
+  /** Record a duration, in milliseconds. */
+  histogram(name: string, value: number, tags?: MetricTags): void;
+}

--- a/test/fakes/fake-logger.ts
+++ b/test/fakes/fake-logger.ts
@@ -1,0 +1,63 @@
+import { Logger } from '../../lib/observability';
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+export interface LogRecord {
+  level: LogLevel;
+  /** Bindings accumulated through child(), root first. */
+  bindings: Record<string, unknown>;
+  /** The fields object of a `(fields, msg)` call; `{}` for a bare `(msg)` call. */
+  fields: Record<string, unknown>;
+  msg: string | undefined;
+  args: unknown[];
+}
+
+/**
+ * In-memory Logger that records every line. Children share the root's `records` array, so a
+ * test holding the root sees lines emitted through any child — the way one bunyan stream would.
+ */
+export class FakeLogger implements Logger {
+  public readonly records: LogRecord[];
+
+  constructor(public readonly bindings: Record<string, unknown> = {}, records: LogRecord[] = []) {
+    this.records = records;
+  }
+
+  public trace = this.at('trace');
+  public debug = this.at('debug');
+  public info = this.at('info');
+  public warn = this.at('warn');
+  public error = this.at('error');
+  public fatal = this.at('fatal');
+
+  public child(bindings: Record<string, unknown>): FakeLogger {
+    return new FakeLogger({ ...this.bindings, ...bindings }, this.records);
+  }
+
+  /** Records at `level`, in emission order. */
+  public atLevel(level: LogLevel): LogRecord[] {
+    return this.records.filter((r) => r.level === level);
+  }
+
+  public reset(): void {
+    this.records.length = 0;
+  }
+
+  private at(level: LogLevel) {
+    return (first: string | object, ...rest: unknown[]): void => {
+      if (typeof first === 'string') {
+        this.records.push({ level, bindings: this.bindings, fields: {}, msg: first, args: rest });
+        return;
+      }
+      const [msg, ...args] = rest;
+      const hasMsg = typeof msg === 'string';
+      this.records.push({
+        level,
+        bindings: this.bindings,
+        fields: first as Record<string, unknown>,
+        msg: hasMsg ? msg : undefined,
+        args: hasMsg ? args : rest,
+      });
+    };
+  }
+}

--- a/test/fakes/fake-metrics.ts
+++ b/test/fakes/fake-metrics.ts
@@ -1,0 +1,46 @@
+import { Metrics, MetricTags } from '../../lib/observability';
+
+export type MetricKind = 'increment' | 'gauge' | 'histogram';
+
+export interface RecordedMetric {
+  kind: MetricKind;
+  name: string;
+  value: number;
+  tags: MetricTags | undefined;
+}
+
+/** In-memory Metrics that records every call, for asserting on what a code path emitted. */
+export class FakeMetrics implements Metrics {
+  public readonly calls: RecordedMetric[] = [];
+
+  public increment(name: string, value = 1, tags?: MetricTags): void {
+    this.calls.push({ kind: 'increment', name, value, tags });
+  }
+
+  public gauge(name: string, value: number, tags?: MetricTags): void {
+    this.calls.push({ kind: 'gauge', name, value, tags });
+  }
+
+  public histogram(name: string, value: number, tags?: MetricTags): void {
+    this.calls.push({ kind: 'histogram', name, value, tags });
+  }
+
+  /** Number of calls, of any kind, that emitted `name`. */
+  public count(name: string): number {
+    return this.calls.filter((c) => c.name === name).length;
+  }
+
+  /** Values emitted under `name`, in emission order. */
+  public values(name: string): number[] {
+    return this.calls.filter((c) => c.name === name).map((c) => c.value);
+  }
+
+  /** Distinct metric names, in first-emission order. */
+  public names(): string[] {
+    return [...new Set(this.calls.map((c) => c.name))];
+  }
+
+  public reset(): void {
+    this.calls.length = 0;
+  }
+}

--- a/test/fakes/index.ts
+++ b/test/fakes/index.ts
@@ -1,0 +1,19 @@
+import { Context } from '../../lib/observability';
+import { FakeLogger } from './fake-logger';
+import { FakeMetrics } from './fake-metrics';
+
+export * from './fake-logger';
+export * from './fake-metrics';
+
+export interface FakeContext {
+  ctx: Context;
+  logger: FakeLogger;
+  metrics: FakeMetrics;
+}
+
+/** A Context over fresh fakes, plus typed handles to them for assertions. */
+export function fakeContext(requestId = 'test-request-id'): FakeContext {
+  const logger = new FakeLogger({ requestId });
+  const metrics = new FakeMetrics();
+  return { ctx: { logger, metrics, requestId }, logger, metrics };
+}

--- a/test/handlers/hard-quote/handler.test.ts
+++ b/test/handlers/hard-quote/handler.test.ts
@@ -8,7 +8,7 @@ import { default as Logger } from 'bunyan';
 import { BigNumber, ethers, Wallet } from 'ethers';
 
 import { KmsSigner } from '@uniswap/signer';
-import { HardQuoteRequest, QuoteResponse, QuoteResponseData } from '../../../lib/entities';
+import { HardQuoteRequest, Metric, QuoteResponse, QuoteResponseData } from '../../../lib/entities';
 import { AWSMetricsLogger } from '../../../lib/entities/aws-metrics-logger';
 import { ApiInjector } from '../../../lib/handlers/base/api-handler';
 import {
@@ -30,6 +30,7 @@ import {
   PostedOrderOutcome,
   PostedOrderRepository,
 } from '../../../lib/repositories/posted-order-repository';
+import { fakeContext } from '../../fakes';
 import { getOrder } from '../../fixtures/hard-quote';
 
 jest.mock('axios');
@@ -68,12 +69,14 @@ describe('Quote handler', () => {
   (KMSClient as jest.Mock).mockImplementation(() => jest.fn());
 
   // Creating mocks for all the handler dependencies.
+  const fakes = fakeContext('test');
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
         log: logger,
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 
@@ -129,6 +132,9 @@ describe('Quote handler', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    // One ctx is shared across the describe; every test starts from empty recordings.
+    fakes.metrics.reset();
+    fakes.logger.reset();
   });
 
   it('Simple request and response', async () => {
@@ -152,6 +158,17 @@ describe('Quote handler', () => {
     expect(cosignedOrder.info.cosignerData.inputOverride).toEqual(BigNumber.from(0));
     expect(cosignedOrder.info.cosignerData.outputOverrides.length).toEqual(1);
     expect(cosignedOrder.info.cosignerData.outputOverrides[0]).toEqual(BigNumber.from(0));
+
+    // The handler's own metrics go through ctx.metrics: the same names the IMetric path emitted,
+    // counts as increments and latencies as histograms, in the same order. No exclusivity was
+    // granted, so the recorder emitted nothing.
+    expect(fakes.metrics.calls.map((c) => [c.kind, c.name])).toEqual([
+      ['increment', Metric.QUOTE_REQUESTED],
+      ['increment', Metric.QUOTE_POST_ATTEMPT],
+      ['increment', Metric.QUOTE_200],
+      ['histogram', Metric.QUOTE_LATENCY],
+      ['histogram', Metric.QUOTE_E2E_LATENCY],
+    ]);
   });
 
   it('Pick the greater of two quotes - EXACT_IN', async () => {
@@ -310,11 +327,11 @@ describe('Quote handler', () => {
       detail: 'No quotes available',
       errorCode: 'QUOTE_ERROR',
     });
+    // The 404 itself is counted by the base handler on the raw MetricsLogger, not through ctx.
+    expect(fakes.metrics.names()).toEqual([Metric.QUOTE_REQUESTED, Metric.QUOTE_E2E_LATENCY]);
   });
 
   it('emits QUOTE_E2E_LATENCY on both the 200 and the no-quote throw path', async () => {
-    const putMetricSpy = jest.spyOn(AWSMetricsLogger.prototype, 'putMetric');
-    const e2eCalls = () => putMetricSpy.mock.calls.filter((c) => c[0] === 'QUOTE_E2E_LATENCY');
     const request = await getRequest(getOrder({ cosigner: cosignerWallet.address }));
 
     const ok = await getQuoteHandler([new MockQuoter(logger, 1, 1)]).handler(
@@ -322,13 +339,13 @@ describe('Quote handler', () => {
       {} as unknown as Context
     );
     expect(ok.statusCode).toEqual(200);
-    expect(e2eCalls()).toHaveLength(1);
+    expect(fakes.metrics.count(Metric.QUOTE_E2E_LATENCY)).toEqual(1);
 
     const notFound = await getQuoteHandler([]).handler(getEvent(request), {} as unknown as Context);
     expect(notFound.statusCode).toEqual(404);
-    expect(e2eCalls()).toHaveLength(2);
-
-    putMetricSpy.mockRestore();
+    expect(fakes.metrics.count(Metric.QUOTE_E2E_LATENCY)).toEqual(2);
+    // The alarmed QUOTE_LATENCY still fires only on the confirmed post.
+    expect(fakes.metrics.count(Metric.QUOTE_LATENCY)).toEqual(1);
   });
 
   describe('getCosignerData', () => {
@@ -543,6 +560,18 @@ describe('Quote handler', () => {
         postedAt: expect.any(Number),
         outcome: PostedOrderOutcome.PENDING,
       });
+
+      // The recorder's bookkeeping metrics ride the same ctx, and land before the alarmed
+      // QUOTE_LATENCY so that metric keeps including the write.
+      expect(fakes.metrics.calls.map((c) => [c.kind, c.name])).toEqual([
+        ['increment', Metric.QUOTE_REQUESTED],
+        ['increment', Metric.QUOTE_POST_ATTEMPT],
+        ['increment', Metric.QUOTE_200],
+        ['increment', Metric.POSTED_ORDER_RECORDED],
+        ['histogram', Metric.POSTED_ORDER_RECORD_LATENCY],
+        ['histogram', Metric.QUOTE_LATENCY],
+        ['histogram', Metric.QUOTE_E2E_LATENCY],
+      ]);
     });
 
     it('records nothing when the quote did not beat the swapper price (no exclusive filler)', async () => {

--- a/test/handlers/hard-quote/handlerDeadline.test.ts
+++ b/test/handlers/hard-quote/handlerDeadline.test.ts
@@ -18,6 +18,7 @@ import { MockOrderServiceProvider } from '../../../lib/providers';
 import { MockQuoter, Quoter } from '../../../lib/quoters';
 import { MockFillerAddressRepository } from '../../../lib/repositories/filler-address-repository';
 import { MockPostedOrderRepository } from '../../../lib/repositories/posted-order-repository';
+import { fakeContext } from '../../fakes';
 import { getOrder } from '../../fixtures/hard-quote';
 
 jest.mock('axios');
@@ -48,12 +49,15 @@ describe('Hard quote handler - order deadline validation', () => {
   }));
   (KMSClient as jest.Mock).mockImplementation(() => jest.fn());
 
+  const fakes = fakeContext('test');
+
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
         log: logger,
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 

--- a/test/handlers/hard-quote/handlerDutchV3.test.ts
+++ b/test/handlers/hard-quote/handlerDutchV3.test.ts
@@ -25,6 +25,7 @@ import { MockOrderServiceProvider } from '../../../lib/providers';
 import { MockQuoter, Quoter } from '../../../lib/quoters';
 import { MockFillerAddressRepository } from '../../../lib/repositories/filler-address-repository';
 import { MockPostedOrderRepository } from '../../../lib/repositories/posted-order-repository';
+import { fakeContext } from '../../fakes';
 
 jest.mock('axios');
 jest.mock('@aws-sdk/client-kms');
@@ -108,12 +109,14 @@ describe('Quote handler', () => {
   (KMSClient as jest.Mock).mockImplementation(() => jest.fn());
 
   // Creating mocks for all the handler dependencies.
+  const fakes = fakeContext('test');
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
         log: logger,
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 

--- a/test/handlers/hard-quote/handlerPostError.test.ts
+++ b/test/handlers/hard-quote/handlerPostError.test.ts
@@ -6,7 +6,8 @@ import { default as Logger } from 'bunyan';
 import { ethers, Wallet } from 'ethers';
 
 import { KmsSigner } from '@uniswap/signer';
-import { AWSMetricsLogger } from '../../../lib/entities/aws-metrics-logger';
+import { POST_ORDER_ERROR_REASON } from '../../../lib/constants';
+import { AWSMetricsLogger, Metric } from '../../../lib/entities/aws-metrics-logger';
 import { ApiInjector } from '../../../lib/handlers/base/api-handler';
 import {
   ContainerInjected,
@@ -19,6 +20,7 @@ import { MOCK_FILLER_ADDRESS, MockQuoter, Quoter } from '../../../lib/quoters';
 import { MockFillerAddressRepository } from '../../../lib/repositories/filler-address-repository';
 import { MockPostedOrderRepository, PostedOrderOutcome } from '../../../lib/repositories/posted-order-repository';
 import { ErrorCode } from '../../../lib/util/errors';
+import { fakeContext } from '../../fakes';
 import { getOrder } from '../../fixtures/hard-quote';
 
 jest.mock('axios');
@@ -52,12 +54,21 @@ describe('Quote handler order post error mapping', () => {
   }));
   (KMSClient as jest.Mock).mockImplementation(() => jest.fn());
 
+  const fakes = fakeContext('test');
+
+  afterEach(() => {
+    // One ctx is shared across the describe; every test starts from empty recordings.
+    fakes.metrics.reset();
+    fakes.logger.reset();
+  });
+
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
         log: logger,
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 
@@ -154,6 +165,51 @@ describe('Quote handler order post error mapping', () => {
     expect(JSON.parse(response.body)).toMatchObject({
       detail: 'Onchain validation failed: InsufficientFunds',
     });
+    // Counted as a rejection, not a confirmed post: no QUOTE_200 and no alarmed QUOTE_LATENCY.
+    expect(fakes.metrics.names()).toEqual(expect.arrayContaining([Metric.QUOTE_POST_ATTEMPT, Metric.QUOTE_400]));
+    expect(fakes.metrics.names()).not.toContain(Metric.QUOTE_200);
+    expect(fakes.metrics.count(Metric.QUOTE_LATENCY)).toEqual(0);
+  });
+
+  it('counts a rejection as QUOTE_POST_ERROR unless the swapper was short of funds', async () => {
+    await postOrderWith({ statusCode: 400, errorCode: ErrorCode.ValidationError, detail: 'rejected' });
+    expect(fakes.metrics.calls.map((c) => [c.kind, c.name])).toEqual([
+      ['increment', Metric.QUOTE_REQUESTED],
+      ['increment', Metric.QUOTE_POST_ATTEMPT],
+      ['increment', Metric.QUOTE_POST_ERROR],
+      ['increment', Metric.QUOTE_400],
+      ['histogram', Metric.QUOTE_E2E_LATENCY],
+    ]);
+
+    fakes.metrics.reset();
+    // A user error, not an alertable service error.
+    await postOrderWith({
+      statusCode: 400,
+      errorCode: ErrorCode.ValidationError,
+      detail: POST_ORDER_ERROR_REASON.INSUFFICIENT_FUNDS,
+    });
+    expect(fakes.metrics.count(Metric.QUOTE_POST_ERROR)).toEqual(0);
+    expect(fakes.metrics.count(Metric.QUOTE_400)).toEqual(1);
+  });
+
+  it('counts an indeterminate outcome as QUOTE_POST_ERROR and QUOTE_500, and logs it at error level', async () => {
+    await postOrderWith({
+      statusCode: 500,
+      errorCode: ErrorCode.InternalError,
+      detail: 'timed out',
+      data: { hash: '0xabc' },
+    });
+    expect(fakes.metrics.calls.map((c) => [c.kind, c.name])).toEqual([
+      ['increment', Metric.QUOTE_REQUESTED],
+      ['increment', Metric.QUOTE_POST_ATTEMPT],
+      ['increment', Metric.QUOTE_POST_ERROR],
+      ['increment', Metric.QUOTE_500],
+      ['histogram', Metric.QUOTE_E2E_LATENCY],
+    ]);
+    const [errorLog] = fakes.logger.atLevel('error');
+    expect(errorLog.msg).toEqual('Error posting order');
+    expect(errorLog.bindings).toEqual({ requestId: 'test' });
+    expect(errorLog.fields.error).toMatchObject({ statusCode: 500, detail: 'timed out' });
   });
 
   it('records nothing when the order service rejects the order', async () => {

--- a/test/handlers/hard-quote/posted-order-recorder.test.ts
+++ b/test/handlers/hard-quote/posted-order-recorder.test.ts
@@ -1,5 +1,4 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { MetricLoggerUnit } from '@uniswap/smart-order-router';
 import {
   CosignedV2DutchOrder,
   CosignedV3DutchOrder,
@@ -8,7 +7,6 @@ import {
   V3CosignerData,
   V3DutchOrderBuilder,
 } from '@uniswap/uniswapx-sdk';
-import { default as Logger } from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 
 import { Metric, QuoteRequest, QuoteResponse } from '../../../lib/entities';
@@ -29,10 +27,8 @@ import {
   PostedOrderRecord,
   PostedOrderRepository,
 } from '../../../lib/repositories/posted-order-repository';
+import { fakeContext } from '../../fakes';
 import { CHAIN_ID, getOrder, TOKEN_IN, TOKEN_OUT } from '../../fixtures/hard-quote';
-
-const logger = Logger.createLogger({ name: 'test' });
-logger.level(Logger.FATAL);
 
 const FILLER = '0x0000000000000000000000000000000000000001';
 const ENDPOINT = 'https://filler.example/rfq';
@@ -43,23 +39,6 @@ const NOW_S = Math.floor(Date.now() / 1000);
 const RAW_AMOUNT = BigNumber.from('1000000000000000000');
 // fromUnsignedOrder stores the cosignature verbatim; hash() does not verify it.
 const DUMMY_COSIGNATURE = `0x${'11'.repeat(65)}`;
-
-/** Hand-written IMetric that records every putMetric call. */
-class RecordingMetric {
-  public readonly puts: { key: string; value: number; unit?: MetricLoggerUnit }[] = [];
-  putMetric(key: string, value: number, unit?: MetricLoggerUnit): void {
-    this.puts.push({ key, value, unit });
-  }
-  putDimensions(): void {
-    return;
-  }
-  setProperty(): void {
-    return;
-  }
-  count(key: string): number {
-    return this.puts.filter((p) => p.key === key).length;
-  }
-}
 
 /** Fake repository whose put either throws or never settles. */
 class FailingRepository extends MockPostedOrderRepository {
@@ -214,7 +193,7 @@ describe('recordPostedOrder', () => {
     args: Partial<Parameters<typeof recordPostedOrder>[0]> = {},
     fillerAddressRepository: FillerAddressRepository = new MockFillerAddressRepository()
   ) => {
-    const metric = new RecordingMetric();
+    const { ctx, metrics } = fakeContext();
     const promise = recordPostedOrder({
       repository,
       fillerAddressRepository,
@@ -222,25 +201,24 @@ describe('recordPostedOrder', () => {
       quote: quote(),
       quoteId: QUOTE_ID,
       requestId: REQUEST_ID,
-      log: logger,
-      metric,
+      ctx,
       ...args,
     });
-    return { promise, metric };
+    return { promise, metrics };
   };
 
   it('writes the record and emits the success metric and latency', async () => {
     const repository = new MockPostedOrderRepository();
-    const { promise, metric } = run(repository);
+    const { promise, metrics } = run(repository);
     await promise;
 
     expect(repository.records.size).toEqual(1);
     const [record] = repository.records.values();
     expect(record.filler).toEqual(ENDPOINT);
     expect(record.outcome).toEqual(PostedOrderOutcome.PENDING);
-    expect(metric.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(0);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_LATENCY)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(0);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_LATENCY)).toEqual(1);
   });
 
   it('skips open orders (no quote) and non-exclusive orders without emitting either metric', async () => {
@@ -251,28 +229,28 @@ describe('recordPostedOrder', () => {
     await nonImproving.promise;
 
     expect(repository.records.size).toEqual(0);
-    for (const { metric } of [openOrder, nonImproving]) {
-      expect(metric.puts).toEqual([]);
+    for (const { metrics } of [openOrder, nonImproving]) {
+      expect(metrics.calls).toEqual([]);
     }
   });
 
   it('swallows a repository error, emitting the failure metric', async () => {
-    const { promise, metric } = run(new FailingRepository('throw'));
+    const { promise, metrics } = run(new FailingRepository('throw'));
     await expect(promise).resolves.toBeUndefined();
 
-    expect(metric.count(Metric.POSTED_ORDER_RECORDED)).toEqual(0);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(1);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_LATENCY)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORDED)).toEqual(0);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_LATENCY)).toEqual(1);
   });
 
   it('attributes the exclusive filler address to the quote endpoint alongside the record', async () => {
     const addresses = new MockFillerAddressRepository();
-    const { promise, metric } = run(new MockPostedOrderRepository(), {}, addresses);
+    const { promise, metrics } = run(new MockPostedOrderRepository(), {}, addresses);
     await promise;
 
     expect([...addresses.addressToFiller.entries()]).toEqual([[FILLER, ENDPOINT]]);
-    expect(metric.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(0);
-    expect(metric.count(Metric.FILLER_ADDRESS_CLAIM_REJECTED)).toEqual(0);
+    expect(metrics.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(0);
+    expect(metrics.count(Metric.FILLER_ADDRESS_CLAIM_REJECTED)).toEqual(0);
   });
 
   it('records no address for open or non-exclusive orders', async () => {
@@ -292,27 +270,27 @@ describe('recordPostedOrder', () => {
       throw new Error('ProvisionedThroughputExceededException');
     };
     const repository = new MockPostedOrderRepository();
-    const { promise, metric } = run(repository, {}, addresses);
+    const { promise, metrics } = run(repository, {}, addresses);
     await expect(promise).resolves.toBeUndefined();
 
     expect(repository.records.size).toEqual(1);
-    expect(metric.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(0);
-    expect(metric.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(0);
+    expect(metrics.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(1);
   });
 
   it('a refused claim (address owned by another endpoint) is counted on its own metric, not as a write failure', async () => {
     const addresses = new MockFillerAddressRepository();
     await addresses.recordWinningAddress(FILLER, 'https://first-owner.example/rfq');
     const repository = new MockPostedOrderRepository();
-    const { promise, metric } = run(repository, {}, addresses);
+    const { promise, metrics } = run(repository, {}, addresses);
     await expect(promise).resolves.toBeUndefined();
 
     expect(addresses.addressToFiller.get(FILLER)).toEqual('https://first-owner.example/rfq');
     expect(repository.records.size).toEqual(1);
-    expect(metric.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
-    expect(metric.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(0);
-    expect(metric.count(Metric.FILLER_ADDRESS_CLAIM_REJECTED)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
+    expect(metrics.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(0);
+    expect(metrics.count(Metric.FILLER_ADDRESS_CLAIM_REJECTED)).toEqual(1);
   });
 
   it('a hung attribution write is bounded by the same wall and does not delay the record beyond it', async () => {
@@ -320,35 +298,35 @@ describe('recordPostedOrder', () => {
     addresses.recordWinningAddress = () => new Promise<WinningAddressClaim>(() => undefined);
     const repository = new MockPostedOrderRepository();
     const start = Date.now();
-    const { promise, metric } = run(repository, { timeoutMs: 50 }, addresses);
+    const { promise, metrics } = run(repository, { timeoutMs: 50 }, addresses);
     await promise;
 
     expect(Date.now() - start).toBeLessThan(500);
     expect(repository.records.size).toEqual(1);
-    expect(metric.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
-    expect(metric.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(1);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORDED)).toEqual(1);
+    expect(metrics.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(1);
   });
 
   it('a failing record write does not prevent the attribution', async () => {
     const addresses = new MockFillerAddressRepository();
-    const { promise, metric } = run(new FailingRepository('throw'), {}, addresses);
+    const { promise, metrics } = run(new FailingRepository('throw'), {}, addresses);
     await promise;
 
     expect([...addresses.addressToFiller.entries()]).toEqual([[FILLER, ENDPOINT]]);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(1);
-    expect(metric.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(0);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(1);
+    expect(metrics.count(Metric.FILLER_ADDRESS_RECORD_FAILED)).toEqual(0);
   });
 
   it('gives up on a hung write at the timeout and counts it as a failure', async () => {
     const start = Date.now();
-    const { promise, metric } = run(new FailingRepository('hang'), { timeoutMs: 50 });
+    const { promise, metrics } = run(new FailingRepository('hang'), { timeoutMs: 50 });
     await expect(promise).resolves.toBeUndefined();
 
     const elapsed = Date.now() - start;
     expect(elapsed).toBeGreaterThanOrEqual(45);
     expect(elapsed).toBeLessThan(1_000);
-    expect(metric.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(1);
-    const latency = metric.puts.find((p) => p.key === Metric.POSTED_ORDER_RECORD_LATENCY);
+    expect(metrics.count(Metric.POSTED_ORDER_RECORD_FAILED)).toEqual(1);
+    const latency = metrics.calls.find((c) => c.name === Metric.POSTED_ORDER_RECORD_LATENCY);
     expect(latency?.value).toBeGreaterThanOrEqual(45);
   });
 });

--- a/test/handlers/hard-quote/requestid-invariant.test.ts
+++ b/test/handlers/hard-quote/requestid-invariant.test.ts
@@ -19,6 +19,7 @@ import { OrderServiceProvider } from '../../../lib/providers/order';
 import { MockQuoter, Quoter } from '../../../lib/quoters';
 import { MockFillerAddressRepository } from '../../../lib/repositories/filler-address-repository';
 import { MockPostedOrderRepository } from '../../../lib/repositories/posted-order-repository';
+import { fakeContext } from '../../fakes';
 import { CHAIN_ID, getOrder } from '../../fixtures/hard-quote';
 
 /**
@@ -126,12 +127,15 @@ describe('hard-quote requestId := quoteId invariant', () => {
       jest.clearAllMocks();
     });
 
+    const fakes = fakeContext('test');
+
     const requestInjectedMock: Promise<RequestInjected> = new Promise(
       (resolve) =>
         resolve({
           log: logger,
           requestId: 'test',
           metric: new AWSMetricsLogger(createMetricsLogger()),
+          ctx: fakes.ctx,
         }) as unknown as RequestInjected
     );
 

--- a/test/handlers/hard-quote/response-surface.test.ts
+++ b/test/handlers/hard-quote/response-surface.test.ts
@@ -20,6 +20,7 @@ import { MockQuoter, Quoter } from '../../../lib/quoters';
 import { MockFillerAddressRepository } from '../../../lib/repositories/filler-address-repository';
 import { MockPostedOrderRepository } from '../../../lib/repositories/posted-order-repository';
 import { ErrorCode } from '../../../lib/util/errors';
+import { fakeContext } from '../../fakes';
 import { CHAIN_ID, getOrder } from '../../fixtures/hard-quote';
 
 /**
@@ -76,6 +77,8 @@ describe('/hard-quote response surface', () => {
     jest.clearAllMocks();
   });
 
+  const fakes = fakeContext('test');
+
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
@@ -83,6 +86,7 @@ describe('/hard-quote response surface', () => {
         // Surfaces as the `id` field of every handler-level error body below.
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 

--- a/test/handlers/quote/handler.test.ts
+++ b/test/handlers/quote/handler.test.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { default as Logger } from 'bunyan';
 import { ethers } from 'ethers';
 
+import { Metric } from '../../../lib/entities';
 import { AWSMetricsLogger } from '../../../lib/entities/aws-metrics-logger';
 import { ApiInjector } from '../../../lib/handlers/base/api-handler';
 import {
@@ -17,6 +18,7 @@ import { QuoteHandler } from '../../../lib/handlers/quote/handler';
 import { MockWebhookConfigurationProvider, ProtocolVersion } from '../../../lib/providers';
 import { FirehoseLogger } from '../../../lib/providers/analytics';
 import { MOCK_FILLER_ADDRESS, MockQuoter, Quoter, WebhookQuoter } from '../../../lib/quoters';
+import { fakeContext } from '../../fakes';
 import { MOCK_V2_CB_PROVIDER } from '../../fixtures';
 
 jest.mock('axios');
@@ -37,12 +39,14 @@ const mockFirehoseLogger = new FirehoseLogger(logger, 'arn:aws:deliverystream/du
 
 describe('Quote handler', () => {
   // Creating mocks for all the handler dependencies.
+  const fakes = fakeContext('test');
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
         log: logger,
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 
@@ -83,6 +87,9 @@ describe('Quote handler', () => {
   });
 
   beforeEach(() => {
+    // One ctx is shared across the describe; every test starts from empty recordings.
+    fakes.metrics.reset();
+    fakes.logger.reset();
     // WebhookQuoter randomizes which side (real vs. opposing) is dispatched first; pin it
     // so the positional axios mocks in these tests (real request first) stay deterministic.
     jest.spyOn(Math, 'random').mockReturnValue(0);
@@ -126,32 +133,51 @@ describe('Quote handler', () => {
     const { allQuotes, ...quoteResponse }: PostQuoteResponseWithAllQuotes = JSON.parse(response.body);
     expect(response.statusCode).toEqual(200);
     expect(responseFromRequest(request, {})).toMatchObject({ ...quoteResponse, quoteId: expect.any(String) });
+
+    // The handler's own metrics go through ctx.metrics: the same names the IMetric path emitted,
+    // counts as increments and latencies as histograms, in the same order.
+    expect(fakes.metrics.calls.map((c) => [c.kind, c.name])).toEqual([
+      ['increment', Metric.QUOTE_REQUESTED],
+      ['increment', Metric.QUOTE_200],
+      ['histogram', Metric.QUOTE_LATENCY],
+      ['histogram', Metric.QUOTE_E2E_LATENCY],
+    ]);
+    // ...and its request log line goes through ctx.logger with the same event and body.
+    const requestLog = fakes.logger.atLevel('info').find((r) => r.fields.eventType === 'QuoteRequest');
+    expect(requestLog?.bindings).toEqual({ requestId: 'test' });
+    expect(requestLog?.fields.body).toMatchObject({
+      requestId: REQUEST_ID,
+      tokenInChainId: CHAIN_ID,
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amount: amountIn.toString(),
+      type: 'EXACT_INPUT',
+      numOutputs: 1,
+    });
   });
 
   describe('QUOTE_E2E_LATENCY', () => {
-    const e2eCalls = (spy: jest.SpyInstance) => spy.mock.calls.filter((c) => c[0] === 'QUOTE_E2E_LATENCY');
-
     it('is emitted on the 200 path', async () => {
-      const putMetricSpy = jest.spyOn(AWSMetricsLogger.prototype, 'putMetric');
       const quoters = [new MockQuoter(logger, 1, 1)];
       const request = getRequest(ethers.utils.parseEther('1').toString(), 'EXACT_INPUT', ProtocolVersion.V2);
 
       const response = await getQuoteHandler(quoters).handler(getEvent(request), {} as unknown as Context);
 
       expect(response.statusCode).toEqual(200);
-      expect(e2eCalls(putMetricSpy)).toHaveLength(1);
+      expect(fakes.metrics.count(Metric.QUOTE_E2E_LATENCY)).toEqual(1);
     });
 
     it('is emitted on the 404 (no quotes) path, which QUOTE_LATENCY misses', async () => {
-      const putMetricSpy = jest.spyOn(AWSMetricsLogger.prototype, 'putMetric');
       const request = getRequest(ethers.utils.parseEther('1').toString(), 'EXACT_INPUT', ProtocolVersion.V2);
 
       const response = await getQuoteHandler([]).handler(getEvent(request), {} as unknown as Context);
 
       expect(response.statusCode).toEqual(404);
-      expect(e2eCalls(putMetricSpy)).toHaveLength(1);
-      const quoteLatencyCalls = putMetricSpy.mock.calls.filter((c) => c[0] === 'QUOTE_LATENCY');
-      expect(quoteLatencyCalls).toHaveLength(0);
+      expect(fakes.metrics.calls.map((c) => [c.kind, c.name])).toEqual([
+        ['increment', Metric.QUOTE_REQUESTED],
+        ['increment', Metric.QUOTE_404],
+        ['histogram', Metric.QUOTE_E2E_LATENCY],
+      ]);
     });
   });
 

--- a/test/handlers/quote/response-surface.test.ts
+++ b/test/handlers/quote/response-surface.test.ts
@@ -9,6 +9,7 @@ import { ContainerInjected, PostQuoteRequestBody, RequestInjected } from '../../
 import { QuoteHandler } from '../../../lib/handlers/quote/handler';
 import { ProtocolVersion } from '../../../lib/providers';
 import { MockQuoter, Quoter } from '../../../lib/quoters';
+import { fakeContext } from '../../fakes';
 
 /**
  * Response-surface snapshots for POST /quote.
@@ -45,6 +46,7 @@ const logger = Logger.createLogger({ name: 'test' });
 logger.level(Logger.FATAL);
 
 describe('/quote response surface', () => {
+  const fakes = fakeContext('test');
   const requestInjectedMock: Promise<RequestInjected> = new Promise(
     (resolve) =>
       resolve({
@@ -52,6 +54,7 @@ describe('/quote response surface', () => {
         // Surfaces as the `id` field of every handler-level error body below.
         requestId: 'test',
         metric: new AWSMetricsLogger(createMetricsLogger()),
+        ctx: fakes.ctx,
       }) as unknown as RequestInjected
   );
 

--- a/test/handlers/shared/quote-injector.test.ts
+++ b/test/handlers/shared/quote-injector.test.ts
@@ -141,6 +141,19 @@ describe('shared quote injector wiring', () => {
       // The child logger is what carries requestBody/requestId onto every downstream log line.
       expect(requestInjected.log).not.toBe(log);
       expect(requestInjected.log.fields.requestId).toEqual('req-1');
+
+      // ctx is a second view of the same request-scoped state, not a second copy of it: the
+      // handler layer's logger IS that child logger, and its metrics forward to the request's
+      // MetricsLogger (the one carrying the dimension sets asserted above), as the same
+      // (name, value, unit) the IMetric path produced.
+      expect(requestInjected.ctx.requestId).toEqual('req-1');
+      expect(requestInjected.ctx.logger).toBe(requestInjected.log);
+      requestInjected.ctx.metrics.increment('QUOTE_REQUESTED');
+      requestInjected.ctx.metrics.histogram('QUOTE_LATENCY', 250);
+      expect(metricsLogger.putMetric.mock.calls).toEqual([
+        ['QUOTE_REQUESTED', 1, 'Count'],
+        ['QUOTE_LATENCY', 250, 'Milliseconds'],
+      ]);
     });
   });
 });

--- a/test/observability/emf-metrics.test.ts
+++ b/test/observability/emf-metrics.test.ts
@@ -1,0 +1,114 @@
+import { MetricLoggerUnit } from '@uniswap/smart-order-router';
+import { createMetricsLogger } from 'aws-embedded-metrics';
+
+import { AWSMetricsLogger, Metric } from '../../lib/entities/aws-metrics-logger';
+import { EmfMetrics, MetricReason, Metrics } from '../../lib/observability';
+import { FakeLogger } from '../fakes';
+
+/**
+ * Every metric the handler layer (quote/handler.ts, hard-quote/handler.ts,
+ * posted-order-recorder.ts) emitted through the smart-order-router IMetric before it moved to
+ * ctx.metrics, with the unit it used then. The equivalence test asserts that the Metrics call
+ * each one became reaches the request's MetricsLogger as the identical (name, value, unit).
+ */
+const HANDLER_METRICS: { name: Metric; kind: keyof Metrics; value: number; unit: MetricLoggerUnit }[] = [
+  { name: Metric.QUOTE_REQUESTED, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_200, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_400, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_404, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_500, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_POST_ATTEMPT, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_POST_ERROR, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.POSTED_ORDER_RECORDED, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.POSTED_ORDER_RECORD_FAILED, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.FILLER_ADDRESS_RECORD_FAILED, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.FILLER_ADDRESS_CLAIM_REJECTED, kind: 'increment', value: 1, unit: MetricLoggerUnit.Count },
+  { name: Metric.QUOTE_LATENCY, kind: 'histogram', value: 187, unit: MetricLoggerUnit.Milliseconds },
+  { name: Metric.QUOTE_E2E_LATENCY, kind: 'histogram', value: 0, unit: MetricLoggerUnit.Milliseconds },
+  { name: Metric.POSTED_ORDER_RECORD_LATENCY, kind: 'histogram', value: 12, unit: MetricLoggerUnit.Milliseconds },
+];
+
+/** A real aws-embedded-metrics logger with putMetric observed; the real validator still runs. */
+function observedEmf() {
+  const emf = createMetricsLogger();
+  return {
+    emf,
+    putMetric: jest.spyOn(emf, 'putMetric'),
+    setProperty: jest.spyOn(emf, 'setProperty'),
+    putDimensions: jest.spyOn(emf, 'putDimensions'),
+    setDimensions: jest.spyOn(emf, 'setDimensions'),
+  };
+}
+
+describe('EmfMetrics', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it.each(HANDLER_METRICS)(
+    '$kind($name) reaches the MetricsLogger as the same (name, value, unit) the IMetric path emitted',
+    ({ name, kind, value, unit }) => {
+      const before = observedEmf();
+      new AWSMetricsLogger(before.emf).putMetric(name, value, unit);
+
+      const after = observedEmf();
+      const logger = new FakeLogger();
+      new EmfMetrics(after.emf, logger)[kind](name, value);
+
+      expect(after.putMetric.mock.calls).toEqual(before.putMetric.mock.calls);
+      expect(after.putMetric).toHaveBeenCalledWith(name, value, unit);
+      // The real validator accepted the tuple: nothing was dropped.
+      expect(logger.records).toEqual([]);
+    }
+  );
+
+  it('increment defaults the value to 1, matching the putMetric(name, 1, Count) it replaces', () => {
+    const { emf, putMetric } = observedEmf();
+    new EmfMetrics(emf, new FakeLogger()).increment(Metric.QUOTE_REQUESTED);
+    expect(putMetric).toHaveBeenCalledTimes(1);
+    expect(putMetric).toHaveBeenCalledWith(Metric.QUOTE_REQUESTED, 1, MetricLoggerUnit.Count);
+  });
+
+  it('gauge emits unit None', () => {
+    const { emf, putMetric } = observedEmf();
+    const logger = new FakeLogger();
+    new EmfMetrics(emf, logger).gauge('FADE_RATE', 0.25);
+    expect(putMetric).toHaveBeenCalledWith('FADE_RATE', 0.25, MetricLoggerUnit.None);
+    expect(logger.records).toEqual([]);
+  });
+
+  it('accepts tags without changing the tuple and without touching properties or dimension sets', () => {
+    const { emf, putMetric, setProperty, putDimensions, setDimensions } = observedEmf();
+    const metrics = new EmfMetrics(emf, new FakeLogger());
+
+    metrics.increment(Metric.QUOTE_404, 1, { status: 'failure', reason: MetricReason.NoQuotes });
+    metrics.histogram(Metric.QUOTE_LATENCY, 42, { status: 'success', chain: '1' });
+
+    expect(putMetric.mock.calls).toEqual([
+      [Metric.QUOTE_404, 1, MetricLoggerUnit.Count],
+      [Metric.QUOTE_LATENCY, 42, MetricLoggerUnit.Milliseconds],
+    ]);
+    // The injector owns the dimension sets; the adapter must not add to them (or to the EMF
+    // blob's properties) on the way through.
+    expect(setProperty).not.toHaveBeenCalled();
+    expect(putDimensions).not.toHaveBeenCalled();
+    expect(setDimensions).not.toHaveBeenCalled();
+  });
+
+  it('logs and drops a metric the MetricsLogger rejects instead of throwing into the request', () => {
+    const { emf } = observedEmf();
+    // The IMetric path let this exception reach the handler (a 500 on the quote).
+    expect(() => emf.putMetric(Metric.QUOTE_LATENCY, NaN, MetricLoggerUnit.Milliseconds)).toThrow();
+
+    const logger = new FakeLogger();
+    const metrics = new EmfMetrics(emf, logger);
+    expect(() => metrics.histogram(Metric.QUOTE_LATENCY, NaN)).not.toThrow();
+    expect(() => metrics.increment('   ')).not.toThrow();
+
+    const warnings = logger.atLevel('warn');
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0].fields).toMatchObject({ metric: Metric.QUOTE_LATENCY, unit: MetricLoggerUnit.Milliseconds });
+    expect(warnings[0].fields.err).toBeInstanceOf(Error);
+    expect(warnings[1].fields).toMatchObject({ metric: '   ', value: 1 });
+    // Nothing else was logged: a healthy request path stays silent.
+    expect(logger.records).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Step 1 of 3 in replacing the smart-order-router observability module globals (`setGlobalLogger` / `setGlobalMetric`) with an explicit per-request context. Those globals hold request-scoped state in module scope, which is safe only because Lambda serves one request per container; the ECS target is concurrent, so they have to go. This PR lays the seam and switches **only the handler layer** onto it. Nothing below the handlers changes, the globals are still set, and the wire behaviour (response bodies, log lines, metric names/units/dimension sets) is unchanged.

## What's new: `lib/observability/`

- `Logger` — structural type for the bunyan/pino-shared subset (six level methods + `child`). bunyan stays the implementation; its logger satisfies the type with no adapter.
- `Metrics` — StatsD/Datadog-shaped: `increment` / `gauge` / `histogram`, with an optional tags map whose reserved keys are `status: 'success' | 'failure'` and an enum-valued `reason` (`MetricReason`).
- `Context` — `{ logger, metrics, requestId }`, field names matching the monorepo's ctx.
- `EmfMetrics` — `Metrics` over the request's existing aws-embedded-metrics `MetricsLogger`.

### `EmfMetrics` delegation design

- **Delegation, not a new sink.** It wraps the very `MetricsLogger` the injector has already configured (namespace + the `Service` / `Service`+`ChainId` / dimensionless dimension sets), so a handler metric lands in the same EMF blob, under the same dimension sets, as before. Dimension sets are not touched in this PR.
- **Same tuples.** `increment → (name, value=1, Count)`, `histogram → (name, ms, Milliseconds)`, `gauge → (name, value, None)` — the same strings `MetricLoggerUnit` produced. The unit test asserts this against the old `AWSMetricsLogger.putMetric` path on a real `MetricsLogger`, for every handler-level metric.
- **Tags are accepted and dropped.** EMF has no per-metric tags: dimensions are the injector's, and EMF properties are per-blob (two metrics in one request with different `status` would overwrite each other). The StatsD sink that replaces this adapter on ECS will honour them.
- **Exception-safe.** `putMetric` validates (non-finite value, bad name/unit) and today that exception would surface as a 500 on the quote; `EmfMetrics` logs a `warn` and drops the metric instead.

## What moved to `ctx`

- `lib/handlers/shared/quote-injector.ts` builds `ctx` in `buildQuoteRequestInjected`, alongside the existing global setup, for both quote Lambdas: `ctx.logger` is the same bunyan child (same `requestId` / `requestBody` bindings), `ctx.metrics` is `EmfMetrics` over the same `MetricsLogger`. `RequestInjected` gains `ctx`.
- `lib/handlers/quote/handler.ts`, `lib/handlers/hard-quote/handler.ts`, `lib/handlers/hard-quote/posted-order-recorder.ts` emit metrics via `ctx.metrics` and log via `ctx.logger`; their `@uniswap/smart-order-router` type imports (`IMetric`, `MetricLoggerUnit`) are gone. `recordPostedOrder` takes `ctx` in place of `log` + `metric`.

## What deliberately still reads the global, and which PR moves it

- `WebhookQuoter` and `S3WebhookConfigurationProvider` read the smart-order-router module globals (`metric`, `log`) → **PR 2 (quote path)**. `setGlobalLogger` / `setGlobalMetric` therefore still run in the injector.
- `getBestQuote` takes the bunyan `Logger` and `IMetric` positionally, so the handlers pass `requestInjected.log` / `metric` through to it (same objects `ctx` wraps); `RequestInjected.metric` stays for that reason → **PR 2**.
- `lib/cron/fade-rate-v2.ts` binds the global so the config provider's `RFQ_CONFIG_CHANGED` has somewhere to go → **PR 3 (cron)**.
- `APIGLambdaHandler` (base) puts `HANDLER_DURATION` / validation-path `QUOTE_400`/`QUOTE_500` on the raw `MetricsLogger`; unchanged here.
- `@uniswap/smart-order-router` stays in `package.json`.

## Tests

- `test/fakes/`: recording `FakeMetrics` and `FakeLogger`, plus a `fakeContext()` helper; used in every test touched, no new `jest.mock()`.
- `test/observability/emf-metrics.test.ts`: for each of the 14 handler-level metrics, the new call reaches a real `MetricsLogger` as the identical `(name, value, unit)` the `IMetric` path produced; increment defaults to 1; gauge → `None`; tags change neither the tuple nor properties/dimension sets; a rejected metric is logged and dropped rather than thrown.
- Handler tests assert the exact metric sequence per path through `FakeMetrics` (200; 404 / no-quote; order-service 4xx including the insufficient-funds carve-out; 5xx; exclusive post with the recorder's bookkeeping metrics landing before `QUOTE_LATENCY`) and the request / error log lines through `FakeLogger` with unchanged bindings. The injector test asserts `ctx.logger` is the same child logger and `ctx.metrics` forwards to the request's `MetricsLogger`.
- Contract snapshots (`test/handlers/*/response-surface.test.ts`) pass with the `.snap` files unmodified.

## Verification

- `yarn build && yarn test:unit && yarn lint`: 42 suites / 469 tests / 38 snapshots pass; lint 0 errors and the same 84 pre-existing warnings as `main` in the same files (none added). No `@ts-ignore`, `eslint-disable` or `any` added.
- `cdk synth` vs `main` (two worktrees, clean `--frozen-lockfile` installs, identical converged context, two in-tree synths per side): **14 of 19 templates byte-identical**, including every nested stack (Cron, Analytics, Firehose, Cosigner key, Dashboard). The API stack (root + beta + prod assemblies) differs only in the Quote / HardQuote code asset keys, their `CurrentVersion` logical IDs and the `LiveAlias` version pointers — the normal code deploy; no resource added, removed or retyped, no alarm / dashboard / dimension change. Pipeline stack: only the two asset-publish BuildSpecs (they embed the new hashes). Bundle module lists: each quote bundle gains exactly `lib/observability/emf-metrics.ts` (the other new files are type-only); the only content-changed sources are the four handler-layer files; no `node_modules` change.

## Post-deploy signals

- Handler metrics still present in CloudWatch under their existing dimension sets (`Service=SoftQuote|HardQuote`, `Service`+`ChainId`, and the dimensionless rollup): `QUOTE_REQUESTED`, `QUOTE_200/400/404/500`, `QUOTE_POST_ATTEMPT`, `QUOTE_POST_ERROR`, `QUOTE_LATENCY`, `QUOTE_E2E_LATENCY`, `POSTED_ORDER_RECORDED` / `RECORD_FAILED` / `RECORD_LATENCY`, `FILLER_ADDRESS_RECORD_FAILED` / `CLAIM_REJECTED`.
- The quote-latency SEV3 alarm still evaluating (not `INSUFFICIENT_DATA`).
- Zero Lambda errors on both quote functions; `QUOTE_LATENCY` p99 unchanged.
- No `Dropped metric rejected by aws-embedded-metrics` warn lines in the quote Lambda logs (that path was a 500 before this PR, so any occurrence is worth a look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
